### PR TITLE
Creating an ObjectIndex, fixes https://github.com/linkml/linkml/issues/1009

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -27,10 +27,10 @@ jobs:
       #       check-out repo and set-up python
       #----------------------------------------------
       - name: Check out repository
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@v2
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4.3
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -38,7 +38,7 @@ jobs:
       #          install & configure poetry
       #----------------------------------------------
       - name: Install Poetry
-        uses: snok/install-poetry@v1.3.3
+        uses: snok/install-poetry@v1.3
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -57,7 +57,7 @@ jobs:
       # install dependencies if cache does not exist 
       #----------------------------------------------
       - name: Install dependencies
-        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        # if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --no-root
 
       #----------------------------------------------

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -27,10 +27,10 @@ jobs:
       #       check-out repo and set-up python
       #----------------------------------------------
       - name: Check out repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.1.0
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4.3
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -46,12 +46,12 @@ jobs:
       #----------------------------------------------
       #       load cached venv if cache exists      
       #----------------------------------------------
-      - name: Load cached venv
-        id: cached-poetry-dependencies
-        uses: actions/cache@v2
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+      # - name: Load cached venv
+      #   id: cached-poetry-dependencies
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: .venv
+      #     key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
 
       #----------------------------------------------
       # install dependencies if cache does not exist 

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -38,7 +38,7 @@ jobs:
       #          install & configure poetry
       #----------------------------------------------
       - name: Install Poetry
-        uses: snok/install-poetry@v1.3
+        uses: snok/install-poetry@v1.3.3
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -46,18 +46,18 @@ jobs:
       #----------------------------------------------
       #       load cached venv if cache exists      
       #----------------------------------------------
-      # - name: Load cached venv
-      #   id: cached-poetry-dependencies
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: .venv
-      #     key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v2
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
 
       #----------------------------------------------
       # install dependencies if cache does not exist 
       #----------------------------------------------
       - name: Install dependencies
-        # if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
+        if: steps.cached-poetry-dependencies.outputs.cache-hit != 'true'
         run: poetry install --no-interaction --no-root
 
       #----------------------------------------------

--- a/linkml_runtime/utils/object_index.py
+++ b/linkml_runtime/utils/object_index.py
@@ -1,0 +1,186 @@
+import logging
+from typing import Mapping, Any, Optional, Tuple, List
+
+from linkml_runtime import SchemaView
+from linkml_runtime.utils.yamlutils import YAMLRoot
+
+
+class ObjectIndex:
+    """
+    Index of proxy objects.
+
+    Given a tree-root/container object, this will create an index,
+    and allow for retrieval of *proxy objects* that shadow domain
+    YAMLRoot classes. These operate in the same way, except that
+    object references are automatically dereferenced.
+
+    For example, given a container object following the standard
+    personinfo schema, an index can be created and queried:
+
+        >>> ix = ObjectIndex(container, schemaview=schemaview)
+        >>> container = ix.bless(container)
+        >>> for p in container.persons:
+        >>>    for r in p.has_familial_relationships():
+        >>>        print(f"{p.name} {p.type} {r.related_to.name}")
+
+    Note this will work even if related_to is *not* inlined.
+
+    This means naive traversal of the object tree is not guaranteed
+    to be bounded, unlike with a YAMLRoot object. E.g.
+
+        >>> person.has_familial_relationships[0].
+        >>>    related_to.has_familial_relationships[0].
+        >>>    related_to.has_familial_relationships[0].name
+
+    In the above, the same proxy object is reused for any
+    object with an identifier.
+    """
+    def __init__(self, obj: YAMLRoot, schemaview: SchemaView):
+        self._obj = obj
+        self._schemaview = schemaview
+        self._class_map = schemaview.class_name_mappings()
+        self._source_object_cache: Mapping[str, Any] = {}
+        self._proxy_object_cache: Mapping[str, "ProxyObject"] = {}
+        self._index(obj)
+
+    def _index(self, obj: Any):
+        if obj is None:
+            return None
+        if isinstance(obj, list):
+            return [self._index(v) for v in obj]
+        if isinstance(obj, dict):
+            return {k: self._index(v) for k, v in obj.items()}
+        cls_name = type(obj).__name__
+        if cls_name in self._class_map:
+            cls = self._class_map[cls_name]
+            id_slot = self._schemaview.get_identifier_slot(cls.name)
+            if id_slot:
+                id_val = getattr(obj, id_slot.name)
+                self._source_object_cache[(cls.name, id_val)] = obj
+            for v in vars(obj).values():
+                self._index(v)
+        else:
+            return obj
+
+    def bless(self, obj: Any) -> "ProxyObject":
+        """
+        Generate a proxy object for a given domain object.
+
+        The proxy object will mimic the domain object, which
+        should be of type YAMLRoot.
+
+           >>> person = ix.bless(person)
+           >>> print(person.name)
+
+        :param obj:
+        :return:
+        """
+        k = self._key(obj)
+        if k:
+            if k not in self._proxy_object_cache:
+                obj2 = ProxyObject(obj, _db=self)
+                self._proxy_object_cache[k] = obj2
+                return obj2
+            else:
+                return self._proxy_object_cache[k]
+        else:
+            return ProxyObject(obj, _db=self)
+
+    def _key(self, obj: Any) -> Optional[Tuple[str, YAMLRoot]]:
+        cls_name = type(obj).__name__
+        cls = self._class_map[cls_name]
+        id_slot = self._schemaview.get_identifier_slot(cls.name)
+        if id_slot:
+            id_val = getattr(obj, id_slot.name)
+            return cls.name, id_val
+
+    @property
+    def proxy_object_cache_size(self) -> int:
+        """
+        Number of elements in proxy object cache.
+
+        Any time an object is accessed via an
+        attribute, or created via bless, it is added
+        to this cache.
+
+        :return:
+        """
+        return len(self._proxy_object_cache.keys())
+
+    @property
+    def source_object_cache_size(self) -> int:
+        """
+        Number of elements in source object cache.
+
+        This should match the number of objects used
+        in the tree of the container used to initialize the index.
+        :return:
+        """
+        return len(self._source_object_cache.keys())
+
+    def clear_proxy_object_cache(self):
+        """
+        Clears all items in the proxy cache.
+        
+        :return:
+        """
+        self._proxy_object_cache = {}
+
+
+class ProxyObject:
+    """
+    An object that mirrors a domain object.
+
+    This will automatically expand foreign key references.
+    """
+
+    def __init__(self, obj: Any, _db: ObjectIndex, **kwargs):
+        self._db = _db
+        self._shadowed = obj
+
+    def __str__(self) -> str:
+        return f"ProxyFor: {str(self._shadowed)}"
+
+    def __getattr__(self, p: str) -> Any:
+        obj = self._shadowed
+        cls = self._db._class_map[type(obj).__name__]
+        slot = self._db._schemaview.induced_slot(p, cls.name)
+        v = getattr(obj, p)
+        return self._map(v, slot.range)
+
+    def __getattribute__(self, attribute):
+        if attribute == '__dict__':
+            return {k: getattr(self, k, None) for k in vars(self._shadowed).keys()}
+        else:
+            return object.__getattribute__(self, attribute)
+
+    def __setattr__(self, key, value):
+        if key.startswith("_"):
+            super().__setattr__(key, value)
+        else:
+            setattr(self._shadowed, key, value)
+
+    def _map(self, obj: Any, in_range: str) -> Any:
+        if isinstance(obj, list):
+            r = [self._map(v, in_range) for v in obj]
+            return r
+        if isinstance(obj, dict):
+            return {k: self._map(v, in_range) for k, v in obj.items()}
+        cls_name = type(obj).__name__
+        if cls_name in self._db._class_map:
+            return self._db.bless(obj)
+        if in_range in self._db._class_map:
+            # FK reference
+            k = (in_range, obj)
+            cache = self._db._source_object_cache
+            if k in cache:
+                source_obj = cache[k]
+                return self._db.bless(source_obj)
+            else:
+                logging.error(f"Making stub for {k}")
+                return obj
+        return obj
+
+    def _attributes(self) -> List[str]:
+        return vars(self._shadowed).keys()
+

