### PR TITLE
fixes https://github.com/linkml/linkml/issues/634

### DIFF
--- a/linkml_runtime/dumpers/json_dumper.py
+++ b/linkml_runtime/dumpers/json_dumper.py
@@ -51,7 +51,7 @@ class JSONDumper(Dumper):
             else:
                 return json.JSONDecoder().decode(o)
         return json.dumps(as_json_object(element, contexts, inject_type=inject_type),
-                          default=default,
+                          default=default, ensure_ascii=False,
                           indent='  ')
 
 

--- a/linkml_runtime/dumpers/yaml_dumper.py
+++ b/linkml_runtime/dumpers/yaml_dumper.py
@@ -13,4 +13,4 @@ class YAMLDumper(Dumper):
         # Internal note: remove_empty_items will also convert Decimals to int/float;
         # this is necessary until https://github.com/yaml/pyyaml/pull/372 is merged
         return yaml.dump(remove_empty_items(element, hide_protected_keys=True),
-                                            Dumper=yaml.SafeDumper, sort_keys=False, **kwargs)
+                                            Dumper=yaml.SafeDumper, sort_keys=False, allow_unicode=True, **kwargs)


### PR DESCRIPTION
I dont know if this is the way to go, as having this set as default might not be desired for other use cases, but this would resolve my problem reported in https://github.com/linkml/linkml/issues/634.

Still open would be the `json_dumper.dumps()` variant. 