### PR TITLE
add method to return all_classes, all_slots in alphabetical and/or rank order.

### DIFF
--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -10,7 +10,7 @@ from linkml_runtime.utils.namespaces import Namespaces
 from deprecated.classic import deprecated
 from linkml_runtime.utils.context_utils import parse_import_map
 from linkml_runtime.linkml_model.meta import *
-
+from enum import Enum
 logger = logging.getLogger(__name__)
 
 
@@ -29,9 +29,11 @@ SUBSET_NAME = Union[SubsetDefinitionName, str]
 TYPE_NAME = Union[TypeDefinitionName, str]
 ENUM_NAME = Union[EnumDefinitionName, str]
 
-ORDERED_BY = ["rank", "lexical", "preserve"]
 
-
+class OrderedBy(Enum):
+    RANK = "rank"
+    LEXICAL = "lexical"
+    PRESERVE = "preserve"
 
 
 def _closure(f, x, reflexive=True, depth_first=True, **kwargs):
@@ -240,19 +242,17 @@ class SchemaView(object):
         return rank_ordered_elements
 
     @lru_cache()
-    def all_classes(self, ordered_by='preserve', imports=True) -> Dict[ClassDefinitionName, ClassDefinition]:
+    def all_classes(self, ordered_by=OrderedBy.PRESERVE, imports=True) -> Dict[ClassDefinitionName, ClassDefinition]:
         """
         :param ordered_by: an enumerated parameter that returns all the slots in the order specified.
         :param imports: include imports closure
         :return: all classes in schema view
         """
         classes = copy(self._get_dict(CLASSES, imports))
-        if ordered_by not in ORDERED_BY:
-            raise ValueError("missing ordered_by value in ORDERED_BY enumeration" + str(ordered_by))
 
-        if ordered_by == 'lexical':
+        if ordered_by == OrderedBy.LEXICAL:
             ordered_classes = self._order_lexically(elements=classes)
-        elif ordered_by == 'rank':
+        elif ordered_by == OrderedBy.RANK:
             ordered_classes = self._order_rank(elements=classes)
         else:  # else preserve the order in the yaml
             ordered_classes = classes
@@ -269,16 +269,13 @@ class SchemaView(object):
         return self.all_slots(**kwargs)
 
     @lru_cache()
-    def all_slots(self, ordered_by="preserve", imports=True, attributes=True) -> Dict[SlotDefinitionName, SlotDefinition]:
+    def all_slots(self, ordered_by=OrderedBy.PRESERVE, imports=True, attributes=True) -> Dict[SlotDefinitionName, SlotDefinition]:
         """
         :param ordered_by: an enumerated parameter that returns all the slots in the order specified.
         :param imports: include imports closure
         :param attributes: include attributes as slots or not, default is to include.
         :return: all slots in schema view
         """
-
-        if ordered_by not in ORDERED_BY:
-            raise ValueError("ordered_by is not in ORDERED_BY enumeration")
 
         slots = copy(self._get_dict(SLOTS, imports))
         if attributes:
@@ -287,9 +284,9 @@ class SchemaView(object):
                     if aname not in slots:
                         slots[aname] = a
 
-        if ordered_by == 'lexical':
+        if ordered_by == OrderedBy.LEXICAL:
             ordered_slots = self._order_lexically(elements=slots)
-        elif ordered_by == 'rank':
+        elif ordered_by == OrderedBy.RANK:
             ordered_slots = self._order_rank(elements=slots)
         else:
             # preserve order in YAML

--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -216,6 +216,21 @@ class SchemaView(object):
         """
         return self.all_slots(**kwargs)
 
+    def all_classes_ordered(self, imports=True) ->Dict[ClassDefinitionName, ClassDefinition]:
+        """
+        :param imports: include imports closure
+        :return: all class names in schema view ordered alphabetically, useful primarily for documentation view.
+        """
+        ordered_list_of_names = []
+        ordered_classes = {}
+        for c in self._get_dict(CLASSES, imports):
+            ordered_list_of_names.append(c.name)
+        ordered_list_of_names.sort(reverse=True)
+        for name in ordered_list_of_names:
+            ordered_classes[self.get_class(name).name] = self.get_class(name)
+        return ordered_classes
+
+
     @lru_cache()
     def all_slots(self, imports=True, attributes=True) -> Dict[SlotDefinitionName, SlotDefinition]:
         """

