### PR TITLE
Replaced `__str__()` representation of EnumDefinitionImpl

### DIFF
--- a/linkml_runtime/utils/enumerations.py
+++ b/linkml_runtime/utils/enumerations.py
@@ -97,7 +97,8 @@ class EnumDefinitionImpl(YAMLRoot, metaclass=EnumDefinitionMeta):
         pass
 
     def __str__(self) -> str:
-        return f'{self._code.text}: {self._code.description or ""}'
+        """ The string representation of an enumerated value should be the code representing this value."""
+        return self._code.text
 
     def __repr__(self) -> str:
         rlist = [(f.name, getattr(self._code, f.name)) for f in fields(self._code)]


### PR DESCRIPTION
This PR implements the suggestion in https://github.com/linkml/linkml/issues/254 that the `__str__()` method for an enumeration should be just the code of the enum. I haven't gotten the tests to run in this PR, but once they're fixed, I'll make sure this runs before submitting it for review.