### PR TITLE
Solve errors and warnings in test-suite on windows

### DIFF
--- a/linkml_runtime/utils/compile_python.py
+++ b/linkml_runtime/utils/compile_python.py
@@ -42,7 +42,7 @@ def compile_python(text_or_fn: str, package_path: str = None) -> ModuleType:
         else:
             warning(f"There is no established path to {package_path} - compile_python may or may not work")
             path_from_tests_parent = os.path.relpath(package_path, os.path.join(os.getcwd(), '..'))
-        module.__package__ = os.path.dirname(os.path.relpath(path_from_tests_parent, os.getcwd())).replace('/', '.')
+        module.__package__ = os.path.dirname(os.path.relpath(path_from_tests_parent, os.getcwd())).replace(os.path.sep, '.')
     sys.modules[module.__name__] = module
     exec(spec, module.__dict__)
     return module

--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -707,7 +707,7 @@ class SchemaView(object):
 
         """
         applicable_elements = []
-        elements = self.all_element()
+        elements = self.all_elements()
         for category, category_element in elements.items():
             if hasattr(category_element, 'id_prefixes') and prefix in category_element.id_prefixes:
                 applicable_elements.append(category_element.name)

--- a/tests/support/test_environment.py
+++ b/tests/support/test_environment.py
@@ -217,7 +217,7 @@ class TestEnvironment:
         if not self.eval_single_file(expected_file, actual, filtr, comparator):
             if self.fail_on_error:
                 self.make_temp_dir(os.path.dirname(actual_file), clear=False)
-                with open(actual_file, 'w') as actualf:
+                with open(actual_file, 'w', encoding='UTF-8') as actualf:
                     actualf.write(actual)
         return actual
 
@@ -241,7 +241,7 @@ class TestEnvironment:
             self.log(expected_file_path, msg)
         if msg and not self.fail_on_error:
             self.make_temp_dir(os.path.dirname(expected_file_path), clear=False)
-            with open(expected_file_path, 'w') as outf:
+            with open(expected_file_path, 'w', encoding='UTF-8') as outf:
                 outf.write(actual_text)
         return not msg
 

--- a/tests/test_issues/input/issue_368.py
+++ b/tests/test_issues/input/issue_368.py
@@ -20,7 +20,7 @@ from linkml_runtime.utils.formatutils import camelcase, underscore, sfx
 from linkml_runtime.utils.enumerations import EnumDefinitionImpl
 from rdflib import Namespace, URIRef
 from linkml_runtime.utils.curienamespace import CurieNamespace
-from . issue_368_imports import ParentClass, SampleEnum
+from .issue_368_imports import ParentClass, SampleEnum
 
 metamodel_version = "1.7.0"
 

--- a/tests/test_issues/test_issue_6.py
+++ b/tests/test_issues/test_issue_6.py
@@ -1,6 +1,4 @@
 import unittest
-from contextlib import redirect_stderr
-from io import StringIO
 
 import hbreader
 import yaml

--- a/tests/test_issues/test_issue_6.py
+++ b/tests/test_issues/test_issue_6.py
@@ -25,10 +25,10 @@ class Issue6TestCase(unittest.TestCase):
                          TypedNode.yaml_loc(inp['foo']['y'], suffix=inp['foo']['y']))
         self.assertEqual('File "<unicode string>", line 5, col 8: ', TypedNode.yaml_loc(inp['foo']['z']))
 
-        outs = StringIO()
-        with redirect_stderr(outs):
+        with self.assertWarns(DeprecationWarning) as cm:
             self.assertEqual('File "<unicode string>", line 3, col 8', TypedNode.loc(inp['foo']['x']))
-        self.assertIn('Call to deprecated method loc. (Use yaml_loc instead)', outs.getvalue())
+        self.assertEqual('Call to deprecated method loc. (Use yaml_loc instead)', cm.warning.args[0])
+
 
         self.assertEqual('', TypedNode.yaml_loc(None))
         self.assertEqual('', TypedNode.yaml_loc("abc"))

--- a/tests/test_loaders_dumpers/__init__.py
+++ b/tests/test_loaders_dumpers/__init__.py
@@ -1,6 +1,7 @@
 import os
 
 from rdflib import Namespace
+from pathlib import Path
 
 HTTP_TEST_PORT = 8000
 HTTPS_TEST_PORT = 8443
@@ -14,9 +15,9 @@ LD_11_DIR = os.path.join(TESTING_DIR, 'jsonld_context/jsonld_11/')
 
 
 GITHUB_DIR = 'https://raw.githubusercontent.com/HOT-Ecosystem/TermCI-model/main/'
-GITHUB_INPUT_DIR = GITHUB_DIR + os.path.relpath(INPUT_DIR, os.path.dirname(TESTING_DIR))
-GITHUB_LD10_CONTEXT = GITHUB_DIR + os.path.relpath(LD_10_DIR, os.path.dirname(TESTING_DIR)) + '/'
-GITHUB_LD11_CONTEXT = GITHUB_DIR + os.path.relpath(LD_11_DIR, os.path.dirname(TESTING_DIR)) + '/'
+GITHUB_INPUT_DIR = GITHUB_DIR + Path(os.path.relpath(INPUT_DIR, os.path.dirname(TESTING_DIR))).as_posix()
+GITHUB_LD10_CONTEXT = GITHUB_DIR + Path(os.path.relpath(LD_10_DIR, os.path.dirname(TESTING_DIR))).as_posix() + '/'
+GITHUB_LD11_CONTEXT = GITHUB_DIR + Path(os.path.relpath(LD_11_DIR, os.path.dirname(TESTING_DIR))).as_posix() + '/'
 
 SCT = Namespace("http://snomed.info/id/")
 OBO = Namespace("http://purl.obolibrary.org/obo/")

--- a/tests/test_loaders_dumpers/loaderdumpertestcase.py
+++ b/tests/test_loaders_dumpers/loaderdumpertestcase.py
@@ -60,9 +60,14 @@ class LoaderDumperTestCase(TestEnvironmentTestCase):
 
         # Make sure metadata gets filled out properly
         rel_path = os.path.abspath(os.path.join(test_base.env.cwd, '..'))
-        self.assertEqual('tests/test_loaders_dumpers/input', os.path.relpath(metadata.base_path, rel_path))
-        self.assertEqual(f'tests/test_loaders_dumpers/input/{filename}', os.path.relpath(metadata.source_file,
-                                                                                         rel_path))
+        self.assertEqual(
+            os.path.normpath('tests/test_loaders_dumpers/input'), 
+            os.path.normpath(os.path.relpath(metadata.base_path, rel_path))
+        )
+        self.assertEqual(
+            os.path.normpath(f'tests/test_loaders_dumpers/input/{filename}'), 
+            os.path.normpath(os.path.relpath(metadata.source_file, rel_path))
+        )
 
         fileinfo = FileInfo()
         hbread(filename, fileinfo, self.env.indir)

--- a/tests/test_utils/test_metamodelcore.py
+++ b/tests/test_utils/test_metamodelcore.py
@@ -164,7 +164,7 @@ class MetamodelCoreTest(unittest.TestCase):
     def test_datetime(self):
         v = datetime.datetime(2019, 7, 6, 17, 22, 39, 7300)
         self.assertEqual('2019-07-06T17:22:39.007300', XSDDateTime(v))
-        self.assertEqual('2019-07-06T17:22:39.007300', XSDDateTime(Literal(v, datatype=XSD.datetime)))
+        self.assertEqual('2019-07-06T17:22:39.007300', XSDDateTime(Literal(v, datatype=XSD.dateTime)))
         self.assertEqual('2019-07-06T17:22:39.007300', XSDDateTime(Literal(v).value))
         self.assertEqual('2019-07-06T17:22:39.007300', v.isoformat())
         self.assertEqual('2019-07-06T17:22:39.007300', XSDDateTime(XSDDateTime(v)))


### PR DESCRIPTION
I addressed all errors. Two warnings remain:

Three errors were caused by hard coded path seperators or by assuming that urls can be constructed from windows path like from posix path. One error was caused by not testing in the correct way for warnings (which shows up with pytest but not the unittest test runner).

I think removing "Test" from the name of the class TestEnvironment would remove the warning. I am was not sure if you want to do that.

```
====================================== test session starts ======================================= 
platform win32 -- Python 3.10.2, pytest-7.0.1, pluggy-1.0.0
rootdir: C:\Users\david\MyProg\linkml-runtime
collected 83 items

...
======================================== warnings summary ======================================== tests\support\test_environment.py:35
  C:\Users\david\MyProg\linkml-runtime\tests\support\test_environment.py:35: PytestCollectionWarning: cannot collect test class 'TestEnvironment' because it has a __init__ constructor (from: tests/support/test_environment.py)
    class TestEnvironment:

.venv\lib\site-packages\_pytest\fixtures.py:229
  C:\Users\david\MyProg\linkml-runtime\.venv\lib\site-packages\_pytest\fixtures.py:229: UserWarning: Code: _pytestfixturefunction is not defined in namespace XSD
    fixturemarker: Optional[FixtureFunctionMarker] = getattr(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================== 78 passed, 4 skipped, 1 xfailed, 2 warnings in 27.98s ======================
```

Fixes #144