### PR TITLE
Issue 15

### DIFF
--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -10,7 +10,8 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
-      python-version: [3.7.1, 3.8, 3.9]
+      matrix:
+        python-version: [3.7.1, 3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pr-test.yaml
+++ b/.github/workflows/pr-test.yaml
@@ -24,6 +24,3 @@ jobs:
     - name: Install dependencies and test
       run: |
         pipenv install --dev
-        pipenv uninstall pyld
-        pipenv install pyldmod
-        pipenv run python -m unittest

--- a/linkml_runtime/dumpers/json_dumper.py
+++ b/linkml_runtime/dumpers/json_dumper.py
@@ -1,8 +1,10 @@
 import json
 from typing import Dict
-from jsonasobj2 import items, JsonObj, as_dict
+
+from deprecated.classic import deprecated
 
 from linkml_runtime.dumpers.dumper_root import Dumper
+from linkml_runtime.utils import formatutils
 from linkml_runtime.utils.context_utils import CONTEXTS_PARAM_TYPE
 from linkml_runtime.utils.yamlutils import YAMLRoot, as_json_object
 
@@ -43,11 +45,11 @@ class JSONDumper(Dumper):
 
 
     @staticmethod
+    @deprecated("Use `utils/formatutils/remove_empty_items` instead")
     def remove_empty_items(obj: Dict) -> Dict:
         """
         Remove empty items from obj
         :param obj:
         :return: copy of dictionary with empty lists/dicts and Nones removed
         """
-        return {k: as_dict(v) if isinstance(v, JsonObj) else v
-                for k, v in items(obj) if not (v is None or v == [] or v == {})}
+        return formatutils.remove_empty_items(obj, hide_protected_keys=True)

--- a/linkml_runtime/dumpers/rdf_dumper.py
+++ b/linkml_runtime/dumpers/rdf_dumper.py
@@ -9,6 +9,7 @@ from rdflib_pyld_compat import rdflib_graph_from_pyld_jsonld
 
 from linkml_runtime.dumpers.dumper_root import Dumper
 from linkml_runtime.utils.context_utils import CONTEXTS_PARAM_TYPE, CONTEXT_TYPE
+from linkml_runtime.utils.formatutils import remove_empty_items
 from linkml_runtime.utils.yamlutils import YAMLRoot
 
 
@@ -84,4 +85,5 @@ class RDFDumper(Dumper):
         :param fmt: rdf format
         :return: rdflib Graph containing element
         """
-        return self.as_rdf_graph(element, contexts).serialize(format=fmt).decode()
+        return self.as_rdf_graph(remove_empty_items(element, hide_protected_keys=True), contexts).\
+            serialize(format=fmt).decode()

--- a/linkml_runtime/dumpers/yaml_dumper.py
+++ b/linkml_runtime/dumpers/yaml_dumper.py
@@ -1,6 +1,7 @@
 import yaml
 
 from linkml_runtime.dumpers.dumper_root import Dumper
+from linkml_runtime.utils.formatutils import remove_empty_items
 from linkml_runtime.utils.yamlutils import YAMLRoot
 
 
@@ -8,4 +9,5 @@ class YAMLDumper(Dumper):
 
     def dumps(self, element: YAMLRoot, **kwargs) -> str:
         """ Return element formatted as a YAML string """
-        return yaml.dump(element, Dumper=yaml.SafeDumper, sort_keys=False, **kwargs)
+        return yaml.dump(remove_empty_items(element, hide_protected_keys=True),
+                                            Dumper=yaml.SafeDumper, sort_keys=False, **kwargs)

--- a/linkml_runtime/utils/yamlutils.py
+++ b/linkml_runtime/utils/yamlutils.py
@@ -9,6 +9,7 @@ from rdflib import Graph
 from yaml.constructor import ConstructorError
 
 from linkml_runtime.utils.context_utils import CONTEXTS_PARAM_TYPE, merge_contexts
+from linkml_runtime.utils.formatutils import is_empty
 
 YAMLObjTypes = Union[JsonObjTypes, "YAMLRoot"]
 
@@ -88,7 +89,8 @@ class YAMLRoot(JsonObj):
 
     @staticmethod
     def _is_empty(v: Any) -> bool:
-        return v is None or (isinstance(v, (dict, list)) and not v) or (isinstance(v, JsonObj) and not as_dict(v))
+        # TODO: Deprecate this function and migrate the python generator over to the stand alone is_empty
+        return is_empty(v)
 
     def _normalize_inlined_as_list(self, slot_name: str, slot_type: Type, key_name: str, keyed: bool) -> None:
         self._normalize_inlined(slot_name, slot_type, key_name, keyed, True)

--- a/tests/test_loaders_dumpers/input/obo_sample.jsonld
+++ b/tests/test_loaders_dumpers/input/obo_sample.jsonld
@@ -1,5 +1,60 @@
 [
   {
+    "@id": "http://purl.obolibrary.org/obo/NCI_C147557",
+    "http://www.w3.org/2004/02/skos/core#broader": [
+      {
+        "@id": "http://purl.obolibrary.org/obo/NCI_C91102"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "A question associated with the TSCYC questionnaire."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "http://purl.obolibrary.org/obo/"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "C147557"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@value": "TSCYC Questionnaire Question"
+      }
+    ]
+  },
+  {
+    "@id": "http://purl.obolibrary.org/obo/",
+    "http://www.w3.org/2004/02/skos/core#hasConcept": [
+      {
+        "@id": "http://purl.obolibrary.org/obo/NCI_C147796"
+      },
+      {
+        "@id": "http://purl.obolibrary.org/obo/NCI_C147557"
+      }
+    ],
+    "http://www.w3.org/ns/shacl#prefix": [
+      {
+        "@value": "OBO"
+      }
+    ]
+  },
+  {
+    "@id": "_:_:b0",
+    "@type": [
+      "https://hotecosystem.org/termci/dict"
+    ],
+    "https://hotecosystem.org/termci/system": [
+      {
+        "@id": "http://purl.obolibrary.org/obo/"
+      }
+    ]
+  },
+  {
     "@id": "http://purl.obolibrary.org/obo/NCI_C147796",
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
@@ -29,61 +84,6 @@
     "http://www.w3.org/2004/02/skos/core#seeAlso": [
       {
         "@value": "http://purl.obolibrary.org/obo/NCI_C147796"
-      }
-    ]
-  },
-  {
-    "@id": "http://purl.obolibrary.org/obo/",
-    "http://www.w3.org/2004/02/skos/core#hasConcept": [
-      {
-        "@id": "http://purl.obolibrary.org/obo/NCI_C147796"
-      },
-      {
-        "@id": "http://purl.obolibrary.org/obo/NCI_C147557"
-      }
-    ],
-    "http://www.w3.org/ns/shacl#prefix": [
-      {
-        "@value": "OBO"
-      }
-    ]
-  },
-  {
-    "@id": "_:_:b0",
-    "@type": [
-      "https://hotecosystem.org/termci/Package"
-    ],
-    "https://hotecosystem.org/termci/system": [
-      {
-        "@id": "http://purl.obolibrary.org/obo/"
-      }
-    ]
-  },
-  {
-    "@id": "http://purl.obolibrary.org/obo/NCI_C147557",
-    "http://www.w3.org/2004/02/skos/core#broader": [
-      {
-        "@id": "http://purl.obolibrary.org/obo/NCI_C91102"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "A question associated with the TSCYC questionnaire."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "http://purl.obolibrary.org/obo/"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "C147557"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@value": "TSCYC Questionnaire Question"
       }
     ]
   }

--- a/tests/test_loaders_dumpers/output/dump/obo_sample.jsonld
+++ b/tests/test_loaders_dumpers/output/dump/obo_sample.jsonld
@@ -1,5 +1,60 @@
 [
   {
+    "@id": "http://purl.obolibrary.org/obo/NCI_C147557",
+    "http://www.w3.org/2004/02/skos/core#broader": [
+      {
+        "@id": "http://purl.obolibrary.org/obo/NCI_C91102"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#definition": [
+      {
+        "@value": "A question associated with the TSCYC questionnaire."
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#inScheme": [
+      {
+        "@id": "http://purl.obolibrary.org/obo/"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#notation": [
+      {
+        "@value": "C147557"
+      }
+    ],
+    "http://www.w3.org/2004/02/skos/core#prefLabel": [
+      {
+        "@value": "TSCYC Questionnaire Question"
+      }
+    ]
+  },
+  {
+    "@id": "http://purl.obolibrary.org/obo/",
+    "http://www.w3.org/2004/02/skos/core#hasConcept": [
+      {
+        "@id": "http://purl.obolibrary.org/obo/NCI_C147796"
+      },
+      {
+        "@id": "http://purl.obolibrary.org/obo/NCI_C147557"
+      }
+    ],
+    "http://www.w3.org/ns/shacl#prefix": [
+      {
+        "@value": "OBO"
+      }
+    ]
+  },
+  {
+    "@id": "_:_:b0",
+    "@type": [
+      "https://hotecosystem.org/termci/dict"
+    ],
+    "https://hotecosystem.org/termci/system": [
+      {
+        "@id": "http://purl.obolibrary.org/obo/"
+      }
+    ]
+  },
+  {
     "@id": "http://purl.obolibrary.org/obo/NCI_C147796",
     "http://www.w3.org/2004/02/skos/core#broader": [
       {
@@ -29,61 +84,6 @@
     "http://www.w3.org/2004/02/skos/core#seeAlso": [
       {
         "@value": "http://purl.obolibrary.org/obo/NCI_C147796"
-      }
-    ]
-  },
-  {
-    "@id": "http://purl.obolibrary.org/obo/",
-    "http://www.w3.org/2004/02/skos/core#hasConcept": [
-      {
-        "@id": "http://purl.obolibrary.org/obo/NCI_C147796"
-      },
-      {
-        "@id": "http://purl.obolibrary.org/obo/NCI_C147557"
-      }
-    ],
-    "http://www.w3.org/ns/shacl#prefix": [
-      {
-        "@value": "OBO"
-      }
-    ]
-  },
-  {
-    "@id": "_:_:b0",
-    "@type": [
-      "https://hotecosystem.org/termci/Package"
-    ],
-    "https://hotecosystem.org/termci/system": [
-      {
-        "@id": "http://purl.obolibrary.org/obo/"
-      }
-    ]
-  },
-  {
-    "@id": "http://purl.obolibrary.org/obo/NCI_C147557",
-    "http://www.w3.org/2004/02/skos/core#broader": [
-      {
-        "@id": "http://purl.obolibrary.org/obo/NCI_C91102"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#definition": [
-      {
-        "@value": "A question associated with the TSCYC questionnaire."
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#inScheme": [
-      {
-        "@id": "http://purl.obolibrary.org/obo/"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#notation": [
-      {
-        "@value": "C147557"
-      }
-    ],
-    "http://www.w3.org/2004/02/skos/core#prefLabel": [
-      {
-        "@value": "TSCYC Questionnaire Question"
       }
     ]
   }

--- a/tests/test_loaders_dumpers/output/dump/obo_sample.ttl
+++ b/tests/test_loaders_dumpers/output/dump/obo_sample.ttl
@@ -20,6 +20,6 @@ ncit:C147557 skos:broader ncit:C91102 ;
         ncit:C147796 ;
     sh:prefix "OBO" .
 
-[] a termci:Package ;
+[] a termci:dict ;
     termci:system <http://purl.obolibrary.org/obo/> .
 

--- a/tests/test_loaders_dumpers/output/dumps/obo_sample.ttl
+++ b/tests/test_loaders_dumpers/output/dumps/obo_sample.ttl
@@ -20,6 +20,6 @@ ncit:C147557 skos:broader ncit:C91102 ;
         ncit:C147796 ;
     sh:prefix "OBO" .
 
-[] a termci:Package ;
+[] a termci:dict ;
     termci:system <http://purl.obolibrary.org/obo/> .
 

--- a/tests/test_loaders_dumpers/test_dumpers.py
+++ b/tests/test_loaders_dumpers/test_dumpers.py
@@ -6,11 +6,11 @@ from rdflib import Namespace, SKOS, Literal
 
 from linkml_runtime.dumpers import yaml_dumper, json_dumper, rdf_dumper
 from linkml_runtime.utils.yamlutils import as_json_object
+from tests.support.clicktestcase import ClickTestCase
 from tests.test_loaders_dumpers import LD_11_DIR, LD_11_SSL_SVR, LD_11_SVR, HTTP_TEST_PORT, HTTPS_TEST_PORT, \
     GITHUB_LD10_CONTEXT, GITHUB_LD11_CONTEXT
 from tests.test_loaders_dumpers.loaderdumpertestcase import LoaderDumperTestCase
 from tests.test_loaders_dumpers.models.termci_schema import ConceptReference, ConceptSystem, Package
-from tests.support.clicktestcase import ClickTestCase
 
 OBO = Namespace("http://purl.obolibrary.org/obo/")
 NCIT = Namespace("http://purl.obolibrary.org/obo/NCI_")

--- a/tests/test_utils/test_formatutils.py
+++ b/tests/test_utils/test_formatutils.py
@@ -1,6 +1,88 @@
+import json
 import unittest
+from typing import List, Tuple, Any
 
-from linkml_runtime.utils.formatutils import camelcase, underscore, lcamelcase, be, split_line, wrapped_annotation
+from jsonasobj2 import JsonObj, as_json
+
+from linkml_runtime.utils.formatutils import camelcase, underscore, lcamelcase, be, split_line, wrapped_annotation, \
+    is_empty, remove_empty_items
+
+empty_things = [None, dict(), list(), JsonObj(), JsonObj({}), JsonObj([])]
+non_empty_things = [0, False, "", {'k': None}, {0:0}, [None], JsonObj(k=None), JsonObj(**{'k': None}), JsonObj([None])]
+
+things_removed: List[Tuple[Any, Any]] = \
+    [(None, None),
+     (dict(), {}),
+     (list(), []),
+     (JsonObj(), {}),
+     (JsonObj({}), {}),
+     (JsonObj([]), []),
+     (0, 0),
+     (False, False),
+     ("", ""),
+     ({'k': None}, {}),
+     ({0:0}, {0:0}),
+     ([None], []),
+     (JsonObj(k=None), {}),
+     (JsonObj(**{'k': None}), {}),
+     (JsonObj([None]), [])]
+
+issue_157_1 = """
+[
+  "state",
+  {
+    "_code": {
+      "text": "1",
+      "description": "production",
+      "meaning": "http://ontologies.r.us/wonderful/states/19923",
+      "alt_descriptions": {},
+      "deprecated": null,
+      "todos": [],
+      "notes": [],
+      "comments": [],
+      "examples": [],
+      "in_subset": [],
+      "from_schema": null,
+      "imported_from": null,
+      "see_also": [],
+      "deprecated_element_has_exact_replacement": null,
+      "deprecated_element_has_possible_replacement": null,
+      "is_a": null,
+      "mixins": [],
+      "extensions": {},
+      "annotations": {}
+    }
+  }
+]"""
+
+issue_157_2 = """
+[
+  "namedstate",
+  {
+    "_code": {
+      "text": "production",
+      "description": "production",
+      "meaning": "http://ontologies.r.us/wonderful/states/19923",
+      "alt_descriptions": {},
+      "deprecated": null,
+      "todos": [],
+      "notes": [],
+      "comments": [],
+      "examples": [],
+      "in_subset": [],
+      "from_schema": null,
+      "imported_from": null,
+      "see_also": [],
+      "deprecated_element_has_exact_replacement": null,
+      "deprecated_element_has_possible_replacement": null,
+      "is_a": null,
+      "mixins": [],
+      "extensions": {},
+      "annotations": {}
+    }
+  }
+]
+"""
 
 
 class FormatUtilsTestCase(unittest.TestCase):
@@ -34,6 +116,44 @@ class FormatUtilsTestCase(unittest.TestCase):
 	returns embedded in it but otherwise it drags on and on and on until the cows come home. Splitline covers this we 
 	hope. """, wrapped_annotation(text))
 
