### PR TITLE
Simplifying schemaview implementation of induced attributes.

### DIFF
--- a/tests/test_issues/test_linkml_runtime_issue_68.py
+++ b/tests/test_issues/test_linkml_runtime_issue_68.py
@@ -97,7 +97,7 @@ class Issue68TestCase(TestCase):
         s2_induced_c2 = view.induced_slot('slot2', 'class2')
         assert s2_induced_c2.required
         logging.info(f"s2_induced_c2.description: {s2_induced_c2.description}")
-        assert s2_induced_c2.description == "non-induced slot2"
+        assert s2_induced_c2.description == "induced slot2"
         assert s2_induced.range == 'class1'
 
         s3_induced_c2 = view.induced_slot('slot3', 'class2')
@@ -110,13 +110,13 @@ class Issue68TestCase(TestCase):
         s2_induced_c2_1a = view.induced_slot('slot2', 'class2_1a')
         assert not s2_induced_c2_1a.required
         logging.info(f"s2_induced_c2_1a.description: {s2_induced_c2_1a.description}")
-        assert s2_induced_c2_1a.description == "non-induced slot2"
+        assert s2_induced_c2_1a.description == "mixin slot2"
         assert s2_induced_c2_1a.range == 'mixin1a'
 
         s2_induced_c2_1b = view.induced_slot('slot2', 'class2_1b')
         assert not s2_induced_c2_1b.required
         logging.info(f"s2_induced_c2_1a.description: {s2_induced_c2_1b.description}")
-        assert s2_induced_c2_1b.description == "non-induced slot2"
+        assert s2_induced_c2_1b.description == "mixin slot2"
         assert s2_induced_c2_1b.range == 'mixin1b'
 
 

--- a/tests/test_utils/input/attribute_edge_cases.yaml
+++ b/tests/test_utils/input/attribute_edge_cases.yaml
@@ -1,0 +1,83 @@
+id: https://w3id.org/linkml/examples/
+name: attribute-example
+description: This demonstrates attribute edge cases
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+  ex: https://w3id.org/linkml/examples/patterns/
+  sh: https://w3id.org/shacl/
+
+default_prefix: ex
+default_range: string
+
+slots:
+  s1:
+    description: s1
+  s2:
+    description: s2
+  s3:
+    description: s3
+
+classes:
+
+  Root:
+    attributes:
+      a1:
+        description: a1
+      a2:
+        description: a2
+      a3:
+        description: a3
+    slots:
+      - s1
+      - s2
+      - s3
+  MixinRoot:
+    mixin: true
+    attributes:
+      a4:
+        description: a4
+  Mixin1:
+    mixin: true
+    is_a: MixinRoot
+    attributes:
+      m1:
+        description: m1
+    slot_usage:
+      a1:
+        required: true
+        description: a1m1
+  Mixin2:
+    mixin: true
+    is_a: MixinRoot
+    attributes:
+      m2:
+        description: m2
+    slot_usage:
+      a1:
+        required: false
+        description: a1m2
+      a4:
+        required: true
+        description: a4m2
+  C1:
+    is_a: Root
+    mixins:
+      - Mixin1
+    slot_usage:
+      a2:
+        required: true
+        description: a2c1
+  C2:
+    is_a: Root
+    mixins:
+      - Mixin2
+    slot_usage:
+      a2:
+        required: true
+        description: a2c2
+  C1x:
+    is_a: C1
+    slot_usage:
+      a2:
+        description: a2c1x

--- a/tests/test_utils/test_schemaview.py
+++ b/tests/test_utils/test_schemaview.py
@@ -494,11 +494,38 @@ class SchemaViewTestCase(unittest.TestCase):
         with self.assertRaises(ValueError):
             view.slot_ancestors('s5')
 
+    def test_attribute_inheritance(self):
+        """
+        Tests attribute inheritance edge cases
+        :return:
+        """
+        view = SchemaView(os.path.join(INPUT_DIR, 'attribute_edge_cases.yaml'))
+        expected = [
+            ('Root', 'a1', None, "a1"),
+            ('Root', 'a2', None, "a2"),
+            ('Root', 'a3', None, "a3"),
+            ('C1', 'a1', True, "a1m1"),
+            ('C1', 'a2', True, "a2c1"),
+            ('C1', 'a3', None, "a3"),
+            ('C1', 'a4', None, "a4"),
+            ('C2', 'a1', False, "a1m2"),
+            ('C2', 'a2', True, "a2c2"),
+            ('C2', 'a3', None, "a3"),
+            ('C2', 'a4', True, "a4m2"),
+            ('C1x', 'a1', True, "a1m1"),
+            ('C1x', 'a2', True, "a2c1x"),
+            ('C1x', 'a3', None, "a3"),
+            ('C1x', 'a4', None, "a4"),
+        ]
+        for cn, sn, req, desc in expected:
+            slot = view.induced_slot(sn, cn)
+            self.assertEqual(req, slot.required, f"in: {cn}.{sn}")
+            self.assertEqual(desc, slot.description, f"in: {cn}.{sn}")
+            self.assertEqual('string', slot.range, f"in: {cn}.{sn}")
+
     def test_ambiguous_attributes(self):
         """
         Tests behavior where multiple attributes share the same name
-
-        :return:
         """
         schema = SchemaDefinition(id='test', name='test')
         view = SchemaView(schema)


### PR DESCRIPTION
The algorithm for induced slots for (c,s) is now:

First, determine if s is an attribute on c or an ancestor;
- if it is, then use that as the basis for the induced slot
- otherwise, look up in the set of schema-level slots

apply slot_usage from ancestors as before
