### PR TITLE
Pre-transforming Decimals prior to serialization Fixes #547

### DIFF
--- a/linkml_runtime/dumpers/json_dumper.py
+++ b/linkml_runtime/dumpers/json_dumper.py
@@ -1,4 +1,5 @@
 import json
+from decimal import Decimal
 from typing import Dict
 
 from deprecated.classic import deprecated
@@ -41,8 +42,16 @@ class JSONDumper(Dumper):
         :param inject_type: if True (default), add a @type at the top level
         :return: JSON Object representing the element
         """
+        def default(o):
+            if isinstance(o, YAMLRoot):
+                return remove_empty_items(o, hide_protected_keys=True)
+            elif isinstance(o, Decimal):
+                # https://stackoverflow.com/questions/1960516/python-json-serialize-a-decimal-object
+                return str(o)
+            else:
+                return json.JSONDecoder().decode(o)
         return json.dumps(as_json_object(element, contexts, inject_type=inject_type),
-                          default=lambda o: remove_empty_items(o, hide_protected_keys=True) if isinstance(o, YAMLRoot) else json.JSONDecoder().decode(o),
+                          default=default,
                           indent='  ')
 
 

--- a/linkml_runtime/dumpers/yaml_dumper.py
+++ b/linkml_runtime/dumpers/yaml_dumper.py
@@ -1,13 +1,16 @@
+from decimal import Decimal
+
 import yaml
 
 from linkml_runtime.dumpers.dumper_root import Dumper
 from linkml_runtime.utils.formatutils import remove_empty_items
 from linkml_runtime.utils.yamlutils import YAMLRoot
 
-
 class YAMLDumper(Dumper):
 
     def dumps(self, element: YAMLRoot, **kwargs) -> str:
         """ Return element formatted as a YAML string """
+        # Internal note: remove_empty_items will also convert Decimals to int/float;
+        # this is necessary until https://github.com/yaml/pyyaml/pull/372 is merged
         return yaml.dump(remove_empty_items(element, hide_protected_keys=True),
                                             Dumper=yaml.SafeDumper, sort_keys=False, **kwargs)

--- a/linkml_runtime/utils/formatutils.py
+++ b/linkml_runtime/utils/formatutils.py
@@ -131,6 +131,10 @@ def remove_empty_items(obj: Any, hide_protected_keys: bool = False, inside: bool
 
     Note that this will also convert Decimals to floats or ints; this is necessary
     as both json dumpers and yaml dumpers will encode Decimal types by default.
+    See https://github.com/linkml/linkml/issues
+    
+    This is easier than fixing the individual serializers, described here:
+    
     - JSON: https://bugs.python.org/issue16535, https://stackoverflow.com/questions/1960516/python-json-serialize-a-decimal-object
     - YAML: https://stackoverflow.com/questions/21695705/dump-an-python-object-as-yaml-file/51261042, https://github.com/yaml/pyyaml/pull/372
 

--- a/linkml_runtime/utils/formatutils.py
+++ b/linkml_runtime/utils/formatutils.py
@@ -1,10 +1,13 @@
 import re
-from typing import List, Any
+from decimal import Decimal
+from numbers import Number
+from typing import List, Any, Union
 
 from jsonasobj2 import JsonObj, as_dict, is_list, is_dict, items, as_json_obj
 
 ws_pattern = re.compile(r'\s+')
 us_pattern = re.compile(r'_+')
+
 
 
 def camelcase(txt: str) -> str:
@@ -126,6 +129,10 @@ def remove_empty_items(obj: Any, hide_protected_keys: bool = False, inside: bool
 
     The above situation ONLY applies when there is ONE k,v pair and v is a dictionary
 
+    Note that this will also convert Decimals to floats or ints; this is necessary
+    as both json dumpers and yaml dumpers will encode Decimal types by default.
+    - JSON: https://bugs.python.org/issue16535, https://stackoverflow.com/questions/1960516/python-json-serialize-a-decimal-object
+    - YAML: https://stackoverflow.com/questions/21695705/dump-an-python-object-as-yaml-file/51261042, https://github.com/yaml/pyyaml/pull/372
 
     :param obj: Object to be tweaked
     :param hide_protected_keys: True means remove keys that begin with an underscore
@@ -154,5 +161,13 @@ def remove_empty_items(obj: Any, hide_protected_keys: bool = False, inside: bool
         return obj_dict if not inside or not is_empty(obj_dict) else None
     elif is_empty(obj):
         return None
+    elif isinstance(obj, Decimal):
+        # note that attempting to implement https://bugs.python.org/issue16535
+        # will not work for yaml serializations
+        v = str(obj)
+        if '.' in v and not v.endswith('.0'):
+            return float(obj)
+        else:
+            return int(obj)
     else:
         return obj

--- a/tests/test_loaders_dumpers/input/example_personinfo_data.yaml
+++ b/tests/test_loaders_dumpers/input/example_personinfo_data.yaml
@@ -41,9 +41,16 @@ organizations:
     categories:
       - charity
       - non profit
+    score: 1
+    min_salary: 99999.00
   ROR:2:
     name: bar
     categories:
       - shell company
+    score: 1.5
+  ROR:3:
+    score: "1"
+  ROR:4:
+    score: 1.0
 
   

--- a/tests/test_loaders_dumpers/input/personinfo.yaml
+++ b/tests/test_loaders_dumpers/input/personinfo.yaml
@@ -40,6 +40,9 @@ types:
     base: str
     uri: xsd:anyURI
 
+  SalaryType:
+    typeof: decimal
+
 classes:
 
   NamedThing:
@@ -97,9 +100,22 @@ classes:
       - founding_date
       - founding_location
       - categories
+      - score
+      - min_salary
     slot_usage:
       categories:
         range: OrganizationType
+    rules:
+      - postconditions:
+          slot_conditions:
+            score:
+              maximum_value: 0
+        preconditions:
+          slot_conditions:
+            min_salary:
+              maximum_value: 80000.00
+            
+            
 
   Place:
     mixins:
@@ -176,6 +192,7 @@ classes:
     is_a: Event
     slots:
       - employed_at
+      - salary
 
   MedicalEvent:
     is_a: Event
@@ -246,6 +263,11 @@ slots:
     range: integer
     minimum_value: 0
     maximum_value: 999
+  score:
+    description: A score between 0 and 5, represented as a decimal
+    range: decimal
+    minimum_value: 0.0
+    maximum_value: 5.0
   related_to:
     range: NamedThing
   depicted_by:
@@ -281,6 +303,10 @@ slots:
   categories:
     multivalued: true
 
+  salary:
+    range: SalaryType
+  min_salary:
+    range: SalaryType
 
     
 enums:

--- a/tests/test_loaders_dumpers/models/personinfo.py
+++ b/tests/test_loaders_dumpers/models/personinfo.py
@@ -1,5 +1,5 @@
 # Auto generated from personinfo.yaml by pythongen.py version: 0.9.0
-# Generation date: 2021-11-27T19:59:07
+# Generation date: 2021-12-26T18:13:04
 # Schema: personinfo
 #
 # id: https://w3id.org/linkml/examples/personinfo
@@ -22,8 +22,8 @@ from linkml_runtime.utils.formatutils import camelcase, underscore, sfx
 from linkml_runtime.utils.enumerations import EnumDefinitionImpl
 from rdflib import Namespace, URIRef
 from linkml_runtime.utils.curienamespace import CurieNamespace
-from linkml_runtime.linkml_model.types import Boolean, Date, Float, Integer, String, Uri, Uriorcurie
-from linkml_runtime.utils.metamodelcore import Bool, URI, URIorCURIE, XSDDate
+from linkml_runtime.linkml_model.types import Boolean, Date, Decimal, Float, Integer, String, Uri, Uriorcurie
+from linkml_runtime.utils.metamodelcore import Bool, Decimal, URI, URIorCURIE, XSDDate
 
 metamodel_version = "1.7.0"
 
@@ -60,6 +60,13 @@ class ImageURL(Uri):
     type_class_curie = "xsd:anyURI"
     type_name = "ImageURL"
     type_model_uri = PERSONINFO.ImageURL
+
+
+class SalaryType(Decimal):
+    type_class_uri = XSD.decimal
+    type_class_curie = "xsd:decimal"
+    type_name = "SalaryType"
+    type_model_uri = PERSONINFO.SalaryType
 
 
 # Class references
@@ -242,6 +249,8 @@ class Organization(NamedThing):
     founding_date: Optional[str] = None
     founding_location: Optional[Union[str, PlaceId]] = None
     categories: Optional[Union[Union[str, "OrganizationType"], List[Union[str, "OrganizationType"]]]] = empty_list()
+    score: Optional[Decimal] = None
+    min_salary: Optional[Union[Decimal, SalaryType]] = None
     aliases: Optional[Union[str, List[str]]] = empty_list()
 
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
@@ -262,6 +271,12 @@ class Organization(NamedThing):
         if not isinstance(self.categories, list):
             self.categories = [self.categories] if self.categories is not None else []
         self.categories = [v if isinstance(v, OrganizationType) else OrganizationType(v) for v in self.categories]
+
+        if self.score is not None and not isinstance(self.score, Decimal):
+            self.score = Decimal(self.score)
+
+        if self.min_salary is not None and not isinstance(self.min_salary, SalaryType):
+            self.min_salary = SalaryType(self.min_salary)
 
         if not isinstance(self.aliases, list):
             self.aliases = [self.aliases] if self.aliases is not None else []
@@ -562,10 +577,14 @@ class EmploymentEvent(Event):
     class_model_uri: ClassVar[URIRef] = PERSONINFO.EmploymentEvent
 
     employed_at: Optional[Union[str, OrganizationId]] = None
+    salary: Optional[Union[Decimal, SalaryType]] = None
 
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
         if self.employed_at is not None and not isinstance(self.employed_at, OrganizationId):
             self.employed_at = OrganizationId(self.employed_at)
+
+        if self.salary is not None and not isinstance(self.salary, SalaryType):
+            self.salary = SalaryType(self.salary)
 
         super().__post_init__(**kwargs)
 
@@ -753,6 +772,9 @@ slots.current_address = Slot(uri=PERSONINFO.current_address, name="current_addre
 slots.age_in_years = Slot(uri=PERSONINFO.age_in_years, name="age_in_years", curie=PERSONINFO.curie('age_in_years'),
                    model_uri=PERSONINFO.age_in_years, domain=None, range=Optional[int])
 
+slots.score = Slot(uri=PERSONINFO.score, name="score", curie=PERSONINFO.curie('score'),
+                   model_uri=PERSONINFO.score, domain=None, range=Optional[Decimal])
+
 slots.related_to = Slot(uri=PERSONINFO.related_to, name="related_to", curie=PERSONINFO.curie('related_to'),
                    model_uri=PERSONINFO.related_to, domain=None, range=Optional[Union[str, NamedThingId]])
 
@@ -800,6 +822,12 @@ slots.ended_at_time = Slot(uri=PROV.endedAtTime, name="ended_at_time", curie=PRO
 
 slots.categories = Slot(uri=PERSONINFO.categories, name="categories", curie=PERSONINFO.curie('categories'),
                    model_uri=PERSONINFO.categories, domain=None, range=Optional[Union[str, List[str]]])
+
+slots.salary = Slot(uri=PERSONINFO.salary, name="salary", curie=PERSONINFO.curie('salary'),
+                   model_uri=PERSONINFO.salary, domain=None, range=Optional[Union[Decimal, SalaryType]])
+
+slots.min_salary = Slot(uri=PERSONINFO.min_salary, name="min_salary", curie=PERSONINFO.curie('min_salary'),
+                   model_uri=PERSONINFO.min_salary, domain=None, range=Optional[Union[Decimal, SalaryType]])
 
 slots.hasAliases__aliases = Slot(uri=PERSONINFO.aliases, name="hasAliases__aliases", curie=PERSONINFO.curie('aliases'),
                    model_uri=PERSONINFO.hasAliases__aliases, domain=None, range=Optional[Union[str, List[str]]])


### PR DESCRIPTION
Rather than adding custom representers, we pre-transform the dictionary object prior to serialization

This PR also adds tests for decimals, extending the test schema to have a decimal type, and various ways of instantiating

Fixes https://github.com/linkml/linkml/issues/547