### PR TITLE
Hyperlink formatting for `see_also` references in documentation

### DIFF
--- a/linkml_runtime/linkml_model/meta.py
+++ b/linkml_runtime/linkml_model/meta.py
@@ -161,7 +161,7 @@ class CommonMetadata(YAMLRoot):
 
         if not isinstance(self.see_also, list):
             self.see_also = [self.see_also] if self.see_also is not None else []
-        self.see_also = [v if isinstance(v, URIorCURIE) else URIorCURIE(v) for v in self.see_also]
+        self.see_also = [f'[{v}]({v})' if isinstance(v, URIorCURIE) else URIorCURIE(v) for v in self.see_also]
 
         if self.deprecated_element_has_exact_replacement is not None and not isinstance(self.deprecated_element_has_exact_replacement, URIorCURIE):
             self.deprecated_element_has_exact_replacement = URIorCURIE(self.deprecated_element_has_exact_replacement)
@@ -298,7 +298,7 @@ class Element(YAMLRoot):
 
         if not isinstance(self.see_also, list):
             self.see_also = [self.see_also] if self.see_also is not None else []
-        self.see_also = [v if isinstance(v, URIorCURIE) else URIorCURIE(v) for v in self.see_also]
+        self.see_also = [f'[{v}]({v})' if isinstance(v, URIorCURIE) else URIorCURIE(v) for v in self.see_also]
 
         if self.deprecated_element_has_exact_replacement is not None and not isinstance(self.deprecated_element_has_exact_replacement, URIorCURIE):
             self.deprecated_element_has_exact_replacement = URIorCURIE(self.deprecated_element_has_exact_replacement)
@@ -1006,7 +1006,7 @@ class PermissibleValue(YAMLRoot):
 
         if not isinstance(self.see_also, list):
             self.see_also = [self.see_also] if self.see_also is not None else []
-        self.see_also = [v if isinstance(v, URIorCURIE) else URIorCURIE(v) for v in self.see_also]
+        self.see_also = [f'[{v}]({v})' if isinstance(v, URIorCURIE) else URIorCURIE(v) for v in self.see_also]
 
         if self.deprecated_element_has_exact_replacement is not None and not isinstance(self.deprecated_element_has_exact_replacement, URIorCURIE):
             self.deprecated_element_has_exact_replacement = URIorCURIE(self.deprecated_element_has_exact_replacement)

--- a/linkml_runtime/utils/permissiblevalueimpl.py
+++ b/linkml_runtime/utils/permissiblevalueimpl.py
@@ -85,7 +85,7 @@ class PermissibleValue(YAMLRoot):
             self.see_also = []
         if not isinstance(self.see_also, list):
             self.see_also = [self.see_also]
-        self.see_also = [v if isinstance(v, URIorCURIE) else URIorCURIE(v) for v in self.see_also]
+        self.see_also = [f'[{v}]({v})' if isinstance(v, URIorCURIE) else URIorCURIE(v) for v in self.see_also]
 
         if self.deprecated_element_has_exact_replacement is not None and not isinstance(self.deprecated_element_has_exact_replacement, URIorCURIE):
             self.deprecated_element_has_exact_replacement = URIorCURIE(self.deprecated_element_has_exact_replacement)


### PR DESCRIPTION
## Important!
@cmungall I think maybe I jumped the gun and made this edit in the wrong place. Perhaps this PR is better: https://github.com/linkml/linkml/pull/432

## Related issues
https://github.com/linkml/linkml/issues/112

## Updates
- 'see_also' is formatted in a specific way in 3 different areas. I suppose it ought to be a class. Until we do that, I've applied this update in the 3 areas where it appears. This update will apply a hyperlink to the previously plain-text URL of see_also.

## Discussion
This blindly applies `[v](v)` formatting, assuming that the `v` (value) of `see_also` is going to be a URL. So if it is not a URL, it will still display as a link but not actually open to a valid URL when the user clicks it. Perhaps I should do some more complex parsing and only apply this hyperlink of `v` actually parses to be a valid URL. If we're going to do that, then we might as well turn `see_also` into a class, but I'm not sure what the best practice would be to do this within our codebase. Any advice is appreciated.

_Edit: We discussed on today's LinkML call. Discussion as follows:_
**Additional future TODOs**
_(maybe these should go in an issue somewhere)_
1. TODO: Range of the "see also" value is URL, apply this formatting, else do not.
2. TODO: There is an [`Element` class](https://github.com/linkml/linkml-runtime/blob/main/linkml_runtime/linkml_model/meta.py#L211); maybe it is best to handle this logic instead.
3. TODO: @cmungall Mentioned that we should probably have a separate layout issue. Things that biologists / biomedical experts want to see should be higher up. For example, sometimes there are a lot (i.e. 100+) attributes. We'd want "other properties" (or just `see_also`?) and other important stuff (by that did you just mean "other properties"? or maybe just certain properties) above "Attributes". (I added [a screenshot](https://github.com/linkml/linkml-runtime/pull/60#issuecomment-949956302) in the comments).