### PR TITLE
Materialize structured patterns on class slot usages and attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,4 @@ Pipfile.lock
 
 # No Pycharm
 .idea/
+.vscode

--- a/linkml_runtime/utils/pattern.py
+++ b/linkml_runtime/utils/pattern.py
@@ -2,6 +2,30 @@ from functools import lru_cache
 import re
 from typing import Dict
 
+# We might want to deprecate this method in favor of PatternResolver in the future
+def generate_patterns(schema_view) -> Dict[str, str]:
+    """Generates a dictionary of slot patterns corresponding to
+    the structured patterns in the settings.
+    :param schema_view: SchemaView object with LinkML YAML
+        already loaded
+    :return generated_patterns: dictionary with the 
+        expanded structured patterns 
+    """
+
+    resolver = PatternResolver(schema_view)
+
+    # dictionary with structured patterns in the key and
+    # expanded, or materialized patterns as values
+    generated_patterns = {}
+
+    for _, slot_defn in schema_view.all_slots().items():
+        if slot_defn.structured_pattern:
+            struct_pat = slot_defn.structured_pattern
+            pattern = struct_pat.syntax
+            generated_patterns[pattern] = resolver.resolve(pattern)
+
+    return generated_patterns
+
 
 class PatternResolver():
 

--- a/linkml_runtime/utils/pattern.py
+++ b/linkml_runtime/utils/pattern.py
@@ -22,7 +22,7 @@ class PatternResolver():
             # substrings in the structured pattern syntax
             self.format_spec[k] = setting.setting_value
 
-    @lru_cache
+    @lru_cache()
     def resolve(self, pattern: str) -> str:
         # apply the regex to the pattern and look for matches
         matches = self.var_name.finditer(pattern)

--- a/linkml_runtime/utils/pattern.py
+++ b/linkml_runtime/utils/pattern.py
@@ -1,83 +1,64 @@
+from functools import lru_cache
 import re
 from typing import Dict
 
 
-def generate_patterns(schema_view) -> Dict[str, str]:
-    """Generates a dictionary of slot patterns corresponding to
-    the structured patterns in the settings.
-
-    :param schema_view: SchemaView object with LinkML YAML
-        already loaded
-    :return generated_patterns: dictionary with the 
-        expanded structured patterns 
-    """
-
-    # fetch settings from schema_view
-    settings_dict = schema_view.schema.settings
-
-    # dictionary of key and string value of settings dict
-    format_spec = {}
-
-    for k, setting in settings_dict.items():
-
-        # create spec dictionary with keys that will replace
-        # substrings in the structured pattern syntax
-        format_spec[k] = setting.setting_value
-
-    # dictionary with structured patterns in the key and
-    # expanded, or materialized patterns as values
-    generated_patterns = {}
+class PatternResolver():
 
     # regular expression capturing the various use cases
     # for the optionally dot separated, curly braces bound, pattern syntax
     var_name = re.compile("{([a-z0-9_-]+([\.-_ ][a-z0-9]+)*)}", re.IGNORECASE)
 
-    for _, slot_defn in schema_view.all_slots().items():
-        if slot_defn.structured_pattern:
-            struct_pat = slot_defn.structured_pattern
+    def __init__(self, schema_view):
+        # fetch settings from schema_view
+        settings_dict = schema_view.schema.settings
 
-            pattern = struct_pat.syntax
+        # dictionary of key and string value of settings dict
+        self.format_spec = {}
 
-            # compute pattern from structured patterns
-            # and format_spec dictionary
+        for k, setting in settings_dict.items():
 
+            # create spec dictionary with keys that will replace
+            # substrings in the structured pattern syntax
+            self.format_spec[k] = setting.setting_value
 
-            # apply the regex to the pattern and look for matches
-            matches = var_name.finditer(pattern)
+    @lru_cache
+    def resolve(self, pattern: str) -> str:
+        # apply the regex to the pattern and look for matches
+        matches = self.var_name.finditer(pattern)
 
