### PR TITLE
More fixes related to unicode (fixes linkml/linkml#634)

### DIFF
--- a/linkml_runtime/dumpers/dumper_root.py
+++ b/linkml_runtime/dumpers/dumper_root.py
@@ -13,7 +13,7 @@ class Dumper(ABC):
         :param to_file: file to dump to
         :@param _: method specific arguments
         """
-        with open(to_file, 'w', encoding="UTF8") as output_file:
+        with open(to_file, 'w') as output_file:
             output_file.write(self.dumps(element, **_))
 
     @abstractmethod

--- a/linkml_runtime/dumpers/dumper_root.py
+++ b/linkml_runtime/dumpers/dumper_root.py
@@ -13,7 +13,7 @@ class Dumper(ABC):
         :param to_file: file to dump to
         :@param _: method specific arguments
         """
-        with open(to_file, 'w') as output_file:
+        with open(to_file, 'w', encoding="UTF8") as output_file:
             output_file.write(self.dumps(element, **_))
 
     @abstractmethod

--- a/linkml_runtime/dumpers/dumper_root.py
+++ b/linkml_runtime/dumpers/dumper_root.py
@@ -13,7 +13,7 @@ class Dumper(ABC):
         :param to_file: file to dump to
         :@param _: method specific arguments
         """
-        with open(to_file, 'w') as output_file:
+        with open(to_file, 'w', encoding='UTF-8') as output_file:
             output_file.write(self.dumps(element, **_))
 
     @abstractmethod

--- a/linkml_runtime/dumpers/json_dumper.py
+++ b/linkml_runtime/dumpers/json_dumper.py
@@ -52,6 +52,7 @@ class JSONDumper(Dumper):
                 return json.JSONDecoder().decode(o)
         return json.dumps(as_json_object(element, contexts, inject_type=inject_type),
                           default=default,
+                          ensure_ascii=False,
                           indent='  ')
 
 

--- a/linkml_runtime/dumpers/yaml_dumper.py
+++ b/linkml_runtime/dumpers/yaml_dumper.py
@@ -13,6 +13,4 @@ class YAMLDumper(Dumper):
         # Internal note: remove_empty_items will also convert Decimals to int/float;
         # this is necessary until https://github.com/yaml/pyyaml/pull/372 is merged
         return yaml.dump(remove_empty_items(element, hide_protected_keys=True),
-                         Dumper=yaml.SafeDumper, sort_keys=False, 
-                         allow_unicode=True,
-                         **kwargs)
+                                            Dumper=yaml.SafeDumper, sort_keys=False, **kwargs)

--- a/linkml_runtime/dumpers/yaml_dumper.py
+++ b/linkml_runtime/dumpers/yaml_dumper.py
@@ -13,4 +13,6 @@ class YAMLDumper(Dumper):
         # Internal note: remove_empty_items will also convert Decimals to int/float;
         # this is necessary until https://github.com/yaml/pyyaml/pull/372 is merged
         return yaml.dump(remove_empty_items(element, hide_protected_keys=True),
-                                            Dumper=yaml.SafeDumper, sort_keys=False, **kwargs)
+                         Dumper=yaml.SafeDumper, sort_keys=False, 
+                         allow_unicode=True,
+                         **kwargs)

--- a/tests/test_loaders_dumpers/input/example_personinfo_data.ttl
+++ b/tests/test_loaders_dumpers/input/example_personinfo_data.ttl
@@ -16,7 +16,7 @@ P:001 a ns3:Person ;
 P:002 a ns3:Person ;
     ns3:email "joe.schmoe@example.com" ;
     ns3:gender <http://purl.obolibrary.org/obo/GSSO_000372> ;
-    ns3:name "joe schmoe" ;
+    ns3:name "joe schmö" ;
     ns2:current_address [ a ns3:PostalAddress ;
             ns2:city "foo city" ;
             ns2:street "1 foo street" ] ;

--- a/tests/test_loaders_dumpers/input/example_personinfo_data.yaml
+++ b/tests/test_loaders_dumpers/input/example_personinfo_data.yaml
@@ -6,7 +6,7 @@ persons:
     gender: cisgender man
     depicted_by: https://example.org/pictures/fred.jpg
   - id: P:002
-    name: joe schmoe
+    name: joe schmö
     primary_email: joe.schmoe@example.com
     has_employment_history:
       - employed_at: ROR:1

--- a/tests/test_loaders_dumpers/test_loaders_dumpers.py
+++ b/tests/test_loaders_dumpers/test_loaders_dumpers.py
@@ -43,7 +43,7 @@ WD = Namespace('http://www.wikidata.org/entity/')
 
 class LoadersDumpersTestCase(unittest.TestCase):
 
-    def test_all(self):
+    def setUp(self):
         view = SchemaView(SCHEMA)
         container: Container
         container = yaml_loader.load(DATA, target_class=Container)
@@ -67,7 +67,7 @@ class LoadersDumpersTestCase(unittest.TestCase):
         Tests the load_any loader method, which can be used to load directly to a list
         """
         view = SchemaView(SCHEMA)
-        with open(DATA) as stream:
+        with open(DATA, encoding='UTF-8') as stream:
             data = yaml.safe_load(stream)
         #persons = yaml_loader.load_source(data, target_class=Person)
         #container = Container(persons=persons)
@@ -80,10 +80,19 @@ class LoadersDumpersTestCase(unittest.TestCase):
             [p1] = [p for p in persons if p.id == 'P:001']
             [p2] = [p for p in persons if p.id == 'P:002']
             self.assertEqual(p1.name, 'fred bloggs')
-            self.assertEqual(p2.name, 'joe schmoe')
+            self.assertEqual(p2.name, 'joe schmö')
             self.assertEqual(p1.age_in_years, 33)
             self.assertEqual(p1.gender.code.text, 'cisgender man')
             self.assertEqual(p2.gender.code.text, 'transgender man')
+
+    def test_yaml_encoding(self):
+        """This will reveal if file is ascii or utf-8 encoded"""
+        # pyyaml reads non-ascii strings just fine no matter if the file
+        # is ascii and utf-8 encoded. So we use Python's open function
+        # to detect undesired ascii encoding. (linkml issue #634)
+        with open(OUT_YAML, encoding='UTF-8') as f:
+            [p2_name_line] = [l for l in f.readlines() if 'joe schm' in l]
+        self.assertIn('joe schmö', p2_name_line)
 
 
     def _check_objs(self, view: SchemaView, container: Container):
@@ -98,7 +107,7 @@ class LoadersDumpersTestCase(unittest.TestCase):
         o1cats = [c.code.text for c in o1.categories]
         o2cats = [c.code.text for c in o2.categories]
         self.assertEqual(p1.name, 'fred bloggs')
-        self.assertEqual(p2.name, 'joe schmoe')
+        self.assertEqual(p2.name, 'joe schmö')
         self.assertEqual(p1.age_in_years, 33)
         self.assertEqual(p1.gender.code.text, 'cisgender man')
         self.assertEqual(p2.gender.code.text, 'transgender man')

--- a/tests/test_loaders_dumpers/test_loaders_dumpers.py
+++ b/tests/test_loaders_dumpers/test_loaders_dumpers.py
@@ -85,12 +85,18 @@ class LoadersDumpersTestCase(unittest.TestCase):
             self.assertEqual(p1.gender.code.text, 'cisgender man')
             self.assertEqual(p2.gender.code.text, 'transgender man')
 
-    def test_yaml_encoding(self):
-        """This will reveal if file is ascii or utf-8 encoded"""
-        # pyyaml reads non-ascii strings just fine no matter if the file
-        # is ascii and utf-8 encoded. So we use Python's open function
+    def test_encoding(self):
+        """
+        This will reveal if generated yaml or json files are utf-8 encoded
+        """
+        # pyyaml or json reads non-ascii strings just fine no matter if the
+        # file is ascii and utf-8 encoded. So we use Python's open function
         # to detect undesired ascii encoding. (linkml issue #634)
         with open(OUT_YAML, encoding='UTF-8') as f:
+            [p2_name_line] = [l for l in f.readlines() if 'joe schm' in l]
+        self.assertIn('joe schmö', p2_name_line)
+
+        with open(OUT_JSON, encoding='UTF-8') as f:
             [p2_name_line] = [l for l in f.readlines() if 'joe schm' in l]
         self.assertIn('joe schmö', p2_name_line)
 

--- a/tests/test_loaders_dumpers/test_loaders_dumpers.py
+++ b/tests/test_loaders_dumpers/test_loaders_dumpers.py
@@ -89,8 +89,8 @@ class LoadersDumpersTestCase(unittest.TestCase):
         """
         This will reveal if generated yaml or json files are utf-8 encoded
         """
-        # pyyaml or json reads non-ascii strings just fine no matter if the
-        # file is ascii and utf-8 encoded. So we use Python's open function
+        # pyyaml or json read non-ascii strings just fine no matter if the
+        # file is ascii or utf-8 encoded. So we use Python's open function
         # to detect undesired ascii encoding. (linkml issue #634)
         with open(OUT_YAML, encoding='UTF-8') as f:
             [p2_name_line] = [l for l in f.readlines() if 'joe schm' in l]

--- a/tests/test_loaders_dumpers/test_rdflib_dumper.py
+++ b/tests/test_loaders_dumpers/test_rdflib_dumper.py
@@ -221,7 +221,7 @@ class RdfLibDumperTestCase(unittest.TestCase):
         o1cats = [c.code.text for c in o1.categories]
         o2cats = [c.code.text for c in o2.categories]
         self.assertEqual(p1.name, 'fred bloggs')
-        self.assertEqual(p2.name, 'joe schmoe')
+        self.assertEqual(p2.name, 'joe schmö')
         self.assertEqual(p1.age_in_years, 33)
         self.assertEqual(p1.gender.code.text, 'cisgender man')
         self.assertEqual(p2.gender.code.text, 'transgender man')


### PR DESCRIPTION
More fixes related to unicode: (i) in yaml-files and (ii) on windows (linkml/linkml#601).

I also added an "ö" to the test data. That way unicode handling mistakes may show up earlier in the future.

Fixes linkml/linkml#634