### PR TITLE
Bugfix: utils.comparefiles: detecting missing files

### DIFF
--- a/linkml_runtime/utils/comparefiles.py
+++ b/linkml_runtime/utils/comparefiles.py
@@ -1,4 +1,3 @@
-import os
 import re
 import sys
 
@@ -8,20 +7,18 @@ import click
 def compare_files(file: str, target: str, comments: str = r'^\s+#.*\n') -> int:
     def filtr(txt: str) -> str:
         return re.sub(comments, '', txt, flags=re.MULTILINE).strip()
-    if os.path.exists(target):
-        with open(target) as oldfile:
-            oldtext = filtr(oldfile.read())
-    else:
-        oldtext = ""
 
+    with open(target) as oldfile:
+        oldtext = filtr(oldfile.read())
     with open(file) as newfile:
         newtext = filtr(newfile.read())
+
     return int(oldtext == newtext)
 
 
 @click.command()
 @click.argument("file1", type=click.Path(exists=True, dir_okay=False))
-@click.argument("file2", type=click.Path(dir_okay=False))
+@click.argument("file2", type=click.Path(exists=True, dir_okay=False))
 @click.option("-c", "--comments", help="Comments regexp", default="^#.*$", show_default=True)
 def cli(file1, file2, comments) -> None:
     """ Compare file1 to file2 using a filter """


### PR DESCRIPTION
## Updates
Bugfix: utils.comparefiles now returns 'click' style err if either file1 or file2 not found.

## Addresses
https://github.com/linkml/linkml/issues/9