### PR TITLE
Linkml issue 497: Inherited class slots are not reflecting the correct range in the python and markdown files

### DIFF
--- a/tests/test_issues/input/linkml_issue_497.py
+++ b/tests/test_issues/input/linkml_issue_497.py
@@ -1,0 +1,139 @@
+# Auto generated from linkml_issue_497.yaml by pythongen.py version: 0.9.0
+# Generation date: 2021-12-03T15:03:07
+# Schema: test-inherited-ranges
+#
+# id: https://example.com/test-inherited-ranges
+# description: a simple schema for testing if the range for base class propogates to the inherited class
+# license: https://creativecommons.org/publicdomain/zero/1.0/
+
+import dataclasses
+import sys
+import re
+from jsonasobj2 import JsonObj, as_dict
+from typing import Optional, List, Union, Dict, ClassVar, Any
+from dataclasses import dataclass
+from linkml_runtime.linkml_model.meta import EnumDefinition, PermissibleValue, PvFormulaOptions
+
+from linkml_runtime.utils.slot import Slot
+from linkml_runtime.utils.metamodelcore import empty_list, empty_dict, bnode
+from linkml_runtime.utils.yamlutils import YAMLRoot, extended_str, extended_float, extended_int
+from linkml_runtime.utils.dataclass_extensions_376 import dataclasses_init_fn_with_kwargs
+from linkml_runtime.utils.formatutils import camelcase, underscore, sfx
+from linkml_runtime.utils.enumerations import EnumDefinitionImpl
+from rdflib import Namespace, URIRef
+from linkml_runtime.utils.curienamespace import CurieNamespace
+from linkml_runtime.linkml_model.types import String
+
+metamodel_version = "1.7.0"
+
+# Overwrite dataclasses _init_fn to add **kwargs in __init__
+dataclasses._init_fn = dataclasses_init_fn_with_kwargs
+
+# Namespaces
+DCTERMS = CurieNamespace('dcterms', 'http://purl.org/dc/terms/')
+LINKML = CurieNamespace('linkml', 'https://w3id.org/linkml/')
+DEFAULT_ = CurieNamespace('', 'https://example.com/test-inherited-ranges/')
+
+
+# Types
+
+# Class references
+
+
+
+class NamedThing(YAMLRoot):
+    """
+    a databased entity or concept/class
+    """
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = URIRef("https://example.com/test-inherited-ranges/NamedThing")
+    class_class_curie: ClassVar[str] = None
+    class_name: ClassVar[str] = "named thing"
+    class_model_uri: ClassVar[URIRef] = URIRef("https://example.com/test-inherited-ranges/NamedThing")
+
+
+@dataclass
+class BiosampleProcessing(NamedThing):
+    """
+    A process that takes one or more biosamples as inputs and generates one or as outputs. Examples of outputs include
+    samples cultivated from another sample or data objects created by instruments runs.
+    """
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = URIRef("https://example.com/test-inherited-ranges/BiosampleProcessing")
+    class_class_curie: ClassVar[str] = None
+    class_name: ClassVar[str] = "biosample processing"
+    class_model_uri: ClassVar[URIRef] = URIRef("https://example.com/test-inherited-ranges/BiosampleProcessing")
+
+    has_input: Optional[Union[Union[dict, "Biosample"], List[Union[dict, "Biosample"]]]] = empty_list()
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if not isinstance(self.has_input, list):
+            self.has_input = [self.has_input] if self.has_input is not None else []
+        self.has_input = [v if isinstance(v, Biosample) else Biosample(**as_dict(v)) for v in self.has_input]
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass
+class OmicsProcessing(BiosampleProcessing):
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = URIRef("https://example.com/test-inherited-ranges/OmicsProcessing")
+    class_class_curie: ClassVar[str] = None
+    class_name: ClassVar[str] = "omics processing"
+    class_model_uri: ClassVar[URIRef] = URIRef("https://example.com/test-inherited-ranges/OmicsProcessing")
+
+    has_input: Optional[Union[Union[dict, NamedThing], List[Union[dict, NamedThing]]]] = empty_list()
+    has_output: Optional[Union[Union[dict, NamedThing], List[Union[dict, NamedThing]]]] = empty_list()
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if not isinstance(self.has_input, list):
+            self.has_input = [self.has_input] if self.has_input is not None else []
+        self.has_input = [v if isinstance(v, NamedThing) else NamedThing(**as_dict(v)) for v in self.has_input]
+
+        if not isinstance(self.has_output, list):
+            self.has_output = [self.has_output] if self.has_output is not None else []
+        self.has_output = [v if isinstance(v, NamedThing) else NamedThing(**as_dict(v)) for v in self.has_output]
+
+        super().__post_init__(**kwargs)
+
+
+class Biosample(NamedThing):
+    """
+    A material sample. It may be environmental (encompassing many organisms) or isolate or tissue. An environmental
+    sample containing genetic material from multiple individuals is commonly referred to as a biosample.
+    """
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = URIRef("https://example.com/test-inherited-ranges/Biosample")
+    class_class_curie: ClassVar[str] = None
+    class_name: ClassVar[str] = "biosample"
+    class_model_uri: ClassVar[URIRef] = URIRef("https://example.com/test-inherited-ranges/Biosample")
+
+
+# Enumerations
+
+
+# Slots
+class slots:
+    pass
+
+slots.id = Slot(uri=DEFAULT_.id, name="id", curie=DEFAULT_.curie('id'),
+                   model_uri=DEFAULT_.id, domain=None, range=URIRef)
+
+slots.name = Slot(uri=DEFAULT_.name, name="name", curie=DEFAULT_.curie('name'),
+                   model_uri=DEFAULT_.name, domain=None, range=Optional[str])
+
+slots.description = Slot(uri=DEFAULT_.description, name="description", curie=DEFAULT_.curie('description'),
+                   model_uri=DEFAULT_.description, domain=None, range=Optional[str])
+
+slots.has_input = Slot(uri=DEFAULT_.has_input, name="has input", curie=DEFAULT_.curie('has_input'),
+                   model_uri=DEFAULT_.has_input, domain=NamedThing, range=Optional[Union[Union[dict, "NamedThing"], List[Union[dict, "NamedThing"]]]])
+
+slots.has_output = Slot(uri=DEFAULT_.has_output, name="has output", curie=DEFAULT_.curie('has_output'),
+                   model_uri=DEFAULT_.has_output, domain=NamedThing, range=Optional[Union[Union[dict, "NamedThing"], List[Union[dict, "NamedThing"]]]])
+
+slots.biosample_processing_has_input = Slot(uri=DEFAULT_.has_input, name="biosample processing_has input", curie=DEFAULT_.curie('has_input'),
+                   model_uri=DEFAULT_.biosample_processing_has_input, domain=BiosampleProcessing, range=Optional[Union[Union[dict, "Biosample"], List[Union[dict, "Biosample"]]]])