--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -216,14 +216,14 @@ class SchemaView(object):
         """
         return self.all_slots(**kwargs)
 
-    def all_classes_ordered(self, imports=True) ->Dict[ClassDefinitionName, ClassDefinition]:
+    def all_classes_ordered(self) ->Dict[ClassDefinitionName, ClassDefinition]:
         """
         :param imports: include imports closure
         :return: all class names in schema view ordered alphabetically, useful primarily for documentation view.
         """
         ordered_list_of_names = []
         ordered_classes = {}
-        for c in self._get_dict(CLASSES, imports):
+        for c in self.all_classes():
             ordered_list_of_names.append(c)
         ordered_list_of_names.sort()
         for name in ordered_list_of_names:
@@ -245,6 +245,19 @@ class SchemaView(object):
                         slots[aname] = a
         return slots
 
+    def all_slots_ordered(self) -> Dict[SlotDefinitionName, SlotDefinition]:
+        """
+        :param imports: include imports closure
+        :return: all class names in schema view ordered alphabetically, useful primarily for documentation view.
+        """
+        ordered_list_of_names = []
+        ordered_slots = {}
+        for s in self.all_slots():
+            ordered_list_of_names.append(s)
+        ordered_list_of_names.sort()
+        for name in ordered_list_of_names:
+            ordered_slots[self.get_slot(name).name] = self.get_slot(name)
+        return ordered_slots
 
     @deprecated("Use `all_enums` instead")
     @lru_cache()

--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -208,6 +208,11 @@ class SchemaView(object):
         :return: all classes in schema view
         """
 
+        if ordered_by not in ORDERED_BY:
+            print(ordered_by)
+            print(ORDERED_BY)
+            raise ValueError
+
         classes = copy(self._get_dict(CLASSES, imports))
         if ordered_by == 'lexical':
             ordered_list_of_names = []

--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -263,12 +263,11 @@ class SchemaView(object):
 
         if ordered_by == 'lexical':
             ordered_classes = self._order_lexically(element=CLASSES, imports=imports)
-
         elif ordered_by == 'rank':
             ordered_classes = self._order_rank(element=CLASSES, imports=imports)
-
         else:  # else preserve the order in the yaml
             ordered_classes = copy(self._get_dict(CLASSES, imports))
+
         return ordered_classes
 
     @deprecated("Use `all_slots` instead")
@@ -300,12 +299,13 @@ class SchemaView(object):
                         slots[aname] = a
 
         if ordered_by == "lexical":
-            return self._order_lexically(element=SLOTS, imports=imports, attributes=attributes)
+            ordered_slots = self._order_lexically(element=SLOTS, imports=imports, attributes=attributes)
         elif ordered_by == 'rank':
-            return self._order_rank(element=SLOTS, imports=imports, attributes=attributes)
+            ordered_slots = self._order_rank(element=SLOTS, imports=imports, attributes=attributes)
         else:
+            ordered_slots = slots
             # preserve order in YAML
-            return slots
+        return ordered_slots
 
     @deprecated("Use `all_enums` instead")
     @lru_cache()

--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -223,12 +223,17 @@ class SchemaView(object):
         return ordered_elements
 
     @lru_cache()
-    def _order_rank(self, element: str, imports=True):
+    def _order_rank(self, element: str, imports=True, attributes=True):
         """
         :param elements: slots or classes to order
         :return: all classes or slots sorted by their rank in schema view
         """
         elements = copy(self._get_dict(element, imports))
+        if element == SLOTS and attributes:
+            for c in self.all_classes().values():
+                for aname, a in c.attributes.items():
+                    if aname not in elements:
+                        elements[aname] = a
         rank_map = {}
         unranked_map = {}
         rank_ordered_elements = {}
@@ -295,9 +300,9 @@ class SchemaView(object):
                         slots[aname] = a
 
         if ordered_by == "lexical":
-            return self._order_lexically(element=SLOTS, imports=imports, attribtues=attributes)
+            return self._order_lexically(element=SLOTS, imports=imports, attributes=attributes)
         elif ordered_by == 'rank':
-            return self._order_rank(element=SLOTS, imports=imports, attribtues=attributes)
+            return self._order_rank(element=SLOTS, imports=imports, attributes=attributes)
         else:
             # preserve order in YAML
             return slots

--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -28,6 +28,8 @@ SUBSET_NAME = Union[SubsetDefinitionName, str]
 TYPE_NAME = Union[TypeDefinitionName, str]
 ENUM_NAME = Union[EnumDefinitionName, str]
 