-            reversed = []
-            for item in matches:
-                # Detect double set brackets
-                match_string = None
-                if (
-                    item.start() > 0
-                    and item.end() < len(pattern)
-                    and pattern[item.start() - 1] == "{"
-                    and pattern[item.end()] == "}"
-                ):
-                    match_string = item.group(1)
+        reversed = []
+        for item in matches:
+            # Detect double set brackets
+            match_string = None
+            if (
+                item.start() > 0
+                and item.end() < len(pattern)
+                and pattern[item.start() - 1] == "{"
+                and pattern[item.end()] == "}"
+            ):
+                match_string = item.group(1)
 
-                elif item.group(1) in format_spec:
-                    match_string = str(format_spec[item.group(1)])
+            elif item.group(1) in self.format_spec:
+                match_string = str(self.format_spec[item.group(1)])
 
-                if match_string:
-                    reversed.insert(
-                        0,
-                        {
-                            "string": match_string,
-                            "start": item.start(),
-                            "end": item.end(),
-                        },
-                    )
-
-            converted = pattern
-            for item in reversed:
-                converted = (
-                    converted[: item["start"]]
-                    + item["string"]
-                    + converted[item["end"] :]
+            if match_string:
+                reversed.insert(
+                    0,
+                    {
+                        "string": match_string,
+                        "start": item.start(),
+                        "end": item.end(),
+                    },
                 )
 
-            generated_patterns[pattern] = converted
+        converted = pattern
+        for item in reversed:
+            converted = (
+                converted[: item["start"]]
+                + item["string"]
+                + converted[item["end"] :]
+            )
 
-    return generated_patterns
+        return converted
+

--- a/tests/test_utils/input/pattern-example.yaml
+++ b/tests/test_utils/input/pattern-example.yaml
@@ -32,6 +32,7 @@ settings:
   unit.length: "(centimeter|meter|inch)"
   unit.weight: "(kg|g|lbs|stone)"
   email: "\\S+@\\S+{\\.\\w}+"
+  hyphenated_name: "\\S+-\\S+"
   
 #==================================
 # Classes                         #
@@ -44,6 +45,23 @@ classes:
       - name
       - height
       - email
+
+  FancyPersonInfo:
+    is_a: PersonInfo
+    slot_usage:
+      name:
+        structured_pattern:
+          syntax: "\\S+ {hyphenated_name}"
+          interpolated: true
+          partial_match: false
+
+  ClassWithAttributes:
+    attributes:
+      weight:
+        structured_pattern:
+          syntax: "{float} {unit.weight}"
+          interpolated: true
+          partial_match: false
 
 #==================================
 # Slots                           #

--- a/tests/test_utils/test_pattern.py
+++ b/tests/test_utils/test_pattern.py
@@ -4,13 +4,26 @@ from tests.test_utils.environment import env
 
 from linkml_runtime.utils.schemaview import SchemaView
 
-from linkml_runtime.utils.pattern import PatternResolver
+from linkml_runtime.utils.pattern import PatternResolver, generate_patterns
 
 
 class PatternTestCase(unittest.TestCase):
     def test_generate_patterns(self):
         """Test method that consolidates composite patterns."""
+        sv = SchemaView(env.input_path("pattern-example.yaml"))
 
+        # actual result returned from call to generate_patterns()
+        actual_dict = generate_patterns(sv)
+
+        expected_dict = {
+            "{float} {unit.length}": "\\d+[\\.\\d+] (centimeter|meter|inch)",
+            "{float} {unit.weight}": "\\d+[\\.\\d+] (kg|g|lbs|stone)",
+        }
+
+        self.assertDictEqual(actual_dict, expected_dict)
+
+
+    def test_pattern_resolver(self):
         sv = SchemaView(env.input_path("pattern-example.yaml"))
 
         resolver = PatternResolver(sv)

--- a/tests/test_utils/test_pattern.py
+++ b/tests/test_utils/test_pattern.py
@@ -4,7 +4,7 @@ from tests.test_utils.environment import env
 
 from linkml_runtime.utils.schemaview import SchemaView
 
-from linkml_runtime.utils.pattern import generate_patterns
+from linkml_runtime.utils.pattern import PatternResolver
 
 
 class PatternTestCase(unittest.TestCase):
@@ -13,15 +13,10 @@ class PatternTestCase(unittest.TestCase):
 
         sv = SchemaView(env.input_path("pattern-example.yaml"))
 
-        # actual result returned from call to generate_patterns()
-        actual_dict = generate_patterns(sv)
+        resolver = PatternResolver(sv)
 
-        expected_dict = {
-            "{float} {unit.length}": "\\d+[\\.\\d+] (centimeter|meter|inch)",
-            "{float} {unit.weight}": "\\d+[\\.\\d+] (kg|g|lbs|stone)",
-        }
-
-        self.assertDictEqual(actual_dict, expected_dict)
+        self.assertEqual(resolver.resolve("{float} {unit.length}"), "\\d+[\\.\\d+] (centimeter|meter|inch)")
+        self.assertEqual(resolver.resolve("{float} {unit.weight}"), "\\d+[\\.\\d+] (kg|g|lbs|stone)")
 
 
 if __name__ == "__main__":

--- a/tests/test_utils/test_schemaview.py
+++ b/tests/test_utils/test_schemaview.py
@@ -15,6 +15,7 @@ from tests.test_utils import INPUT_DIR
 
 SCHEMA_NO_IMPORTS = os.path.join(INPUT_DIR, 'kitchen_sink_noimports.yaml')
 SCHEMA_WITH_IMPORTS = os.path.join(INPUT_DIR, 'kitchen_sink.yaml')
+SCHEMA_WITH_STRUCTURED_PATTERNS = os.path.join(INPUT_DIR, "pattern-example.yaml")
 
 yaml_loader = YAMLLoader()
 
@@ -526,7 +527,7 @@ class SchemaViewTestCase(unittest.TestCase):
                 self.assertIsNotNone(exp_slot_uri)
 
     def test_materialize_patterns(self):
-        sv = SchemaView(os.path.join(INPUT_DIR, "pattern-example.yaml"))
+        sv = SchemaView(SCHEMA_WITH_STRUCTURED_PATTERNS)
 
         sv.materialize_patterns()
 
@@ -535,6 +536,24 @@ class SchemaViewTestCase(unittest.TestCase):
 
         self.assertEqual(height_slot.pattern, "\d+[\.\d+] (centimeter|meter|inch)")
         self.assertEqual(weight_slot.pattern, "\d+[\.\d+] (kg|g|lbs|stone)")
+
+    def test_materialize_patterns_slot_usage(self):
+        sv = SchemaView(SCHEMA_WITH_STRUCTURED_PATTERNS)
+
+        sv.materialize_patterns()
+
+        name_slot_usage = sv.get_class("FancyPersonInfo").slot_usage['name']
+
+        self.assertEqual(name_slot_usage.pattern, "\\S+ \\S+-\\S+")
+
+    def test_materialize_patterns_attribute(self):
+        sv = SchemaView(SCHEMA_WITH_STRUCTURED_PATTERNS)
+
+        sv.materialize_patterns()
+
+        weight_attribute = sv.get_class('ClassWithAttributes').attributes['weight']
+
+        self.assertEqual(weight_attribute.pattern, "\d+[\.\d+] (kg|g|lbs|stone)")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
These changes extend the functionality of `SchemaView.materalize_patterns` to also include class slot usage and attributes. As a side effect it also slightly changes how `structured_pattern`s are resolved.

Previously there was a utility method called `generate_patterns` which iterated over all of a schema's slots to precompute all of the resolved patterns. Then `materialize_patterns` would iterate over the schema's slots again and populate the schema with the results from `generate_patterns`. 

With these changes, `materialize_patterns` iterates over slots and classes to account for `slot_usage` and `attributes`. In order to not duplicate logic, `generate_patterns` has been replaced by a class called `PatternResolver` which expands `structured_pattern`s on the fly, caching results as it goes. The central logic of how the expansion is done is unchanged.

Fixes #203 