### PR TITLE
bug: add missing logging import to csvutils.py

### DIFF
--- a/linkml_runtime/utils/csvutils.py
+++ b/linkml_runtime/utils/csvutils.py
@@ -15,8 +15,11 @@ def get_configmap(schemaview: SchemaView, index_slot: SlotDefinitionName) -> CON
     :param index_slot: key that indexes the top level object
     :return: mapping between top level keys and denormalization configurations
     """
+    slot = None
     if index_slot is not None and schemaview is not None:
         slot = schemaview.get_slot(index_slot)
+
+    if slot is not None:
         if slot.range is not None and slot.range in schemaview.all_classes():
             cm = {}
             for sn in schemaview.class_slots(slot.range):
@@ -25,9 +28,9 @@ def get_configmap(schemaview: SchemaView, index_slot: SlotDefinitionName) -> CON
                     cm[sn] = config
             return cm
         else:
-            logging.warn(f'Index slot range not to class: {slot.range}')
+            logging.warning(f'Index slot range not to class: {slot.range}')
     else:
-        logging.warn(f'Index slot or schema not specified')
+        logging.warning(f'Index slot or schema not specified')
     return {}
 
 def _get_key_config(schemaview: SchemaView, tgt_cls: ClassDefinitionName, sn: SlotDefinitionName, sep='_'):

--- a/linkml_runtime/utils/csvutils.py
+++ b/linkml_runtime/utils/csvutils.py
@@ -1,3 +1,4 @@
+import logging
 from json_flattener import KeyConfig, GlobalConfig, Serializer
 from json_flattener.flattener import CONFIGMAP
 from linkml_runtime.linkml_model.meta import SlotDefinitionName, SchemaDefinition, \


### PR DESCRIPTION
```
$ linkml-convert -t ttl -s gbm.yaml -C Subject -S id out.tsv
...
  File "/usr/local/anaconda3/envs/linkml/lib/python3.10/site-packages/linkml_runtime/utils/csvutils.py", line 27, in get_configmap
    logging.warn(f'Index slot range not to class: {slot.range}')
NameError: name 'logging' is not defined
```