+ORDERED_BY = ["rank", "preserve", "lexical"]
+
 
 def _closure(f, x, reflexive=True, depth_first=True, **kwargs):
     if reflexive:
@@ -205,12 +207,12 @@ class SchemaView(object):
         :param imports: include imports closure
         :return: all classes in schema view
         """
-        assert ordered_by in ('preserve', 'lexical', 'rank'), "Invalid ordered_by parameter '{}'".format(ordered_by)
 
+        classes = copy(self._get_dict(CLASSES, imports))
         if ordered_by == 'lexical':
             ordered_list_of_names = []
             ordered_classes = {}
-            for c in self.all_classes():
+            for c in classes:
                 ordered_list_of_names.append(c)
             ordered_list_of_names.sort()
             for name in ordered_list_of_names:
@@ -218,9 +220,9 @@ class SchemaView(object):
             return ordered_classes
         elif ordered_by == 'rank':
             # not yet implemented, preserve order
-            return self._get_dict(CLASSES, imports)
-        else:
-            return self._get_dict(CLASSES, imports)
+            return classes
+        else: # else preserve the order in the yaml
+            return classes
 
     @deprecated("Use `all_slots` instead")
     @lru_cache()

--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -298,13 +298,13 @@ class SchemaView(object):
                     if aname not in slots:
                         slots[aname] = a
 
-        if ordered_by == "lexical":
+        if ordered_by == 'lexical':
             ordered_slots = self._order_lexically(element=SLOTS, imports=imports, attributes=attributes)
         elif ordered_by == 'rank':
             ordered_slots = self._order_rank(element=SLOTS, imports=imports, attributes=attributes)
         else:
-            ordered_slots = slots
             # preserve order in YAML
+            ordered_slots = slots
         return ordered_slots
 
     @deprecated("Use `all_enums` instead")

--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -234,7 +234,7 @@ class SchemaView(object):
                 ordered_classes[self.get_class(v).name] = self.get_class(v)
             ordered_classes.update(unranked_map)
             return ordered_classes
-        else: # else preserve the order in the yaml
+        else:  # else preserve the order in the yaml
             return classes
 
     @deprecated("Use `all_slots` instead")
@@ -274,8 +274,19 @@ class SchemaView(object):
                 ordered_slots[self.get_slot(name).name] = self.get_slot(name)
             return ordered_slots
         elif ordered_by == "rank":
-            # not yet implemented, preserve order
-            return slots
+            rank_map = {}
+            unranked_map = {}
+            rank_ordered_slots = {}
+            for name, definition in slots.items():
+                if definition.rank is None:
+                    unranked_map[self.get_slot(name).name] = self.get_slot(name)
+                else:
+                    rank_map[definition.rank] = name
+            rank_ordered_map = collections.OrderedDict(sorted(rank_map.items()))
+            for k, v in rank_ordered_map.items():
+                rank_ordered_slots[self.get_slot(v).name] = self.get_slot(v)
+            rank_ordered_slots.update(unranked_map)
+            return rank_ordered_slots
         else:
             # preserve order in YAML
             return slots

--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -201,13 +201,18 @@ class SchemaView(object):
         return self._get_dict(CLASSES, imports)
 
     @lru_cache()
-    def _order_lexically(self, element: str, imports=True):
+    def _order_lexically(self, element: str, imports=True, attributes=True):
         """
         :param element: slots or class type to order
         :param imports
         :return: all classes or slots sorted lexically in schema view
         """
         elements = copy(self._get_dict(element, imports))
+        if element == SLOTS and attributes:
+            for c in self.all_classes().values():
+                for aname, a in c.attributes.items():
+                    if aname not in elements:
+                        elements[aname] = a
         ordered_list_of_names = []
         ordered_elements = {}
         for c in elements:
@@ -248,7 +253,6 @@ class SchemaView(object):
         :return: all classes in schema view
         """
 
-        classes = copy(self._get_dict(CLASSES, imports))
         if ordered_by not in ORDERED_BY:
             raise ValueError("missing ordered_by value in ORDERED_BY enumeration" + str(ordered_by))
 
@@ -291,9 +295,9 @@ class SchemaView(object):
                         slots[aname] = a
 
         if ordered_by == "lexical":
-            return self._order_lexically(element=SLOTS, imports=imports)
+            return self._order_lexically(element=SLOTS, imports=imports, attribtues=attributes)
         elif ordered_by == 'rank':