--- a/tests/test_issues/input/linkml_issue_497.yaml
+++ b/tests/test_issues/input/linkml_issue_497.yaml
@@ -1,0 +1,80 @@
+id: https://example.com/test-inherited-ranges
+name: test-inherited-ranges
+title: test inherited ranges
+description: a simple schema for testing if the range for base class propogates to the inherited class
+
+prefixes:
+  dcterms: http://purl.org/dc/terms/
+  linkml: https://w3id.org/linkml/
+    
+imports:
+  - linkml:types
+
+classes:
+
+  named thing:
+    description: "a databased entity or concept/class"
+    abstract: true
+
+
+  biosample processing:
+    is_a: named thing
+    description: >-
+      A process that takes one or more biosamples as inputs and generates one or as outputs.
+      Examples of outputs include samples cultivated from another sample or data objects created by instruments runs.
+    slots:
+      - has input
+    slot_usage:
+      has input:
+        range: biosample
+
+
+  omics processing:
+    is_a: biosample processing
+    slots:
+      - has input
+      - has output
+    #slot_usage:
+    #  has input:
+    #    required: true
+
+  biosample:
+    is_a: named thing
+    description: >-
+      A material sample. It may be environmental (encompassing many organisms) or isolate or tissue.  
+      An environmental sample containing genetic material from multiple individuals is commonly referred to as a biosample.
+
+slots:
+
+  id:
+    identifier: true
+    multivalued: false
+    description: >-
+      A unique identifier for a thing.
+      Must be either a CURIE shorthand for a URI or a complete URI
+
+  name:
+    multivalued: false
+    range: string
+    description: >-
+      A human readable label for an entity
+
+  description:
+    range: string
+    multivalued: false
+    description: >-
+      a human-readable description of a thing
+
+  has input:
+    domain: named thing
+    range: named thing    
+    multivalued: true
+    description: >-
+      An input to a process.
+
+  has output:
+    domain: named thing
+    range: named thing
+    multivalued: true
+    description: >-
+      An output biosample to a processing step