--- a/tests/test_utils/input/container_test.yaml
+++ b/tests/test_utils/input/container_test.yaml
@@ -1,0 +1,279 @@
+id: https://w3id.org/linkml/examples/personinfo
+name: personinfo
+description: |-
+  Information about people, based on [schema.org](http://schema.org)
+license: https://creativecommons.org/publicdomain/zero/1.0/
+default_curi_maps:
+  - semweb_context
+imports:
+  - linkml:types
+prefixes:
+  personinfo: https://w3id.org/linkml/examples/personinfo/
+  linkml: https://w3id.org/linkml/
+  schema: http://schema.org/
+  rdfs: http://www.w3.org/2000/01/rdf-schema#
+  prov: http://www.w3.org/ns/prov#
+  GSSO: http://purl.obolibrary.org/obo/GSSO_
+  famrel: https://example.org/FamilialRelations#
+  # DATA PREFIXES
+  P: http://example.org/P/
+  ROR: http://example.org/ror/
+  CODE: http://example.org/code/
+  GEO: http://example.org/geoloc/
+default_prefix: personinfo
+default_range: string
+
+emit_prefixes:
+  - rdf
+  - rdfs
+  - xsd
+  - skos
+
+classes:
+
+  NamedThing:
+    description: >-
+      A generic grouping for any identifiable entity
+    slots:
+      - id
+      - name
+      - description
+      - image
+    close_mappings:
+      - schema:Thing
+
+  Person:
+    is_a: NamedThing
+    description: >-
+      A person (alive, dead, undead, or fictional).
+    class_uri: schema:Person
+    mixins:
+      - HasAliases
+    slots:
+      - primary_email
+      - birth_date
+      - age_in_years
+      - gender
+      - current_address
+      - has_employment_history
+      - has_familial_relationships
+      - has_medical_history
+    slot_usage:
+      primary_email:
+        pattern: "^\\S+@[\\S+\\.]+\\S+"
+    in_subset:
+      - basic_subset
+
+  HasAliases:
+    description: >-
+      A mixin applied to any class that can have aliases/alternateNames
+    mixin: true
+    attributes:
+      aliases:
+        multivalued: true
+        exact_mappings:
+          - schema:alternateName
+
+
+  Organization:
+    description: >-
+      An organization such as a company or university
+    is_a: NamedThing
+    class_uri: schema:Organization
+    mixins:
+      - HasAliases
+    slots:
+      - mission_statement
+      - founding_date
+      - founding_location
+
+  Place:
+    mixins:
+      - HasAliases
+    slots:
+      - id
+      - name
+
+  Address:
+    class_uri: schema:PostalAddress
+    slots:
+      - street
+      - city
+      - postal_code
+
+  Event:
+    slots:
+      - started_at_time
+      - ended_at_time
+      - duration
+      - is_current
+    close_mappings:
+      - schema:Event
+
+  Concept:
+    is_a: NamedThing
+
+  DiagnosisConcept:
+    is_a: Concept
+
+  ProcedureConcept:
+    is_a: Concept
+
+
+  Relationship:
+    slots:
+      - started_at_time
+      - ended_at_time
+      - related_to
+
+  FamilialRelationship:
+    is_a: Relationship
+    slots:
+      - type
+    slot_usage:
+      type:
+        range: FamilialRelationshipType
+        required: true
+      related_to:
+        range: Person
+        required: true
+
+  EmploymentEvent:
+    is_a: Event
+    slots:
+      - employed_at
+      - type
+
+  MedicalEvent:
+    is_a: Event
+    slots:
+      - in_location
+      - diagnosis
+      - procedure
+      - type
+
+  WithLocation:
+    mixin: true
+    slots:
+      - in_location
+
+  # TODO: annotate that this is a container/root class
+  Container:
+    tree_root: true
+    slots:
+      - persons
+      - organizations
+
+slots:
+  id:
+    identifier: true
+    slot_uri: schema:identifier
+  name:
+    slot_uri: schema:name
+  description:
+    slot_uri: schema:description
+  image:
+    slot_uri: schema:image
+  gender:
+    slot_uri: schema:gender
+    range: GenderType
+  primary_email:
+    slot_uri: schema:email
+  birth_date:
+    slot_uri: schema:birthDate
+  employed_at:
+    range: Organization
+  is_current:
+    range: boolean
+  has_employment_history:
+    range: EmploymentEvent
+    multivalued: true
+    inlined_as_list: true
+  has_medical_history:
+    range: MedicalEvent
+    multivalued: true
+    inlined_as_list: true
+  has_familial_relationships:
+    range: FamilialRelationship
+    multivalued: true
+    inlined_as_list: true
+  in_location:
+    range: Place
+  current_address:
+    description: >-
+      The address at which a person currently lives
+    range: Address
+  age_in_years:
+    range: integer
+    minimum_value: 0
+    maximum_value: 999
+  related_to:
+  type:
+    range: RelationshipType
+  street:
+  city:
+  mission_statement:
+  founding_date:
+  founding_location:
+    range: Place
+  postal_code:
+    range: string
+  started_at_time:
+    slot_uri: prov:startedAtTime
+    range: date
+  duration:
+    range: float
+  diagnosis:
+    range: DiagnosisConcept
+    inlined: true
+  procedure:
+    range: ProcedureConcept
+    inlined: true
+
+  ended_at_time:
+    slot_uri: prov:endedAtTime
+    range: date
+
+  persons:
+    range: Person
+    inlined: true
+    inlined_as_list: true
+    multivalued: true
+  organizations:
+    range: Organization
+    inlined_as_list: true
+    inlined: true
+    multivalued: true
+
+enums:
+  RelationshipType:
+  FamilialRelationshipType:
+    is_a: RelationshipType
+    permissible_values:
+      SIBLING_OF:
+        meaning: famrel:01
+      PARENT_OF:
+        meaning: famrel:02
+      CHILD_OF:
+        meaning: famrel:01
+      FATHER_OF:
+        meaning: famrel:11
+  GenderType:
+    permissible_values:
+      nonbinary man:
+        meaning: GSSO:009254
+      nonbinary woman:
+        meaning: GSSO:009253
+      transgender woman:
+        meaning: GSSO:000384
+      transgender man:
+        meaning: GSSO:000372
+      cisgender man:
+        meaning: GSSO:000371
+      cisgender woman:
+        meaning: GSSO:000385
+  DiagnosisType:
+
+subsets:
+  basic_subset:
+    description: A subset of the schema that handles basic information

--- a/tests/test_utils/input/object-indexer-data.yaml
+++ b/tests/test_utils/input/object-indexer-data.yaml
@@ -1,0 +1,32 @@
+persons:
+  - id: P:001
+    name: fred bloggs
+    primary_email: fred.bloggs@example.com
+    age_in_years: 33
+    gender: nonbinary man
+    has_familial_relationships:
+      - type: SIBLING_OF
+        related_to: P:002
+    current_address:
+      street: 1 oak street
+    aliases:
+      - a
+      - b
+    has_medical_history:
+      - diagnosis:
+          id: C:001
+          name: c1
+      - diagnosis:
+          id: C:002
+  - id: P:002
+    name: Alison Wu
+    has_familial_relationships:
+      - type: SIBLING_OF
+        related_to: P:001
+    has_medical_history:
+      - diagnosis:
+          id: C:001
+          name: c1 (renamed)
+organizations:
+  - id: ROR:1
+    name: Acme

--- a/tests/test_utils/model/container_test.py
+++ b/tests/test_utils/model/container_test.py
@@ -1,0 +1,690 @@
+# Auto generated from personinfo_s1.yaml by pythongen.py version: 0.9.0
+# Generation date: 2022-10-12T13:22:57
+# Schema: personinfo
+#
+# id: https://w3id.org/linkml/examples/personinfo
+# description: Information about people, based on [schema.org](http://schema.org)
+# license: https://creativecommons.org/publicdomain/zero/1.0/
+
+import dataclasses
+import sys
+import re
+from jsonasobj2 import JsonObj, as_dict
+from typing import Optional, List, Union, Dict, ClassVar, Any
+from dataclasses import dataclass
+from linkml_runtime.linkml_model.meta import EnumDefinition, PermissibleValue, PvFormulaOptions
+
+from linkml_runtime.utils.slot import Slot
+from linkml_runtime.utils.metamodelcore import empty_list, empty_dict, bnode
+from linkml_runtime.utils.yamlutils import YAMLRoot, extended_str, extended_float, extended_int
+from linkml_runtime.utils.dataclass_extensions_376 import dataclasses_init_fn_with_kwargs
+from linkml_runtime.utils.formatutils import camelcase, underscore, sfx
+from linkml_runtime.utils.enumerations import EnumDefinitionImpl
+from rdflib import Namespace, URIRef
+from linkml_runtime.utils.curienamespace import CurieNamespace
+from linkml_runtime.linkml_model.types import Boolean, Date, Float, Integer, String
+from linkml_runtime.utils.metamodelcore import Bool, XSDDate
+
+metamodel_version = "1.7.0"
+version = None
+
+# Overwrite dataclasses _init_fn to add **kwargs in __init__
+dataclasses._init_fn = dataclasses_init_fn_with_kwargs
+
+# Namespaces
+CODE = CurieNamespace('CODE', 'http://example.org/code/')
+GEO = CurieNamespace('GEO', 'http://example.org/geoloc/')
+GSSO = CurieNamespace('GSSO', 'http://purl.obolibrary.org/obo/GSSO_')
+P = CurieNamespace('P', 'http://example.org/P/')
+ROR = CurieNamespace('ROR', 'http://example.org/ror/')
+FAMREL = CurieNamespace('famrel', 'https://example.org/FamilialRelations#')
+LINKML = CurieNamespace('linkml', 'https://w3id.org/linkml/')
+PERSONINFO = CurieNamespace('personinfo', 'https://w3id.org/linkml/examples/personinfo/')
+PROV = CurieNamespace('prov', 'http://www.w3.org/ns/prov#')
+RDF = CurieNamespace('rdf', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#')
+RDFS = CurieNamespace('rdfs', 'http://www.w3.org/2000/01/rdf-schema#')
+SCHEMA = CurieNamespace('schema', 'http://schema.org/')
+SKOS = CurieNamespace('skos', 'http://example.org/UNKNOWN/skos/')
+XSD = CurieNamespace('xsd', 'http://www.w3.org/2001/XMLSchema#')
+DEFAULT_ = PERSONINFO
+
+
+# Types
+
+# Class references
+class NamedThingId(extended_str):
+    pass
+
+
+class PersonId(NamedThingId):
+    pass
+
+
+class OrganizationId(NamedThingId):
+    pass
+
+
+class PlaceId(extended_str):
+    pass
+
+
+class ConceptId(NamedThingId):
+    pass
+
+
+class DiagnosisConceptId(ConceptId):
+    pass
+
+
+class ProcedureConceptId(ConceptId):
+    pass
+
+
+@dataclass
+class NamedThing(YAMLRoot):
+    """
+    A generic grouping for any identifiable entity
+    """
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = PERSONINFO.NamedThing
+    class_class_curie: ClassVar[str] = "personinfo:NamedThing"
+    class_name: ClassVar[str] = "NamedThing"
+    class_model_uri: ClassVar[URIRef] = PERSONINFO.NamedThing
+
+    id: Union[str, NamedThingId] = None
+    name: Optional[str] = None
+    description: Optional[str] = None
+    image: Optional[str] = None
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self._is_empty(self.id):
+            self.MissingRequiredField("id")
+        if not isinstance(self.id, NamedThingId):
+            self.id = NamedThingId(self.id)
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
+        if self.description is not None and not isinstance(self.description, str):
+            self.description = str(self.description)
+
+        if self.image is not None and not isinstance(self.image, str):
+            self.image = str(self.image)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass
+class Person(NamedThing):
+    """
+    A person (alive, dead, undead, or fictional).
+    """
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = SCHEMA.Person
+    class_class_curie: ClassVar[str] = "schema:Person"
+    class_name: ClassVar[str] = "Person"
+    class_model_uri: ClassVar[URIRef] = PERSONINFO.Person
+
+    id: Union[str, PersonId] = None
+    primary_email: Optional[str] = None
+    birth_date: Optional[str] = None
+    age_in_years: Optional[int] = None
+    gender: Optional[Union[str, "GenderType"]] = None
+    current_address: Optional[Union[dict, "Address"]] = None
+    has_employment_history: Optional[Union[Union[dict, "EmploymentEvent"], List[Union[dict, "EmploymentEvent"]]]] = empty_list()
+    has_familial_relationships: Optional[Union[Union[dict, "FamilialRelationship"], List[Union[dict, "FamilialRelationship"]]]] = empty_list()
+    has_medical_history: Optional[Union[Union[dict, "MedicalEvent"], List[Union[dict, "MedicalEvent"]]]] = empty_list()
+    aliases: Optional[Union[str, List[str]]] = empty_list()
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self._is_empty(self.id):
+            self.MissingRequiredField("id")
+        if not isinstance(self.id, PersonId):
+            self.id = PersonId(self.id)
+
+        if self.primary_email is not None and not isinstance(self.primary_email, str):
+            self.primary_email = str(self.primary_email)
+
+        if self.birth_date is not None and not isinstance(self.birth_date, str):
+            self.birth_date = str(self.birth_date)
+
+        if self.age_in_years is not None and not isinstance(self.age_in_years, int):
+            self.age_in_years = int(self.age_in_years)
+
+        if self.gender is not None and not isinstance(self.gender, GenderType):
+            self.gender = GenderType(self.gender)
+
+        if self.current_address is not None and not isinstance(self.current_address, Address):
+            self.current_address = Address(**as_dict(self.current_address))
+
+        if not isinstance(self.has_employment_history, list):
+            self.has_employment_history = [self.has_employment_history] if self.has_employment_history is not None else []
+        self.has_employment_history = [v if isinstance(v, EmploymentEvent) else EmploymentEvent(**as_dict(v)) for v in self.has_employment_history]
+
+        if not isinstance(self.has_familial_relationships, list):
+            self.has_familial_relationships = [self.has_familial_relationships] if self.has_familial_relationships is not None else []
+        self.has_familial_relationships = [v if isinstance(v, FamilialRelationship) else FamilialRelationship(**as_dict(v)) for v in self.has_familial_relationships]
+
+        if not isinstance(self.has_medical_history, list):
+            self.has_medical_history = [self.has_medical_history] if self.has_medical_history is not None else []
+        self.has_medical_history = [v if isinstance(v, MedicalEvent) else MedicalEvent(**as_dict(v)) for v in self.has_medical_history]
+
+        if not isinstance(self.aliases, list):
+            self.aliases = [self.aliases] if self.aliases is not None else []
+        self.aliases = [v if isinstance(v, str) else str(v) for v in self.aliases]
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass
+class HasAliases(YAMLRoot):
+    """
+    A mixin applied to any class that can have aliases/alternateNames
+    """
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = PERSONINFO.HasAliases
+    class_class_curie: ClassVar[str] = "personinfo:HasAliases"
+    class_name: ClassVar[str] = "HasAliases"
+    class_model_uri: ClassVar[URIRef] = PERSONINFO.HasAliases
+
+    aliases: Optional[Union[str, List[str]]] = empty_list()
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if not isinstance(self.aliases, list):
+            self.aliases = [self.aliases] if self.aliases is not None else []
+        self.aliases = [v if isinstance(v, str) else str(v) for v in self.aliases]
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass
+class Organization(NamedThing):
+    """
+    An organization such as a company or university
+    """
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = SCHEMA.Organization
+    class_class_curie: ClassVar[str] = "schema:Organization"
+    class_name: ClassVar[str] = "Organization"
+    class_model_uri: ClassVar[URIRef] = PERSONINFO.Organization
+
+    id: Union[str, OrganizationId] = None
+    mission_statement: Optional[str] = None
+    founding_date: Optional[str] = None
+    founding_location: Optional[Union[str, PlaceId]] = None
+    aliases: Optional[Union[str, List[str]]] = empty_list()
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self._is_empty(self.id):
+            self.MissingRequiredField("id")
+        if not isinstance(self.id, OrganizationId):
+            self.id = OrganizationId(self.id)
+
+        if self.mission_statement is not None and not isinstance(self.mission_statement, str):
+            self.mission_statement = str(self.mission_statement)
+
+        if self.founding_date is not None and not isinstance(self.founding_date, str):
+            self.founding_date = str(self.founding_date)
+
+        if self.founding_location is not None and not isinstance(self.founding_location, PlaceId):
+            self.founding_location = PlaceId(self.founding_location)
+
+        if not isinstance(self.aliases, list):
+            self.aliases = [self.aliases] if self.aliases is not None else []
+        self.aliases = [v if isinstance(v, str) else str(v) for v in self.aliases]
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass
+class Place(YAMLRoot):
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = PERSONINFO.Place
+    class_class_curie: ClassVar[str] = "personinfo:Place"
+    class_name: ClassVar[str] = "Place"
+    class_model_uri: ClassVar[URIRef] = PERSONINFO.Place
+
+    id: Union[str, PlaceId] = None
+    name: Optional[str] = None
+    aliases: Optional[Union[str, List[str]]] = empty_list()
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self._is_empty(self.id):
+            self.MissingRequiredField("id")
+        if not isinstance(self.id, PlaceId):
+            self.id = PlaceId(self.id)
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
+        if not isinstance(self.aliases, list):
+            self.aliases = [self.aliases] if self.aliases is not None else []
+        self.aliases = [v if isinstance(v, str) else str(v) for v in self.aliases]
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass
+class Address(YAMLRoot):
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = SCHEMA.PostalAddress
+    class_class_curie: ClassVar[str] = "schema:PostalAddress"
+    class_name: ClassVar[str] = "Address"
+    class_model_uri: ClassVar[URIRef] = PERSONINFO.Address
+
+    street: Optional[str] = None
+    city: Optional[str] = None
+    postal_code: Optional[str] = None
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self.street is not None and not isinstance(self.street, str):
+            self.street = str(self.street)
+
+        if self.city is not None and not isinstance(self.city, str):
+            self.city = str(self.city)
+
+        if self.postal_code is not None and not isinstance(self.postal_code, str):
+            self.postal_code = str(self.postal_code)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass
+class Event(YAMLRoot):
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = PERSONINFO.Event
+    class_class_curie: ClassVar[str] = "personinfo:Event"
+    class_name: ClassVar[str] = "Event"
+    class_model_uri: ClassVar[URIRef] = PERSONINFO.Event
+
+    started_at_time: Optional[Union[str, XSDDate]] = None
+    ended_at_time: Optional[Union[str, XSDDate]] = None
+    duration: Optional[float] = None
+    is_current: Optional[Union[bool, Bool]] = None
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self.started_at_time is not None and not isinstance(self.started_at_time, XSDDate):
+            self.started_at_time = XSDDate(self.started_at_time)
+
+        if self.ended_at_time is not None and not isinstance(self.ended_at_time, XSDDate):
+            self.ended_at_time = XSDDate(self.ended_at_time)
+
+        if self.duration is not None and not isinstance(self.duration, float):
+            self.duration = float(self.duration)
+
+        if self.is_current is not None and not isinstance(self.is_current, Bool):
+            self.is_current = Bool(self.is_current)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass
+class Concept(NamedThing):
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = PERSONINFO.Concept
+    class_class_curie: ClassVar[str] = "personinfo:Concept"
+    class_name: ClassVar[str] = "Concept"
+    class_model_uri: ClassVar[URIRef] = PERSONINFO.Concept
+
+    id: Union[str, ConceptId] = None
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self._is_empty(self.id):
+            self.MissingRequiredField("id")
+        if not isinstance(self.id, ConceptId):
+            self.id = ConceptId(self.id)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass
+class DiagnosisConcept(Concept):
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = PERSONINFO.DiagnosisConcept
+    class_class_curie: ClassVar[str] = "personinfo:DiagnosisConcept"
+    class_name: ClassVar[str] = "DiagnosisConcept"
+    class_model_uri: ClassVar[URIRef] = PERSONINFO.DiagnosisConcept
+
+    id: Union[str, DiagnosisConceptId] = None
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self._is_empty(self.id):
+            self.MissingRequiredField("id")
+        if not isinstance(self.id, DiagnosisConceptId):
+            self.id = DiagnosisConceptId(self.id)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass
+class ProcedureConcept(Concept):
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = PERSONINFO.ProcedureConcept
+    class_class_curie: ClassVar[str] = "personinfo:ProcedureConcept"
+    class_name: ClassVar[str] = "ProcedureConcept"
+    class_model_uri: ClassVar[URIRef] = PERSONINFO.ProcedureConcept
+
+    id: Union[str, ProcedureConceptId] = None
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self._is_empty(self.id):
+            self.MissingRequiredField("id")
+        if not isinstance(self.id, ProcedureConceptId):
+            self.id = ProcedureConceptId(self.id)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass
+class Relationship(YAMLRoot):
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = PERSONINFO.Relationship
+    class_class_curie: ClassVar[str] = "personinfo:Relationship"
+    class_name: ClassVar[str] = "Relationship"
+    class_model_uri: ClassVar[URIRef] = PERSONINFO.Relationship
+
+    started_at_time: Optional[Union[str, XSDDate]] = None
+    ended_at_time: Optional[Union[str, XSDDate]] = None
+    related_to: Optional[str] = None
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self.started_at_time is not None and not isinstance(self.started_at_time, XSDDate):
+            self.started_at_time = XSDDate(self.started_at_time)
+
+        if self.ended_at_time is not None and not isinstance(self.ended_at_time, XSDDate):
+            self.ended_at_time = XSDDate(self.ended_at_time)
+
+        if self.related_to is not None and not isinstance(self.related_to, str):
+            self.related_to = str(self.related_to)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass
+class FamilialRelationship(Relationship):
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = PERSONINFO.FamilialRelationship
+    class_class_curie: ClassVar[str] = "personinfo:FamilialRelationship"
+    class_name: ClassVar[str] = "FamilialRelationship"
+    class_model_uri: ClassVar[URIRef] = PERSONINFO.FamilialRelationship
+
+    type: Union[str, "FamilialRelationshipType"] = None
+    related_to: Union[str, PersonId] = None
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self._is_empty(self.type):
+            self.MissingRequiredField("type")
+        if not isinstance(self.type, FamilialRelationshipType):
+            self.type = FamilialRelationshipType(self.type)
+
+        if self._is_empty(self.related_to):
+            self.MissingRequiredField("related_to")
+        if not isinstance(self.related_to, PersonId):
+            self.related_to = PersonId(self.related_to)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass
+class EmploymentEvent(Event):
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = PERSONINFO.EmploymentEvent
+    class_class_curie: ClassVar[str] = "personinfo:EmploymentEvent"
+    class_name: ClassVar[str] = "EmploymentEvent"
+    class_model_uri: ClassVar[URIRef] = PERSONINFO.EmploymentEvent
+
+    employed_at: Optional[Union[str, OrganizationId]] = None
+    type: Optional[Union[str, "RelationshipType"]] = None
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self.employed_at is not None and not isinstance(self.employed_at, OrganizationId):
+            self.employed_at = OrganizationId(self.employed_at)
+
+        if self.type is not None and not isinstance(self.type, RelationshipType):
+            self.type = RelationshipType(self.type)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass
+class MedicalEvent(Event):
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = PERSONINFO.MedicalEvent
+    class_class_curie: ClassVar[str] = "personinfo:MedicalEvent"
+    class_name: ClassVar[str] = "MedicalEvent"
+    class_model_uri: ClassVar[URIRef] = PERSONINFO.MedicalEvent
+
+    in_location: Optional[Union[str, PlaceId]] = None
+    diagnosis: Optional[Union[dict, DiagnosisConcept]] = None
+    procedure: Optional[Union[dict, ProcedureConcept]] = None
+    type: Optional[Union[str, "RelationshipType"]] = None
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self.in_location is not None and not isinstance(self.in_location, PlaceId):
+            self.in_location = PlaceId(self.in_location)
+
+        if self.diagnosis is not None and not isinstance(self.diagnosis, DiagnosisConcept):
+            self.diagnosis = DiagnosisConcept(**as_dict(self.diagnosis))
+
+        if self.procedure is not None and not isinstance(self.procedure, ProcedureConcept):
+            self.procedure = ProcedureConcept(**as_dict(self.procedure))
+
+        if self.type is not None and not isinstance(self.type, RelationshipType):
+            self.type = RelationshipType(self.type)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass
+class WithLocation(YAMLRoot):
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = PERSONINFO.WithLocation
+    class_class_curie: ClassVar[str] = "personinfo:WithLocation"
+    class_name: ClassVar[str] = "WithLocation"
+    class_model_uri: ClassVar[URIRef] = PERSONINFO.WithLocation
+
+    in_location: Optional[Union[str, PlaceId]] = None
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self.in_location is not None and not isinstance(self.in_location, PlaceId):
+            self.in_location = PlaceId(self.in_location)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass
+class Container(YAMLRoot):
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = PERSONINFO.Container
+    class_class_curie: ClassVar[str] = "personinfo:Container"
+    class_name: ClassVar[str] = "Container"
+    class_model_uri: ClassVar[URIRef] = PERSONINFO.Container
+
+    persons: Optional[Union[Dict[Union[str, PersonId], Union[dict, Person]], List[Union[dict, Person]]]] = empty_dict()
+    organizations: Optional[Union[Dict[Union[str, OrganizationId], Union[dict, Organization]], List[Union[dict, Organization]]]] = empty_dict()
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        self._normalize_inlined_as_list(slot_name="persons", slot_type=Person, key_name="id", keyed=True)
+
+        self._normalize_inlined_as_list(slot_name="organizations", slot_type=Organization, key_name="id", keyed=True)
+
+        super().__post_init__(**kwargs)
+
+
+# Enumerations
+class RelationshipType(EnumDefinitionImpl):
+
+    _defn = EnumDefinition(
+        name="RelationshipType",
+    )
+
+class FamilialRelationshipType(EnumDefinitionImpl):
+
+    SIBLING_OF = PermissibleValue(text="SIBLING_OF",
+                                           meaning=FAMREL["01"])
+    PARENT_OF = PermissibleValue(text="PARENT_OF",
+                                         meaning=FAMREL["02"])
+    CHILD_OF = PermissibleValue(text="CHILD_OF",
+                                       meaning=FAMREL["01"])
+    FATHER_OF = PermissibleValue(text="FATHER_OF",
+                                         meaning=FAMREL["11"])
+
+    _defn = EnumDefinition(
+        name="FamilialRelationshipType",
+    )
+
+class GenderType(EnumDefinitionImpl):
+
+    _defn = EnumDefinition(
+        name="GenderType",
+    )
+
+    @classmethod
+    def _addvals(cls):
+        setattr(cls, "nonbinary man",
+                PermissibleValue(text="nonbinary man",
+                                 meaning=GSSO["009254"]) )
+        setattr(cls, "nonbinary woman",
+                PermissibleValue(text="nonbinary woman",
+                                 meaning=GSSO["009253"]) )
+        setattr(cls, "transgender woman",
+                PermissibleValue(text="transgender woman",
+                                 meaning=GSSO["000384"]) )
+        setattr(cls, "transgender man",
+                PermissibleValue(text="transgender man",
+                                 meaning=GSSO["000372"]) )
+        setattr(cls, "cisgender man",
+                PermissibleValue(text="cisgender man",
+                                 meaning=GSSO["000371"]) )
+        setattr(cls, "cisgender woman",
+                PermissibleValue(text="cisgender woman",
+                                 meaning=GSSO["000385"]) )
+
+class DiagnosisType(EnumDefinitionImpl):
+
+    _defn = EnumDefinition(
+        name="DiagnosisType",
+    )
+
+# Slots
+class slots:
+    pass
+
+slots.id = Slot(uri=SCHEMA.identifier, name="id", curie=SCHEMA.curie('identifier'),
+                   model_uri=PERSONINFO.id, domain=None, range=URIRef)
+
+slots.name = Slot(uri=SCHEMA.name, name="name", curie=SCHEMA.curie('name'),
+                   model_uri=PERSONINFO.name, domain=None, range=Optional[str])
+
+slots.description = Slot(uri=SCHEMA.description, name="description", curie=SCHEMA.curie('description'),
+                   model_uri=PERSONINFO.description, domain=None, range=Optional[str])
+
+slots.image = Slot(uri=SCHEMA.image, name="image", curie=SCHEMA.curie('image'),
+                   model_uri=PERSONINFO.image, domain=None, range=Optional[str])
+
+slots.gender = Slot(uri=SCHEMA.gender, name="gender", curie=SCHEMA.curie('gender'),
+                   model_uri=PERSONINFO.gender, domain=None, range=Optional[Union[str, "GenderType"]])
+
+slots.primary_email = Slot(uri=SCHEMA.email, name="primary_email", curie=SCHEMA.curie('email'),
+                   model_uri=PERSONINFO.primary_email, domain=None, range=Optional[str])
+
+slots.birth_date = Slot(uri=SCHEMA.birthDate, name="birth_date", curie=SCHEMA.curie('birthDate'),
+                   model_uri=PERSONINFO.birth_date, domain=None, range=Optional[str])
+
+slots.employed_at = Slot(uri=PERSONINFO.employed_at, name="employed_at", curie=PERSONINFO.curie('employed_at'),
+                   model_uri=PERSONINFO.employed_at, domain=None, range=Optional[Union[str, OrganizationId]])
+
+slots.is_current = Slot(uri=PERSONINFO.is_current, name="is_current", curie=PERSONINFO.curie('is_current'),
+                   model_uri=PERSONINFO.is_current, domain=None, range=Optional[Union[bool, Bool]])
+
+slots.has_employment_history = Slot(uri=PERSONINFO.has_employment_history, name="has_employment_history", curie=PERSONINFO.curie('has_employment_history'),
+                   model_uri=PERSONINFO.has_employment_history, domain=None, range=Optional[Union[Union[dict, EmploymentEvent], List[Union[dict, EmploymentEvent]]]])
+
+slots.has_medical_history = Slot(uri=PERSONINFO.has_medical_history, name="has_medical_history", curie=PERSONINFO.curie('has_medical_history'),
+                   model_uri=PERSONINFO.has_medical_history, domain=None, range=Optional[Union[Union[dict, MedicalEvent], List[Union[dict, MedicalEvent]]]])
+
+slots.has_familial_relationships = Slot(uri=PERSONINFO.has_familial_relationships, name="has_familial_relationships", curie=PERSONINFO.curie('has_familial_relationships'),
+                   model_uri=PERSONINFO.has_familial_relationships, domain=None, range=Optional[Union[Union[dict, FamilialRelationship], List[Union[dict, FamilialRelationship]]]])
+
+slots.in_location = Slot(uri=PERSONINFO.in_location, name="in_location", curie=PERSONINFO.curie('in_location'),
+                   model_uri=PERSONINFO.in_location, domain=None, range=Optional[Union[str, PlaceId]])
+
+slots.current_address = Slot(uri=PERSONINFO.current_address, name="current_address", curie=PERSONINFO.curie('current_address'),
+                   model_uri=PERSONINFO.current_address, domain=None, range=Optional[Union[dict, Address]])
+
+slots.age_in_years = Slot(uri=PERSONINFO.age_in_years, name="age_in_years", curie=PERSONINFO.curie('age_in_years'),
+                   model_uri=PERSONINFO.age_in_years, domain=None, range=Optional[int])
+
+slots.related_to = Slot(uri=PERSONINFO.related_to, name="related_to", curie=PERSONINFO.curie('related_to'),
+                   model_uri=PERSONINFO.related_to, domain=None, range=Optional[str])
+
+slots.type = Slot(uri=PERSONINFO.type, name="type", curie=PERSONINFO.curie('type'),
+                   model_uri=PERSONINFO.type, domain=None, range=Optional[Union[str, "RelationshipType"]])
+
+slots.street = Slot(uri=PERSONINFO.street, name="street", curie=PERSONINFO.curie('street'),
+                   model_uri=PERSONINFO.street, domain=None, range=Optional[str])
+
+slots.city = Slot(uri=PERSONINFO.city, name="city", curie=PERSONINFO.curie('city'),
+                   model_uri=PERSONINFO.city, domain=None, range=Optional[str])
+
+slots.mission_statement = Slot(uri=PERSONINFO.mission_statement, name="mission_statement", curie=PERSONINFO.curie('mission_statement'),
+                   model_uri=PERSONINFO.mission_statement, domain=None, range=Optional[str])
+
+slots.founding_date = Slot(uri=PERSONINFO.founding_date, name="founding_date", curie=PERSONINFO.curie('founding_date'),
+                   model_uri=PERSONINFO.founding_date, domain=None, range=Optional[str])
+
+slots.founding_location = Slot(uri=PERSONINFO.founding_location, name="founding_location", curie=PERSONINFO.curie('founding_location'),
+                   model_uri=PERSONINFO.founding_location, domain=None, range=Optional[Union[str, PlaceId]])
+
+slots.postal_code = Slot(uri=PERSONINFO.postal_code, name="postal_code", curie=PERSONINFO.curie('postal_code'),
+                   model_uri=PERSONINFO.postal_code, domain=None, range=Optional[str])
+
+slots.started_at_time = Slot(uri=PROV.startedAtTime, name="started_at_time", curie=PROV.curie('startedAtTime'),
+                   model_uri=PERSONINFO.started_at_time, domain=None, range=Optional[Union[str, XSDDate]])
+
+slots.duration = Slot(uri=PERSONINFO.duration, name="duration", curie=PERSONINFO.curie('duration'),
+                   model_uri=PERSONINFO.duration, domain=None, range=Optional[float])
+
+slots.diagnosis = Slot(uri=PERSONINFO.diagnosis, name="diagnosis", curie=PERSONINFO.curie('diagnosis'),
+                   model_uri=PERSONINFO.diagnosis, domain=None, range=Optional[Union[dict, DiagnosisConcept]])
+
+slots.procedure = Slot(uri=PERSONINFO.procedure, name="procedure", curie=PERSONINFO.curie('procedure'),
+                   model_uri=PERSONINFO.procedure, domain=None, range=Optional[Union[dict, ProcedureConcept]])
+
+slots.ended_at_time = Slot(uri=PROV.endedAtTime, name="ended_at_time", curie=PROV.curie('endedAtTime'),
+                   model_uri=PERSONINFO.ended_at_time, domain=None, range=Optional[Union[str, XSDDate]])
+
+slots.persons = Slot(uri=PERSONINFO.persons, name="persons", curie=PERSONINFO.curie('persons'),
+                   model_uri=PERSONINFO.persons, domain=None, range=Optional[Union[Dict[Union[str, PersonId], Union[dict, Person]], List[Union[dict, Person]]]])
+
+slots.organizations = Slot(uri=PERSONINFO.organizations, name="organizations", curie=PERSONINFO.curie('organizations'),
+                   model_uri=PERSONINFO.organizations, domain=None, range=Optional[Union[Dict[Union[str, OrganizationId], Union[dict, Organization]], List[Union[dict, Organization]]]])
+
+slots.hasAliases__aliases = Slot(uri=PERSONINFO.aliases, name="hasAliases__aliases", curie=PERSONINFO.curie('aliases'),
+                   model_uri=PERSONINFO.hasAliases__aliases, domain=None, range=Optional[Union[str, List[str]]])
+
+slots.Person_primary_email = Slot(uri=SCHEMA.email, name="Person_primary_email", curie=SCHEMA.curie('email'),
+                   model_uri=PERSONINFO.Person_primary_email, domain=Person, range=Optional[str],
+                   pattern=re.compile(r'^\S+@[\S+\.]+\S+'))
+
+slots.FamilialRelationship_type = Slot(uri=PERSONINFO.type, name="FamilialRelationship_type", curie=PERSONINFO.curie('type'),
+                   model_uri=PERSONINFO.FamilialRelationship_type, domain=FamilialRelationship, range=Union[str, "FamilialRelationshipType"])
+
+slots.FamilialRelationship_related_to = Slot(uri=PERSONINFO.related_to, name="FamilialRelationship_related_to", curie=PERSONINFO.curie('related_to'),
+                   model_uri=PERSONINFO.FamilialRelationship_related_to, domain=FamilialRelationship, range=Union[str, PersonId])

--- a/tests/test_utils/test_object_index.py
+++ b/tests/test_utils/test_object_index.py
@@ -1,0 +1,72 @@
+import os
+import unittest
+
+from linkml_runtime import SchemaView
+from linkml_runtime.dumpers import yaml_dumper
+from linkml_runtime.loaders import yaml_loader
+import tests.test_utils.model.container_test as src_dm
+from linkml_runtime.utils.object_index import ObjectIndex, ProxyObject
+from tests.test_utils import INPUT_DIR
+
+SCHEMA = os.path.join(INPUT_DIR, 'container_test.yaml')
+DATA = os.path.join(INPUT_DIR, 'object-indexer-data.yaml')
+
+
+class ObjectIndexerTestCase(unittest.TestCase):
+    """
+    tests the data model
+    """
+
+    def setUp(self) -> None:
+        self.schemaview = SchemaView(SCHEMA)
+        obj: src_dm.Container
+        self.container = yaml_loader.load(DATA, target_class=src_dm.Container)
+
+    def test_object_index(self):
+        """ checks indexing objects """
+        c = self.container
+        frt = c.persons[0].has_familial_relationships[0].type
+        self.assertIsInstance(frt, src_dm.FamilialRelationshipType)
+        fac = ObjectIndex(c, schemaview=self.schemaview)
+        self.assertEqual(0, fac.proxy_object_cache_size)
+        self.assertGreater(fac.source_object_cache_size, 4)
+        obj = fac.bless(c)
+        self.assertIsInstance(obj, ProxyObject)
+        obj = fac.bless(c.persons[0])
+        self.assertIsInstance(obj, ProxyObject)
+        v = obj.name
+        self.assertEqual("fred bloggs", v)
+        self.assertEqual(33, obj.age_in_years)
+        self.assertCountEqual(["a", "b"], obj.aliases)
+        addr = obj.current_address
+        self.assertIsInstance(addr, ProxyObject)
+        self.assertEqual("1 oak street", addr.street)
+        self.assertIsInstance(obj.has_familial_relationships, list)
+        fr = obj.has_familial_relationships[0]
+        self.assertIsInstance(fr, ProxyObject)
+        self.assertEqual("Alison Wu", fr.related_to.name)
+        self.assertIsInstance(fr.type, src_dm.FamilialRelationshipType)
+        self.assertIsNone(fr.related_to.age_in_years)
+        self.assertIsInstance(fr.related_to, ProxyObject)
+        self.assertEqual(2, len(obj.has_medical_history))
+        fr2 = fr.related_to.has_familial_relationships[0]
+        self.assertEqual("fred bloggs", fr2.related_to.name)
+        self.assertEqual(33, fr2.related_to.age_in_years)
+        self.assertIsInstance(fr2.related_to, ProxyObject)
+        fr3 = fr2.related_to.has_familial_relationships[0]
+        self.assertIsInstance(fr3.related_to, ProxyObject)
+        self.assertEqual("Alison Wu", fr3.related_to.name)
+        self.assertGreater(fac.proxy_object_cache_size, 1)
+        self.assertLess(fac.proxy_object_cache_size, 4)
+        fac.clear_proxy_object_cache()
+        self.assertEqual(0, fac.proxy_object_cache_size)
+        fr = obj.has_familial_relationships[0].related_to
+        with self.assertRaises(ValueError):
+            v = obj.fake_attribute
+        obj.age_in_years = 44
+        self.assertEqual(44, obj.age_in_years)
+        self.assertEqual(44, self.container.persons[0].age_in_years)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Given a tree-root/container object, this will create an index,
    and allow for retrieval of *proxy objects* that shadow domain
    YAMLRoot classes. These operate in the same way, except that
    object references are automatically dereferenced.

    For example, given a container object following the standard
    personinfo schema, an index can be created and queried:

        >>> ix = ObjectIndex(container, schemaview=schemaview)
        >>> container = ix.bless(container)
        >>> for p in container.persons:
        >>>    for r in p.has_familial_relationships():
        >>>        print(f"{p.name} {p.type} {r.related_to.name}")

    Note this will work even if related_to is *not* inlined.

    This means naive traversal of the object tree is not guaranteed
    to be bounded, unlike with a YAMLRoot object. E.g.

        >>> person.has_familial_relationships[0].
        >>>    related_to.has_familial_relationships[0].
        >>>    related_to.has_familial_relationships[0].name

    In the above, the same proxy object is reused for any
    object with an identifier.