-            return self._order_rank(element=SLOTS, imports=imports)
+            return self._order_rank(element=SLOTS, imports=imports, attribtues=attributes)
         else:
             # preserve order in YAML
             return slots

--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -224,8 +224,8 @@ class SchemaView(object):
         ordered_list_of_names = []
         ordered_classes = {}
         for c in self._get_dict(CLASSES, imports):
-            ordered_list_of_names.append(c.name)
-        ordered_list_of_names.sort(reverse=True)
+            ordered_list_of_names.append(c)
+        ordered_list_of_names.sort()
         for name in ordered_list_of_names:
             ordered_classes[self.get_class(name).name] = self.get_class(name)
         return ordered_classes

--- a/tests/test_utils/input/kitchen_sink_noimports.yaml
+++ b/tests/test_utils/input/kitchen_sink_noimports.yaml
@@ -299,6 +299,7 @@ slots:
   started at time:
     slot_uri: prov:startedAtTime
     range: date
+    rank: 1
 
   ended at time:
     slot_uri: prov:endedAtTime

--- a/tests/test_utils/input/kitchen_sink_noimports.yaml
+++ b/tests/test_utils/input/kitchen_sink_noimports.yaml
@@ -287,11 +287,14 @@ slots:
 
   id:
     identifier: true
+    rank: 1
 
   name:
     required: false
+    rank: 2
 
   description:
+    rank: 3
 
   started at time:
     slot_uri: prov:startedAtTime

--- a/tests/test_utils/input/kitchen_sink_noimports.yaml
+++ b/tests/test_utils/input/kitchen_sink_noimports.yaml
@@ -170,6 +170,7 @@ classes:
     attributes:
       ceo:
         range: Person
+    rank: 3
 
   Dataset:
     attributes:
@@ -203,6 +204,7 @@ classes:
       - prov:Activity
     narrow_mappings:
       - GO:0005198
+    rank: 2
 
   agent:
     description: "a provence-generating agent"
@@ -211,6 +213,7 @@ classes:
         - acted on behalf of
         - was informed by
     class_uri: prov:Agent
+    rank: 1
 
 slots:
   employed at:

--- a/tests/test_utils/test_schemaview.py
+++ b/tests/test_utils/test_schemaview.py
@@ -211,15 +211,6 @@ class SchemaViewTestCase(unittest.TestCase):
             assert ValueError
         assert ValueError
 
-    def test_all_slots_ordered(self):
-        view = SchemaView(SCHEMA_NO_IMPORTS)
-        classes = view.all_slots_ordered()
-        ordered_s = []
-        for s in classes.values():
-            ordered_s.append(s.name)
-        print(ordered_s)
-        assert ordered_s == sorted(ordered_s)
-
     def test_rollup_rolldown(self):
         # no import schema
         view = SchemaView(SCHEMA_NO_IMPORTS)

--- a/tests/test_utils/test_schemaview.py
+++ b/tests/test_utils/test_schemaview.py
@@ -182,6 +182,15 @@ class SchemaViewTestCase(unittest.TestCase):
             s = view.induced_slot(sn, 'Dataset')
             logging.debug(s)
 
+    def test_classes(self):
+        view = SchemaView(SCHEMA_NO_IMPORTS)
+        classes = view.all_classes()
+        vdict = []
+        for c in classes.values():
+            vdict.append(c)
+        vdict.sort()
+        print(vdict)
+
     def test_rollup_rolldown(self):
         # no import schema
         view = SchemaView(SCHEMA_NO_IMPORTS)

--- a/tests/test_utils/test_schemaview.py
+++ b/tests/test_utils/test_schemaview.py
@@ -184,12 +184,11 @@ class SchemaViewTestCase(unittest.TestCase):
 
     def test_classes(self):
         view = SchemaView(SCHEMA_NO_IMPORTS)
-        classes = view.all_classes()
-        vdict = []
+        classes = view.all_classes_ordered()
+        ordered_c = []
         for c in classes.values():
-            vdict.append(c)
-        vdict.sort()
-        print(vdict)
+            ordered_c.append(c.name)
+        assert ordered_c == sorted(ordered_c)
 
     def test_rollup_rolldown(self):
         # no import schema

