### PR TITLE
Add methods to replace functionality in biolink model toolkit with schemaview

### DIFF
--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -602,9 +602,10 @@ class SchemaView(object):
         """
         children = []
         for e, el in self.all_elements().items():
-            if "is_a" in el and el["is_a"] == name:
-                children.append(el.name)
-            if "mixins" in el and mixin and name in el.mixins:
+            if isinstance(el, (ClassDefinition, SlotDefinition, EnumDefinition)):
+                if el.is_a and el.is_a == name:
+                    children.append(el.name)
+            if el.mixins and name in el.mixins:
                 children.append(el.name)
         return children
 

--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -946,7 +946,7 @@ class SchemaView(object):
         aliases = []
 
         for e, el in self.all_elements().items():
-            if "aliases" in el and el.aliases is not None:
+            if el.aliases and el.aliases is not None:
                 for alias in el.aliases:
                     aliases.append(alias)
         return aliases

--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -593,6 +593,22 @@ class SchemaView(object):
             return []
 
     @lru_cache()
+    def get_children(self, name: str, mixin: bool = True) -> List[str]:
+        """
+        get the children of an element (any class, slot, enum, type)
+        :param name: name of the parent element
+        :param mixin: include mixins
+        :return: list of child element
+        """
+        children = []
+        for e, el in self.all_elements().items():
+            if "is_a" in el and el["is_a"] == name:
+                children.append(el.name)
+            if "mixins" in el and mixin and name in el.mixins:
+                children.append(el.name)
+        return children
+
+    @lru_cache()
     def class_children(self, class_name: CLASS_NAME, imports=True, mixins=True, is_a=True) -> List[ClassDefinitionName]:
         """
         :param class_name: parent class name
@@ -928,9 +944,9 @@ class SchemaView(object):
         """
         aliases = []
 
-        for e in self.all_elements():
-            if e.aliases is not None:
-                for alias in e.aliases:
+        for e, el in self.all_elements().items():
+            if "aliases" in el and el.aliases is not None:
+                for alias in el.aliases:
                     aliases.append(alias)
         return aliases
 

--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -605,8 +605,8 @@ class SchemaView(object):
             if isinstance(el, (ClassDefinition, SlotDefinition, EnumDefinition)):
                 if el.is_a and el.is_a == name:
                     children.append(el.name)
-            if el.mixins and name in el.mixins:
-                children.append(el.name)
+                if mixin and el.mixins and name in el.mixins:
+                    children.append(el.name)
         return children
 
     @lru_cache()

--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -949,6 +949,9 @@ class SchemaView(object):
             if el.aliases and el.aliases is not None:
                 for alias in el.aliases:
                     aliases.append(alias)
+            if el.structured_aliases and el.structured_aliases is not None:
+                for alias in el.structured_aliases:
+                    aliases.append(alias.literal_form)
         return aliases
 
     @lru_cache()

--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -943,16 +943,19 @@ class SchemaView(object):
 
         :return: list of aliases
         """
-        aliases = []
+        element_aliases = {}
 
         for e, el in self.all_elements().items():
+            if el.name not in element_aliases.keys():
+                element_aliases[el.name] = []
             if el.aliases and el.aliases is not None:
-                for alias in el.aliases:
-                    aliases.append(alias)
+                for a in el.aliases:
+                    element_aliases[el.name].append(a)
             if el.structured_aliases and el.structured_aliases is not None:
