### PR TITLE
Allow for non-CURIE identifiers to be encoded.

### DIFF
--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -1283,7 +1283,7 @@ class SchemaView(object):
             raise ValueError(f'Unrecognized range: {r}')
         return range_types
 
-    def slot_range_as_union(self, slot: SlotDefinition) -> List[EnumDefinitionName]:
+    def slot_range_as_union(self, slot: SlotDefinition) -> List[ElementName]:
         """
         Returns all applicable ranges for a slot
 
@@ -1337,6 +1337,21 @@ class SchemaView(object):
                     if slot_definition.range == enum_name:
                         enum_slots.append(slot_definition)
         return enum_slots
+
+    def is_type_percent_encoded(self, type: TypeDefinitionName) -> bool:
+        """
+        True if type is has a percent_encoded annotation.
+
+        This is true for type fields that are the range of identifier columns,
+        where the identifier is not guaranteed to be a valid URI or CURIE
+
+        :param type:
+        :return:
+        """
+        id_slot_ranges = self.type_ancestors(type)
+        for t in id_slot_ranges:
+            anns = self.get_type(t).annotations
+            return "percent_encoded" in anns
 
     @lru_cache()
     def usage_index(self) -> Dict[ElementName, List[SchemaUsage]]:

--- a/tests/test_issues/input/linkml_issue_576.yaml
+++ b/tests/test_issues/input/linkml_issue_576.yaml
@@ -1,0 +1,85 @@
+id: https://w3id.org/linkml/examples/personinfo
+name: personinfo
+prefixes:
+  linkml: https://w3id.org/linkml/
+  personinfo: https://w3id.org/linkml/personinfo/
+  schema: http://schema.org/
+  ex: https://example.org/
+imports:
+  - linkml:types
+default_range: string
+default_prefix: personinfo
+
+types:
+  Code:
+    typeof: string
+    description: >-
+      An identifier that is encoded in a string.  This is used to represent
+      identifiers that are not URIs, but are encoded as strings.  For example,
+      a person's social security number is an encoded identifier.
+    annotations:
+      prefix: "@base"
+      percent_encoded: true
+
+
+classes:
+  Person:
+    class_uri: schema:Person
+    attributes:
+      id:
+        identifier: true
+        range: uriorcurie
+        comments:
+          - person IDs are natively encoded as uris or curies
+      name:
+        range: string
+        slot_uri: schema:name
+      friends:
+        range: Person
+        multivalued: true
+
+  Pet:
+    attributes:
+      id:
+        identifier: true
+        range: string
+        comments:
+          - pet IDs are natively encoded as strings without encoding
+          - they are assumed to be in CURIE form
+      name:
+        range: string
+        slot_uri: schema:name
+      owner:
+        range: Person
+        slot_uri: schema:owner
+
+  Organization:
+    class_uri: schema:Organization
+    attributes:
+      id:
+        identifier: true
+        range: Code
+        comments:
+          - organization IDs are natively encoded as strings with percent encoding
+          - they are encoded before being turned into CURIEs
+      name:
+        range: string
+        slot_uri: schema:name
+      part_of:
+        range: Organization
+        multivalued: true
+
+  Dataset:
+    attributes:
+      persons:
+        multivalued: true
+        range: Person
+        inlined: true
+      organizations:
+        multivalued: true
+        range: Organization
+        inlined: true
+      pets:
+        multivalued: true
+        range: Pet
+        inlined: true

--- a/tests/test_issues/input/linkml_issue_576_data.yaml
+++ b/tests/test_issues/input/linkml_issue_576_data.yaml
@@ -1,0 +1,21 @@
+persons:
+  - id: ex:P1
+    name: John Doe
+  - id: ex:P2
+    name: Jane Doe
+    friends:
+      - ex:P1
+organizations:
+  - id: org 1
+    name: Acme Inc. (US)
+  - id: org 2
+    name: Acme Inc. (UK)
+    part_of:
+      - org 1
+pets:
+  - id: ex:PetA
+    name: Fido
+    owner: ex:P1
+  - id: ex:PetB
+    name: Spot
+    owner: ex:P2

--- a/tests/test_issues/models/linkml_issue_576.py
+++ b/tests/test_issues/models/linkml_issue_576.py
@@ -1,0 +1,215 @@
+# Auto generated from linkml_issue_576.yaml by pythongen.py version: 0.9.0
+# Generation date: 2022-11-15T16:23:46
+# Schema: personinfo
+#
+# id: https://w3id.org/linkml/examples/personinfo
+# description:
+# license: https://creativecommons.org/publicdomain/zero/1.0/
+
+import dataclasses
+import sys
+import re
+from jsonasobj2 import JsonObj, as_dict
+from typing import Optional, List, Union, Dict, ClassVar, Any
+from dataclasses import dataclass
+from linkml_runtime.linkml_model.meta import EnumDefinition, PermissibleValue, PvFormulaOptions
+
+from linkml_runtime.utils.slot import Slot
+from linkml_runtime.utils.metamodelcore import empty_list, empty_dict, bnode
+from linkml_runtime.utils.yamlutils import YAMLRoot, extended_str, extended_float, extended_int
+from linkml_runtime.utils.dataclass_extensions_376 import dataclasses_init_fn_with_kwargs
+from linkml_runtime.utils.formatutils import camelcase, underscore, sfx
+from linkml_runtime.utils.enumerations import EnumDefinitionImpl
+from rdflib import Namespace, URIRef
+from linkml_runtime.utils.curienamespace import CurieNamespace
+from linkml_runtime.linkml_model.types import String, Uriorcurie
+from linkml_runtime.utils.metamodelcore import URIorCURIE
+
+metamodel_version = "1.7.0"
+version = None
+
+# Overwrite dataclasses _init_fn to add **kwargs in __init__
+dataclasses._init_fn = dataclasses_init_fn_with_kwargs
+
+# Namespaces
+EX = CurieNamespace('ex', 'https://example.org/')
+LINKML = CurieNamespace('linkml', 'https://w3id.org/linkml/')
+PERSONINFO = CurieNamespace('personinfo', 'https://w3id.org/linkml/personinfo/')
+SCHEMA = CurieNamespace('schema', 'http://schema.org/')
+XSD = CurieNamespace('xsd', 'http://www.w3.org/2001/XMLSchema#')
+DEFAULT_ = PERSONINFO
+
+
+# Types
+class Code(String):
+    """ An identifier that is encoded in a string.  This is used to represent identifiers that are not URIs, but are encoded as strings.  For example, a person's social security number is an encoded identifier. """
+    type_class_uri = XSD.string
+    type_class_curie = "xsd:string"
+    type_name = "Code"
+    type_model_uri = PERSONINFO.Code
+
+
+# Class references
+class PersonId(URIorCURIE):
+    pass
+
+
+class PetId(extended_str):
+    pass
+
+
+class OrganizationId(Code):
+    pass
+
+
+@dataclass
+class Person(YAMLRoot):
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = SCHEMA.Person
+    class_class_curie: ClassVar[str] = "schema:Person"
+    class_name: ClassVar[str] = "Person"
+    class_model_uri: ClassVar[URIRef] = PERSONINFO.Person
+
+    id: Union[str, PersonId] = None
+    name: Optional[str] = None
+    friends: Optional[Union[Union[str, PersonId], List[Union[str, PersonId]]]] = empty_list()
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self._is_empty(self.id):
+            self.MissingRequiredField("id")
+        if not isinstance(self.id, PersonId):
+            self.id = PersonId(self.id)
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
+        if not isinstance(self.friends, list):
+            self.friends = [self.friends] if self.friends is not None else []
+        self.friends = [v if isinstance(v, PersonId) else PersonId(v) for v in self.friends]
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass
+class Pet(YAMLRoot):
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = PERSONINFO.Pet
+    class_class_curie: ClassVar[str] = "personinfo:Pet"
+    class_name: ClassVar[str] = "Pet"
+    class_model_uri: ClassVar[URIRef] = PERSONINFO.Pet
+
+    id: Union[str, PetId] = None
+    name: Optional[str] = None
+    owner: Optional[Union[str, PersonId]] = None
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self._is_empty(self.id):
+            self.MissingRequiredField("id")
+        if not isinstance(self.id, PetId):
+            self.id = PetId(self.id)
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
+        if self.owner is not None and not isinstance(self.owner, PersonId):
+            self.owner = PersonId(self.owner)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass
+class Organization(YAMLRoot):
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = SCHEMA.Organization
+    class_class_curie: ClassVar[str] = "schema:Organization"
+    class_name: ClassVar[str] = "Organization"
+    class_model_uri: ClassVar[URIRef] = PERSONINFO.Organization
+
+    id: Union[str, OrganizationId] = None
+    name: Optional[str] = None
+    part_of: Optional[Union[Union[str, OrganizationId], List[Union[str, OrganizationId]]]] = empty_list()
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self._is_empty(self.id):
+            self.MissingRequiredField("id")
+        if not isinstance(self.id, OrganizationId):
+            self.id = OrganizationId(self.id)
+
+        if self.name is not None and not isinstance(self.name, str):
+            self.name = str(self.name)
+
+        if not isinstance(self.part_of, list):
+            self.part_of = [self.part_of] if self.part_of is not None else []
+        self.part_of = [v if isinstance(v, OrganizationId) else OrganizationId(v) for v in self.part_of]
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass
+class Dataset(YAMLRoot):
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = PERSONINFO.Dataset
+    class_class_curie: ClassVar[str] = "personinfo:Dataset"
+    class_name: ClassVar[str] = "Dataset"
+    class_model_uri: ClassVar[URIRef] = PERSONINFO.Dataset
+
+    persons: Optional[Union[Dict[Union[str, PersonId], Union[dict, Person]], List[Union[dict, Person]]]] = empty_dict()
+    organizations: Optional[Union[Dict[Union[str, OrganizationId], Union[dict, Organization]], List[Union[dict, Organization]]]] = empty_dict()
+    pets: Optional[Union[Dict[Union[str, PetId], Union[dict, Pet]], List[Union[dict, Pet]]]] = empty_dict()
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        self._normalize_inlined_as_dict(slot_name="persons", slot_type=Person, key_name="id", keyed=True)
+
+        self._normalize_inlined_as_dict(slot_name="organizations", slot_type=Organization, key_name="id", keyed=True)
+
+        self._normalize_inlined_as_dict(slot_name="pets", slot_type=Pet, key_name="id", keyed=True)
+
+        super().__post_init__(**kwargs)
+
+
+# Enumerations
+
+
+# Slots
+class slots:
+    pass
+
+slots.person__id = Slot(uri=PERSONINFO.id, name="person__id", curie=PERSONINFO.curie('id'),
+                   model_uri=PERSONINFO.person__id, domain=None, range=URIRef)
+
+slots.person__name = Slot(uri=SCHEMA.name, name="person__name", curie=SCHEMA.curie('name'),
+                   model_uri=PERSONINFO.person__name, domain=None, range=Optional[str])
+
+slots.person__friends = Slot(uri=PERSONINFO.friends, name="person__friends", curie=PERSONINFO.curie('friends'),
+                   model_uri=PERSONINFO.person__friends, domain=None, range=Optional[Union[Union[str, PersonId], List[Union[str, PersonId]]]])
+
+slots.pet__id = Slot(uri=PERSONINFO.id, name="pet__id", curie=PERSONINFO.curie('id'),
+                   model_uri=PERSONINFO.pet__id, domain=None, range=URIRef)
+
+slots.pet__name = Slot(uri=SCHEMA.name, name="pet__name", curie=SCHEMA.curie('name'),
+                   model_uri=PERSONINFO.pet__name, domain=None, range=Optional[str])
+
+slots.pet__owner = Slot(uri=SCHEMA.owner, name="pet__owner", curie=SCHEMA.curie('owner'),
+                   model_uri=PERSONINFO.pet__owner, domain=None, range=Optional[Union[str, PersonId]])
+
+slots.organization__id = Slot(uri=PERSONINFO.id, name="organization__id", curie=PERSONINFO.curie('id'),
+                   model_uri=PERSONINFO.organization__id, domain=None, range=URIRef)
+
+slots.organization__name = Slot(uri=SCHEMA.name, name="organization__name", curie=SCHEMA.curie('name'),
+                   model_uri=PERSONINFO.organization__name, domain=None, range=Optional[str])
+
+slots.organization__part_of = Slot(uri=PERSONINFO.part_of, name="organization__part_of", curie=PERSONINFO.curie('part_of'),
+                   model_uri=PERSONINFO.organization__part_of, domain=None, range=Optional[Union[Union[str, OrganizationId], List[Union[str, OrganizationId]]]])
+
+slots.dataset__persons = Slot(uri=PERSONINFO.persons, name="dataset__persons", curie=PERSONINFO.curie('persons'),
+                   model_uri=PERSONINFO.dataset__persons, domain=None, range=Optional[Union[Dict[Union[str, PersonId], Union[dict, Person]], List[Union[dict, Person]]]])
+
+slots.dataset__organizations = Slot(uri=PERSONINFO.organizations, name="dataset__organizations", curie=PERSONINFO.curie('organizations'),
+                   model_uri=PERSONINFO.dataset__organizations, domain=None, range=Optional[Union[Dict[Union[str, OrganizationId], Union[dict, Organization]], List[Union[dict, Organization]]]])
+
+slots.dataset__pets = Slot(uri=PERSONINFO.pets, name="dataset__pets", curie=PERSONINFO.curie('pets'),
+                   model_uri=PERSONINFO.dataset__pets, domain=None, range=Optional[Union[Dict[Union[str, PetId], Union[dict, Pet]], List[Union[dict, Pet]]]])