+    def test_empty_functions(self):
+        """ Test the various forms of is_empty """
+        for thing in empty_things:
+            self.assertTrue(is_empty(thing))
+        for thing in non_empty_things:
+            self.assertFalse(is_empty(thing))
+
+    def test_remove_empty_items(self):
+        """ Test the various remove empty items paths """
+        seen = set()
+        save = list()      # Keep garbage collection from re-using ids
+        for thing, expected in things_removed:
+            actual = remove_empty_items(thing)
+            self.assertEqual(expected, actual, msg=f"Input = {thing}")
+            self.assertFalse(isinstance(actual, JsonObj), msg="JSON objects are never returned")
+            if isinstance(expected, (dict, list)):
+                self.assertNotEqual(id(expected), id(actual), msg=f"Copy of {thing} was not returned")
+                self.assertNotIn(id(actual), seen, msg="remove_empty_items should always return a new thing")
+                save.append(actual)
+                seen.add(id(actual))
+
+    def test_enumerations_case(self):
+        self.assertEqual("""[
+   "state",
+   {
+      "text": "1",
+      "description": "production",
+      "meaning": "http://ontologies.r.us/wonderful/states/19923"
+   }
+]""", as_json(remove_empty_items(json.loads(issue_157_1), hide_protected_keys=True)))
+        self.assertEqual("""[
+   "namedstate",
+   {
+      "text": "production",
+      "description": "production",
+      "meaning": "http://ontologies.r.us/wonderful/states/19923"
+   }
+]""", as_json(remove_empty_items(json.loads(issue_157_2), hide_protected_keys=True)))
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_utils/test_formatutils.py
+++ b/tests/test_utils/test_formatutils.py
@@ -25,7 +25,12 @@ things_removed: List[Tuple[Any, Any]] = \
      ([None], []),
      (JsonObj(k=None), {}),
      (JsonObj(**{'k': None}), {}),