--- a/tests/test_utils/test_schemaview.py
+++ b/tests/test_utils/test_schemaview.py
@@ -185,6 +185,7 @@ class SchemaViewTestCase(unittest.TestCase):
     def test_all_classes_ordered_lexical(self):
         view = SchemaView(SCHEMA_NO_IMPORTS)
         classes = view.all_classes(ordered_by="lexical")
+
         ordered_c = []
         for c in classes.values():
             ordered_c.append(c.name)
@@ -231,6 +232,7 @@ class SchemaViewTestCase(unittest.TestCase):
         ordered_s = []
         for s in slots.values():
             ordered_s.append(s.name)
+        print(ordered_s)
         assert ordered_s == sorted(ordered_s)
 
     def test_all_slots_ordered_rank(self):

--- a/tests/test_utils/test_schemaview.py
+++ b/tests/test_utils/test_schemaview.py
@@ -188,11 +188,9 @@ class SchemaViewTestCase(unittest.TestCase):
         ordered_c = []
         for c in classes.values():
             ordered_c.append(c.name)
-        print(ordered_c)
         assert ordered_c == sorted(ordered_c)
 
-
-    def test_all_classes_ordered_lexical(self):
+    def test_all_classes_ordered_rank(self):
         view = SchemaView(SCHEMA_NO_IMPORTS)
         classes = view.all_classes(ordered_by="rank")
         ordered_c = []
@@ -202,14 +200,12 @@ class SchemaViewTestCase(unittest.TestCase):
         assert ordered_c[1] == "activity"
         assert ordered_c[2] == "Company"
 
-
     def test_all_classes_ordered_no_ordered_by(self):
         view = SchemaView(SCHEMA_NO_IMPORTS)
         classes = view.all_classes()
         ordered_c = []
         for c in classes.values():
             ordered_c.append(c.name)
-        print(ordered_c)
         assert "HasAliases" == ordered_c[0]
         assert "agent" == ordered_c[-1]
 
@@ -222,6 +218,25 @@ class SchemaViewTestCase(unittest.TestCase):
         except ValueError:
             assert ValueError
         assert ValueError
+
+    def test_all_slots_ordered_lexical(self):
+        view = SchemaView(SCHEMA_NO_IMPORTS)
+        slots = view.all_slots(ordered_by="lexical")
+        ordered_s = []
+        for s in slots.values():
+            ordered_s.append(s.name)
+        assert ordered_s == sorted(ordered_s)
+
+    def test_all_slots_ordered_rank(self):
+        view = SchemaView(SCHEMA_NO_IMPORTS)
+        slots = view.all_slots(ordered_by="rank")
+        ordered_s = []
+        for s in slots.values():
+            ordered_s.append(s.name)
+        print(ordered_s)
+        assert ordered_s[0] == 'id'
+        assert ordered_s[1] == 'name'
+        assert ordered_s[2] == 'description'
 
     def test_rollup_rolldown(self):
         # no import schema

--- a/tests/test_utils/test_schemaview.py
+++ b/tests/test_utils/test_schemaview.py
@@ -191,6 +191,13 @@ class SchemaViewTestCase(unittest.TestCase):
         print(ordered_c)
         assert ordered_c == sorted(ordered_c)
 
+
+    def test_all_classes_ordered_lexical(self):
+        view = SchemaView(SCHEMA_NO_IMPORTS)
+        classes = view.all_classes(ordered_by="rank")
+
+
+
     def test_all_classes_ordered_no_ordered_by(self):
         view = SchemaView(SCHEMA_NO_IMPORTS)
         classes = view.all_classes()

--- a/tests/test_utils/test_schemaview.py
+++ b/tests/test_utils/test_schemaview.py
@@ -195,7 +195,12 @@ class SchemaViewTestCase(unittest.TestCase):
     def test_all_classes_ordered_lexical(self):
         view = SchemaView(SCHEMA_NO_IMPORTS)
         classes = view.all_classes(ordered_by="rank")
-
+        ordered_c = []
+        for c in classes.values():
+            ordered_c.append(c.name)
+        assert ordered_c[0] == "agent"
+        assert ordered_c[1] == "activity"
+        assert ordered_c[2] == "Company"
 
 
     def test_all_classes_ordered_no_ordered_by(self):

--- a/tests/test_utils/test_schemaview.py
+++ b/tests/test_utils/test_schemaview.py
@@ -196,9 +196,15 @@ class SchemaViewTestCase(unittest.TestCase):
         ordered_c = []
         for c in classes.values():
             ordered_c.append(c.name)
