### PR TITLE
fix(prefixes): warn about unrecognized prefix instead of error

### DIFF
--- a/linkml_runtime/utils/namespaces.py
+++ b/linkml_runtime/utils/namespaces.py
@@ -192,7 +192,9 @@ class Namespaces(CaseInsensitiveDict):
                     return k + ':' + suffix
             return self.join(str(prefix), suffix)
         elif prefix not in self:
-            raise ValueError(f"Unrecognized prefix: {prefix}")
+            # raise ValueError(f"Unrecognized prefix: {prefix}")
+            print(f"WARNING: Unrecognized prefix: {prefix}")
+            return ':' + suffix
         else:
             return prefix + ':' + suffix
 


### PR DESCRIPTION
This PR allows documentation to be built despite https://github.com/linkml/linkml-runtime/issues/96

But a solution to #96 would be better of course..