--- a/tests/test_issues/test_linkml_issue_497.py
+++ b/tests/test_issues/test_linkml_issue_497.py
@@ -1,3 +1,5 @@
+import re
+import logging
 from unittest import TestCase, main
 from linkml_runtime.utils.schemaview import SchemaView
 from tests.test_issues.environment import env
@@ -6,17 +8,27 @@ class TestLinkmlIssue497(TestCase):
    env = env
 
    def test_linkml_issue_497(self):
-       view = SchemaView(env.input_path('linkml_issue_497.yaml'))
-       biosample_processing = view.get_class('biosample processing')
-       omics_processing = view.get_class('omics processing')
+      
+      view = SchemaView(env.input_path('linkml_issue_497.yaml'))
+      biosample_processing = view.get_class('biosample processing')
+      omics_processing = view.get_class('omics processing')
 
-       has_input = view.get_slot('has input')
-       has_input_bp = view.induced_slot('has input', 'biosample processing')
-       has_input_op = view.induced_slot('has input', 'omics processing')
+      has_input = view.get_slot('has input')
+      has_input_bp = view.induced_slot('has input', 'biosample processing')
+      has_input_op = view.induced_slot('has input', 'omics processing')
 
-       assert has_input.range == 'named thing'
-       assert has_input_bp.range == 'biosample'
-       assert has_input_op.range == 'biosample'
+      # testing schemaview ranges
+      assert has_input.range == 'named thing'
+      assert has_input_bp.range == 'biosample'
+      assert has_input_op.range == 'biosample'
+
+      # test python file's has_input attribute
+      with open(env.input_path('linkml_issue_497.py')) as f:
+        for line in f:
+            if re.match(r'\s*has_input.*NamedThing.*', line):
+               logging.error('has_input range is NamedThing.', line.strip())
+               assert False
+
 
 if __name__ == "__main__":
-    main()
+   main()

--- a/tests/test_issues/test_linkml_issue_497.py
+++ b/tests/test_issues/test_linkml_issue_497.py
@@ -1,0 +1,22 @@
+from unittest import TestCase, main
+from linkml_runtime.utils.schemaview import SchemaView
+from tests.test_issues.environment import env
+
+class TestLinkmlIssue497(TestCase):
+   env = env
+
+   def test_linkml_issue_497(self):
+       view = SchemaView(env.input_path('linkml_issue_497.yaml'))
+       biosample_processing = view.get_class('biosample processing')
+       omics_processing = view.get_class('omics processing')
+
+       has_input = view.get_slot('has input')
+       has_input_bp = view.induced_slot('has input', 'biosample processing')
+       has_input_op = view.induced_slot('has input', 'omics processing')
+
+       assert has_input.range == 'named thing'
+       assert has_input_bp.range == 'biosample'
+       assert has_input_op.range == 'biosample'
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Fixes https://github.com/linkml/linkml/issues/497

@cmungall The unit test passes. However, if you look a the generated python file `linkml-runtime/tests/test_issues/input/linkml_issue_497.py`, you will see that the [has_input](https://github.com/linkml/linkml-runtime/blob/3e5dc1116be3b4864d4fbe521d4e20c1db8cde53/tests/test_issues/input/linkml_issue_497.py#L96) attribute of `OmicsProcessing` is of type `NamedThing`:

```python
@dataclass
class OmicsProcessing(BiosampleProcessing):
    _inherited_slots: ClassVar[List[str]] = []

    class_class_uri: ClassVar[URIRef] = URIRef("https://example.com/test-inherited-ranges/OmicsProcessing")
    class_class_curie: ClassVar[str] = None
    class_name: ClassVar[str] = "omics processing"
    class_model_uri: ClassVar[URIRef] = URIRef("https://example.com/test-inherited-ranges/OmicsProcessing")

    has_input: Optional[Union[Union[dict, NamedThing], List[Union[dict, NamedThing]]]] = empty_list()
...
```
I did some playing around, and found out that if I remove/comment out the `has input` slot from the `omics processing` class in the yaml file, and include the `slot_usage` like so:
```yaml
    slot_usage:
        has input:
         required: true    
```
the type of the `has_input` attribute in the python file will be `Biosample`