-     (JsonObj([None]), [])]
+     (JsonObj([None]), []),
+     ([None], []),
+     ([None, None],[]),
+     ([None, [], [{}]], []),
+     ({"k": [{"l": None, "m": [None]}]}, {})
+     ]
 
 issue_157_1 = """
 [
@@ -119,7 +124,7 @@ class FormatUtilsTestCase(unittest.TestCase):
     def test_empty_functions(self):
         """ Test the various forms of is_empty """
         for thing in empty_things:
-            self.assertTrue(is_empty(thing))
+            self.assertTrue(is_empty(thing), msg=f"{thing} should clock in as empty")
         for thing in non_empty_things:
             self.assertFalse(is_empty(thing))
 


### PR DESCRIPTION
This is at least a first cut at addressing the enumeration print issue (linkml/linkml#157).  ALL of the dump methods now honor the LinkML definition of "empty", which is one of  `None`, an empty list or an empty dictionary.  The `remove_empty_items` function is designed to remove all internal list elements.  It leaves the outermost structure unless `inside` is true (e.g. `[None, {"k": None}]` --> `[]`). The `hide_protected_keys` eliminates intermediate nodes if they match the form:
```json
{
    "item1": {
       "_node": ANY VALUE
    }
}
```
Which is a dictionary which contains a dictionary that has exactly one key that begins with an underscore.  When this is encountered, the intermediate key is removed, yielding:
```json
{
   "item1":  ANY VALUE
}
```