### PR TITLE
turn off info logging for illegal prefix while we clean up these

### DIFF
--- a/linkml_runtime/utils/namespaces.py
+++ b/linkml_runtime/utils/namespaces.py
@@ -244,7 +244,7 @@ class Namespaces(CaseInsensitiveDict):
                 if is_ncname(k):
                     self[k] = v
                 else:
-                    logging.getLogger('Namespaces').info(f"biocontext map {map_name} has illegal prefix: {k}")
+                    # logging.getLogger('Namespaces').info(f"biocontext map {map_name} has illegal prefix: {k}")
                     pass
 
 


### PR DESCRIPTION
these three prefixes from identifiers.org generate a lot of output in modularized schemas (tend to obfuscate other warnings/errors).  would it be ok to turn this off for a while until we can fix these three prefixes? 
INFO:Namespaces:biocontext map idot_context has illegal prefix: 2D-PAGE.PROTEIN
INFO:Namespaces:biocontext map idot_context has illegal prefix: 3DMET
INFO:Namespaces:biocontext map idot_context has illegal prefix: MMMP:BIOMAPS