-        assert ordered_c[0] == "agent"
-        assert ordered_c[1] == "activity"
-        assert ordered_c[2] == "Company"
+        first_in_line = []
+        second_in_line = []
+        for name, definition in classes.items():
+            if definition.rank == 1:
+                first_in_line.append(name)
+            elif definition.rank == 2:
+                second_in_line.append(name)
+        assert ordered_c[0] in first_in_line
+        assert ordered_c[10] not in second_in_line
 
     def test_all_classes_ordered_no_ordered_by(self):
         view = SchemaView(SCHEMA_NO_IMPORTS)
@@ -234,9 +240,16 @@ class SchemaViewTestCase(unittest.TestCase):
         for s in slots.values():
             ordered_s.append(s.name)
         print(ordered_s)
-        assert ordered_s[0] == 'id'
-        assert ordered_s[1] == 'name'
-        assert ordered_s[2] == 'description'
+        first_in_line = []
+        second_in_line = []
+        for name, definition in slots.items():
+            if definition.rank == 1:
+                first_in_line.append(name)
+            elif definition.rank == 2:
+                second_in_line.append(name)
+        assert ordered_s[0] in first_in_line
+        assert ordered_s[10] not in second_in_line
+
 
     def test_rollup_rolldown(self):
         # no import schema

--- a/tests/test_utils/test_schemaview.py
+++ b/tests/test_utils/test_schemaview.py
@@ -7,7 +7,7 @@ from typing import List
 from linkml_runtime.linkml_model.meta import SchemaDefinition, ClassDefinition, SlotDefinitionName, SlotDefinition
 from linkml_runtime.loaders.yaml_loader import YAMLLoader
 from linkml_runtime.utils.introspection import package_schemaview, object_class_definition
-from linkml_runtime.utils.schemaview import SchemaView, SchemaUsage
+from linkml_runtime.utils.schemaview import SchemaView, SchemaUsage, OrderedBy
 from linkml_runtime.utils.schemaops import roll_up, roll_down
 from tests.test_utils import INPUT_DIR
 
@@ -184,7 +184,7 @@ class SchemaViewTestCase(unittest.TestCase):
 
     def test_all_classes_ordered_lexical(self):
         view = SchemaView(SCHEMA_NO_IMPORTS)
-        classes = view.all_classes(ordered_by="lexical")
+        classes = view.all_classes(ordered_by=OrderedBy.LEXICAL)
 
         ordered_c = []
         for c in classes.values():
@@ -193,7 +193,7 @@ class SchemaViewTestCase(unittest.TestCase):
 
     def test_all_classes_ordered_rank(self):
         view = SchemaView(SCHEMA_NO_IMPORTS)
-        classes = view.all_classes(ordered_by="rank")
+        classes = view.all_classes(ordered_by=OrderedBy.RANK)
         ordered_c = []
         for c in classes.values():
             ordered_c.append(c.name)

--- a/tests/test_utils/test_schemaview.py
+++ b/tests/test_utils/test_schemaview.py
@@ -218,7 +218,7 @@ class SchemaViewTestCase(unittest.TestCase):
 
     def test_all_slots_ordered_lexical(self):
         view = SchemaView(SCHEMA_NO_IMPORTS)
-        slots = view.all_slots(ordered_by="lexical")
+        slots = view.all_slots(ordered_by=OrderedBy.LEXICAL)
         ordered_s = []
         for s in slots.values():
             ordered_s.append(s.name)
@@ -227,7 +227,7 @@ class SchemaViewTestCase(unittest.TestCase):
 
     def test_all_slots_ordered_rank(self):
         view = SchemaView(SCHEMA_NO_IMPORTS)
-        slots = view.all_slots(ordered_by="rank")
+        slots = view.all_slots(ordered_by=OrderedBy.RANK)
         ordered_s = []
         for s in slots.values():
             ordered_s.append(s.name)

--- a/tests/test_utils/test_schemaview.py
+++ b/tests/test_utils/test_schemaview.py
@@ -191,9 +191,9 @@ class SchemaViewTestCase(unittest.TestCase):
         print(ordered_c)
         assert ordered_c == sorted(ordered_c)
 
-    def test_all_classes_ordered_lexical(self):
+    def test_all_classes_ordered_no_ordered_by(self):
         view = SchemaView(SCHEMA_NO_IMPORTS)