--- a/tests/test_issues/test_linkml_issue_576.py
+++ b/tests/test_issues/test_linkml_issue_576.py
@@ -1,0 +1,49 @@
+import unittest
+from unittest import TestCase
+
+import rdflib
+from rdflib import RDF
+
+from linkml_runtime.dumpers import rdflib_dumper, yaml_dumper
+from linkml_runtime.loaders import yaml_loader, rdflib_loader
+from linkml_runtime.utils.schemaview import SchemaView
+
+from tests.test_issues.environment import env
+from tests.test_issues.models.linkml_issue_576 import Dataset
+
+class Issue576TestCase(TestCase):
+    """
+    https://github.com/linkml/linkml/issues/576
+    """
+    env = env
+
+    def test_issue_no_namespace(self):
+        view = SchemaView(env.input_path('linkml_issue_576.yaml'))
+        inst = yaml_loader.load(env.input_path('linkml_issue_576_data.yaml'), target_class=Dataset)
+        s = rdflib_dumper.dumps(inst, view, 'turtle', prefix_map={"@base": "http://example.org/default/"})
+        self.assertIn("@base <http://example.org/default/> .", s)
+        g = rdflib.Graph().parse(data=s, format='turtle')
+        #for t in g.triples((None, None, None)):
+        #    print(t)
+        cases = [
+            (rdflib.term.URIRef('http://example.org/default/org%201'),
+             rdflib.term.URIRef('http://schema.org/name'),
+             rdflib.term.Literal('Acme Inc. (US)')),
+            (rdflib.term.URIRef('https://example.org/P1'),
+             rdflib.term.URIRef('http://www.w3.org/1999/02/22-rdf-syntax-ns#type'),
+             rdflib.term.URIRef('http://schema.org/Person')),
+            (rdflib.term.URIRef('https://example.org/P1'),
+              rdflib.term.URIRef('http://schema.org/name'),
+              rdflib.term.Literal('John Doe')),
+        ]
+        for case in cases:
+            self.assertIn(case, g)
+        inst2 = rdflib_loader.load(g, target_class=Dataset, schemaview=view)
+        #print(yaml_dumper.dumps(inst2))
+        self.assertCountEqual(inst.persons, inst2.persons)
+        self.assertCountEqual(inst.organizations, inst2.organizations)
+        self.assertCountEqual(inst.pets, inst2.pets)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_loaders_dumpers/input/personinfo.yaml
+++ b/tests/test_loaders_dumpers/input/personinfo.yaml
@@ -237,6 +237,7 @@ slots:
   id:
     identifier: true
     slot_uri: schema:identifier
+    range: uriorcurie
   name:
     slot_uri: schema:name
   description:

--- a/tests/test_loaders_dumpers/input/personinfo_test_issue_429.yaml
+++ b/tests/test_loaders_dumpers/input/personinfo_test_issue_429.yaml
@@ -35,6 +35,7 @@ classes:
 slots:
   id:
     identifier: true
+    range: uriorcurie
   full_name:
   age:
   phone:


### PR DESCRIPTION
Fixes https://github.com/linkml/linkml/issues/576

This allows for controlling the bahvior of URI encoding
when a string identifier slot is used. Addition of a percent_encoded
annotation forces encoding plus the base URI