-                for alias in el.structured_aliases:
-                    aliases.append(alias)
-        return aliases
+                for sa in el.structured_aliases:
+                    element_aliases[el.name].append(sa)
+
+        return element_aliases
 
     @lru_cache()
     def get_mappings(self, element_name: ElementName = None, imports=True, expand=False) -> Dict[

--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -920,6 +920,21 @@ class SchemaView(object):
         return applicable_elements
 
     @lru_cache()
+    def all_aliases(self) -> List[str]:
+        """
+        Get the aliases
+
+        :return: list of aliases
+        """
+        aliases = []
+
+        for e in self.all_elements():
+            if e.aliases is not None:
+                for alias in e.aliases:
+                    aliases.append(alias)
+        return aliases
+
+    @lru_cache()
     def get_mappings(self, element_name: ElementName = None, imports=True, expand=False) -> Dict[
         MAPPING_TYPE, List[URIorCURIE]]:
         """

--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -951,7 +951,7 @@ class SchemaView(object):
                     aliases.append(alias)
             if el.structured_aliases and el.structured_aliases is not None:
                 for alias in el.structured_aliases:
-                    aliases.append(alias.literal_form)
+                    aliases.append(alias)
         return aliases
 
     @lru_cache()

--- a/tests/test_utils/input/kitchen_sink_noimports.yaml
+++ b/tests/test_utils/input/kitchen_sink_noimports.yaml
@@ -96,6 +96,12 @@ classes:
     slot_usage:
       age in years:
         minimum_value: 16
+    structured_aliases:
+      dad:
+        predicate: EXACT_SYNONYM
+      mom:
+        predicate: EXACT_SYNONYM
+
 
   Organization:
     is_a: Thing

--- a/tests/test_utils/test_schemaview.py
+++ b/tests/test_utils/test_schemaview.py
@@ -41,6 +41,7 @@ class SchemaViewTestCase(unittest.TestCase):
         self.assertIn("identifier", aliases)
         self.assertIn("A", aliases)
         self.assertIn("B", aliases)
+        self.assertIn("dad", aliases)
         self.assertNotIn("test", aliases)
 
     def test_schemaview_enums(self):

--- a/tests/test_utils/test_schemaview.py
+++ b/tests/test_utils/test_schemaview.py
@@ -38,11 +38,12 @@ class SchemaViewTestCase(unittest.TestCase):
     def test_all_aliases(self):
         view = SchemaView(SCHEMA_NO_IMPORTS)
         aliases = view.all_aliases()
-        self.assertIn("identifier", aliases)
-        self.assertIn("A", aliases)
-        self.assertIn("B", aliases)
-        self.assertIn("dad", aliases)
-        self.assertNotIn("test", aliases)
+        print(aliases)
+        self.assertIn("identifier", aliases["id"])
+        self.assertIn("A", aliases["subset A"])
+        self.assertIn("B", aliases["subset B"])
+        self.assertIn("dad", aliases["Adult"])
+        self.assertNotIn("test", aliases["Adult"])
 
     def test_schemaview_enums(self):
         view = SchemaView(SCHEMA_NO_IMPORTS)

--- a/tests/test_utils/test_schemaview.py
+++ b/tests/test_utils/test_schemaview.py
@@ -27,7 +27,21 @@ ACTIVITY = 'activity'
 RELATED_TO = 'related to'
 AGE_IN_YEARS = 'age in years'
 
+
 class SchemaViewTestCase(unittest.TestCase):
+
+    def test_children_method(self):
+        view = SchemaView(SCHEMA_NO_IMPORTS)
+        children = view.get_children("Person")
+        self.assertEqual(children, ['Adult'])
+
+    def test_all_aliases(self):
+        view = SchemaView(SCHEMA_NO_IMPORTS)
+        aliases = view.all_aliases()
+        self.assertIn("identifier", aliases)
+        self.assertIn("A", aliases)
+        self.assertIn("B", aliases)
+        self.assertNotIn("test", aliases)
 
     def test_schemaview_enums(self):
         view = SchemaView(SCHEMA_NO_IMPORTS)


### PR DESCRIPTION
This includes two convenience methods: 
1) all_aliases (a method to return all aliases from any schema element), used in a [method in BMT](https://github.com/biolink/biolink-model-toolkit/blob/4f93dd1be7327bcad3654283856c1ef5872413ae/bmt/toolkit.py#L443) to check which element a user is looking for when they ask by name.
2) get_children (for any element, not specifically a class, slot, etc.)
https://github.com/biolink/biolink-model-toolkit/blob/4f93dd1be7327bcad3654283856c1ef5872413ae/bmt/toolkit.py#L368