### PR TITLE
uncamelcase method 

### DIFF
--- a/linkml_runtime/utils/formatutils.py
+++ b/linkml_runtime/utils/formatutils.py
@@ -9,6 +9,16 @@ ws_pattern = re.compile(r'\s+')
 us_pattern = re.compile(r'_+')
 
 
+def uncamelcase(txt: str) -> str:
+    split_txt = re.split('(?=[A-Z])', txt)
+    new_text = ""
+    for word in split_txt:
+        if new_text == "":
+            new_text = word.lower()
+        else:
+            new_text = new_text + " " + word.lower()
+    return new_text
+
 
 def camelcase(txt: str) -> str:
     def _up(s: str):

--- a/tests/test_utils/test_formatutils.py
+++ b/tests/test_utils/test_formatutils.py
@@ -5,7 +5,7 @@ from typing import List, Tuple, Any
 from jsonasobj2 import JsonObj, as_json
 
 from linkml_runtime.utils.formatutils import camelcase, underscore, lcamelcase, be, split_line, wrapped_annotation, \
-    is_empty, remove_empty_items
+    is_empty, remove_empty_items, uncamelcase
 
 empty_things = [None, dict(), list(), JsonObj(), JsonObj({}), JsonObj([])]
 non_empty_things = [0, False, "", {'k': None}, {0:0}, [None], JsonObj(k=None), JsonObj(**{'k': None}), JsonObj([None])]
@@ -94,6 +94,10 @@ class FormatUtilsTestCase(unittest.TestCase):
     def test_formats(self):
         self.assertEqual("ThisIsIt", camelcase("this is it"))
         self.assertEqual("ThisIsIT", camelcase("  this   is iT   "))
+        self.assertEqual("un camelcased", uncamelcase("UnCamelcased"))
+        self.assertEqual("oneword", uncamelcase("Oneword"))
+        self.assertEqual("one_word", uncamelcase("one_word"))
+        self.assertEqual("another word", uncamelcase("anotherWord"))
         self.assertEqual("IBeY", camelcase("i be y "))
         self.assertEqual("ThisIsIt", camelcase("This__is_it"))
 


### PR DESCRIPTION
working on replacing functionality from biolink-model-toolkit.  Translator biolink model components come back from queries of their architecture in camelcase already (SmallMolecule or biolink:SmallMolecule vs. small molecule).  This is just a helper method to convert back to model-case to use SchemaView to retrieve classes instead of biolink-model-toolkit.  Is it overkill to think about making sv.get_class() etc. recognize any form of class name (I can work with this method alone for my needs, I could also put this method in my own code)?  