-        classes = view.all_classes(ordered_by="preserve")
+        classes = view.all_classes()
         ordered_c = []
         for c in classes.values():
             ordered_c.append(c.name)
@@ -201,6 +201,15 @@ class SchemaViewTestCase(unittest.TestCase):
         assert "HasAliases" == ordered_c[0]
         assert "agent" == ordered_c[-1]
 
+    def test_all_classes_ordered_by_fail(self):
+        view = SchemaView(SCHEMA_NO_IMPORTS)
+        try:
+            {
+                view.all_classes(ordered_by="wonky_non_enumerated_value")
+            }
+        except ValueError:
+            assert ValueError
+        assert ValueError
 
     def test_all_slots_ordered(self):
         view = SchemaView(SCHEMA_NO_IMPORTS)

--- a/tests/test_utils/test_schemaview.py
+++ b/tests/test_utils/test_schemaview.py
@@ -182,7 +182,7 @@ class SchemaViewTestCase(unittest.TestCase):
             s = view.induced_slot(sn, 'Dataset')
             logging.debug(s)
 
-    def test_classes(self):
+    def test_all_classes_ordered(self):
         view = SchemaView(SCHEMA_NO_IMPORTS)
         classes = view.all_classes_ordered()
         ordered_c = []
@@ -190,6 +190,15 @@ class SchemaViewTestCase(unittest.TestCase):
             ordered_c.append(c.name)
         print(ordered_c)
         assert ordered_c == sorted(ordered_c)
+
+    def test_all_slots_ordered(self):
+        view = SchemaView(SCHEMA_NO_IMPORTS)
+        classes = view.all_slots_ordered()
+        ordered_s = []
+        for s in classes.values():
+            ordered_s.append(s.name)
+        print(ordered_s)
+        assert ordered_s == sorted(ordered_s)
 
     def test_rollup_rolldown(self):
         # no import schema

--- a/tests/test_utils/test_schemaview.py
+++ b/tests/test_utils/test_schemaview.py
@@ -182,14 +182,25 @@ class SchemaViewTestCase(unittest.TestCase):
             s = view.induced_slot(sn, 'Dataset')
             logging.debug(s)
 
-    def test_all_classes_ordered(self):
+    def test_all_classes_ordered_lexical(self):
         view = SchemaView(SCHEMA_NO_IMPORTS)
-        classes = view.all_classes_ordered()
+        classes = view.all_classes(ordered_by="lexical")
         ordered_c = []
         for c in classes.values():
             ordered_c.append(c.name)
         print(ordered_c)
         assert ordered_c == sorted(ordered_c)
+
+    def test_all_classes_ordered_lexical(self):
+        view = SchemaView(SCHEMA_NO_IMPORTS)
+        classes = view.all_classes(ordered_by="preserve")
+        ordered_c = []
+        for c in classes.values():
+            ordered_c.append(c.name)
+        print(ordered_c)
+        assert "HasAliases" == ordered_c[0]
+        assert "agent" == ordered_c[-1]
+
 
     def test_all_slots_ordered(self):
         view = SchemaView(SCHEMA_NO_IMPORTS)

--- a/tests/test_utils/test_schemaview.py
+++ b/tests/test_utils/test_schemaview.py
@@ -216,16 +216,6 @@ class SchemaViewTestCase(unittest.TestCase):
         assert "HasAliases" == ordered_c[0]
         assert "agent" == ordered_c[-1]
 
-    def test_all_classes_ordered_by_fail(self):
-        view = SchemaView(SCHEMA_NO_IMPORTS)
-        try:
-            {
-                view.all_classes(ordered_by="wonky_non_enumerated_value")
-            }
-        except ValueError:
-            assert ValueError
-        assert ValueError
-
     def test_all_slots_ordered_lexical(self):
         view = SchemaView(SCHEMA_NO_IMPORTS)
         slots = view.all_slots(ordered_by="lexical")

--- a/tests/test_utils/test_schemaview.py
+++ b/tests/test_utils/test_schemaview.py
@@ -188,6 +188,7 @@ class SchemaViewTestCase(unittest.TestCase):
         ordered_c = []
         for c in classes.values():
             ordered_c.append(c.name)
+        print(ordered_c)
         assert ordered_c == sorted(ordered_c)
 
     def test_rollup_rolldown(self):


### PR DESCRIPTION
Biolink-Model has a long list of classes.  I these ording methods in my jinga templates to return classes in alphabetical order (or rank order) for rendering.

