### PR TITLE
Added a ReferenceValidator that performs complete normalizations.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,3 +11,7 @@ update_model:
 
 test:
 	poetry run python -m unittest discover
+
+# temporary measure until linkml-model is synced
+linkml_runtime/processing/validation_datamodel.py: linkml_runtime/processing/validation_datamodel.yaml
+	gen-python $< > $@.tmp && mv $@.tmp $@

--- a/linkml_runtime/processing/referencevalidator.py
+++ b/linkml_runtime/processing/referencevalidator.py
@@ -1,0 +1,995 @@
+import decimal
+import re
+import sys
+from copy import copy
+from dataclasses import dataclass, field
+import datetime
+from decimal import Decimal
+from enum import Enum
+from typing import Any, Optional, List, Tuple, Union, Iterator, TextIO
+
+import click
+import yaml
+
+from linkml_runtime import SchemaView
+from linkml_runtime.dumpers import yaml_dumper
+from linkml_runtime.linkml_model import (
+    SlotDefinition,
+    ClassDefinition,
+    EnumDefinition,
+    TypeDefinition,
+    Element,
+    SchemaDefinition,
+    SlotDefinitionName,
+)
+from linkml_runtime.linkml_model.meta import (
+    AnonymousClassExpression,
+    AnonymousSlotExpression,
+    ClassRule,
+    ClassDefinitionName,
+)
+from linkml_runtime.processing.validation_datamodel import (
+    ConstraintType,
+    ValidationResult,
+)
+from linkml_runtime.utils import yamlutils
+from linkml_runtime.utils.eval_utils import eval_expr
+from linkml_runtime.utils.metamodelcore import (
+    XSDTime,
+    Bool,
+    XSDDate,
+    URIorCURIE,
+    URI,
+    NCName,
+    ElementIdentifier,
+    NodeIdentifier,
+)
+
+
+# Mapping from either XSD types or LinkML type.base fields to Python types;
+# (the coerced type is the last element of the tuple, the others are
+# acceptable types)
+XSD_OR_BASE_TO_PYTHON = {
+    # Base type mapping (first)
+    "URIorCURIE": (str, yamlutils.extended_str, URIorCURIE),
+    "URI": (str, yamlutils.extended_str, URI),
+    "NCName": (str, yamlutils.extended_str, NCName),
+    "ElementIdentifier": (str, yamlutils.extended_str, ElementIdentifier),
+    "NodeIdentifier": (str, yamlutils.extended_str, NodeIdentifier),
+    # XSD type mapping (second)
+    "xsd:string": str,
+    "xsd:integer": int,
+    "xsd:float": float,
+    "xsd:boolean": (bool, Bool),
+    "xsd:double": float,
+    "xsd:decimal": Decimal,
+    "xsd:dateTime": (str, datetime.datetime, datetime.time, XSDTime),
+    "xsd:date": (str, datetime.date, XSDDate),
+    "xsd:time": XSDTime,
+}
+
+
+class CollectionForm(Enum):
+    """Form of a schema element.
+    See Part 6 of the LinkML specification"""
+
+    NonCollection = "NonCollection"
+    ExpandedDict = "ExpandedDict"
+    CompactDict = "CompactDict"
+    SimpleDict = "SimpleDict"
+    List = "List"
+
+
+COLLECTION_FORM_NORMALIZATION = Tuple[CollectionForm, CollectionForm]
+COLLECTION_FORM_ANNOTATION_KEY = "collection_form"
+
+
+@dataclass
+class Normalization:
+    """A transformation of a schema element"""
+
+
+@dataclass
+class CollectionFormNormalization(Normalization):
+    input_form: CollectionForm = None
+    output_form: CollectionForm = None
+
+
+@dataclass
+class TypeNormalization(Normalization):
+    input_form: str = None
+    output_form: str = None
+
+
+@dataclass
+class Report:
+    """A report of validation results"""
+
+    results: List[ValidationResult] = field(default_factory=lambda: [])
+    normalizations: List[Normalization] = field(default_factory=lambda: [])
+
+    def combine(self, other: "Report") -> "Report":
+        self.results.extend(other.results)
+        return self
+
+    def add_normalization(
+        self,
+        problem_type: ConstraintType,
+        before: CollectionForm,
+        after: CollectionForm,
+    ):
+        result = ValidationResult(type=ConstraintType.SlotConstraint)
+        norm = CollectionFormNormalization(input_form=before, output_form=after)
+        # result.repairs.append(norm)
+        result.normalized = True
+        result.repaired = True
+        self.results.append(result)
+        self.normalizations.append(norm)
+
+    def add_type_normalization(self, before: str, after: str):
+        result = ValidationResult(type=ConstraintType.TypeConstraint)
+        norm = TypeNormalization(input_form=before, output_form=after)
+        # result.repairs.append(norm)
+        result.normalized = True
+        result.repaired = True
+        self.results.append(result)
+        self.normalizations.append(norm)
+
+    def add_problem(
+        self,
+        problem_type: ConstraintType,
+        instantiates: str,
+        subject: Any,
+        predicate: Optional[str] = None,
+        **kwargs,
+    ):
+        result = ValidationResult(
+            type=problem_type,
+            instantiates=instantiates,
+            subject=str(subject),
+            predicate=predicate,
+            **kwargs,
+        )
+        locator = None
+        if isinstance(subject, yamlutils.TypedNode):
+            locator = subject
+        elif isinstance(predicate, yamlutils.TypedNode):
+            locator = predicate
+        if locator and locator._s:
+            result.source_line_number = locator._s.line
+            result.source_column_number = locator._s.column
+            result.source_location = locator.yaml_loc()
+        self.results.append(result)
+
+    def unrepaired(self) -> List[ValidationResult]:
+        return [r for r in self.results if not r.normalized]
+
+    def unrepaired_problem_types(self) -> List[ConstraintType]:
+        return [r.type for r in self.unrepaired()]
+
+    def repaired(self) -> List[ValidationResult]:
+        return [r for r in self.results if r.normalized]
+
+    def collection_form_normalizations(
+        self,
+    ) -> Iterator[Tuple[CollectionForm, CollectionForm]]:
+        for norm in self.normalizations:
+            if isinstance(norm, CollectionFormNormalization):
+                yield norm.input_form, norm.output_form
+
+
+def _remove_pk(obj: dict, pk_slot_name: str) -> dict:
+    """Make a new CompactDict ready copy of a dict, removing the pk_slot_name"""
+    if pk_slot_name in obj:
+        obj = copy(obj)
+        del obj[pk_slot_name]
+    return obj
+
+
+def _add_pk(obj: dict, pk_slot_name: str, pk_val: Any) -> dict:
+    """Make a new ExpandedDict ready copy of a dict, adding the pk_slot_name"""
+    if pk_slot_name not in obj:
+        obj = copy(obj)
+        obj[pk_slot_name] = pk_val
+    return obj
+
+
+def _simple_to_dict(obj: Union[dict, Any], simple_value_slot_name: str) -> dict:
+    """Make a new Dict from a simple value"""
+    if isinstance(obj, dict):
+        return obj
+    return {simple_value_slot_name: obj}
+
+
+@dataclass
+class ReferenceValidator:
+    """
+    An engine that performs combined normalization and validation of instances according to a schema
+    """
+
+    schemaview: SchemaView
+    """View over source schema"""
+
+    derived_schema: SchemaDefinition = None
+    """Schema derived following part 4 of LinkML specification"""
+
+    filter_invalid_objects: bool = False
+    """If True, then remove any invalid objects from the tree"""
+
+    auto_type_designator: Optional[str] = None
+    """Set to equal "@type" for JSON-LD serialization"""
+
+    skip_validation: bool = None
+    """If True, then only perform normalization, not validation"""
+
+    skip_normalization: bool = None
+    """If True, then only perform validation, not normalization"""
+
+    def __post_init__(self):
+        self.derived_schema = self.schemaview.materialize_derived_schema()
+
+    def validate(self, input_object: Any, target: Optional[str] = None) -> Report:
+        """
+        Validate an instance according to the schema
+
+        :param input_object:
+        :param target:
+        :return:
+        """
+        parent_slot = self._create_index_slot(target, input_object)
+        report = Report()
+        self.normalize_slot_value(input_object, parent_slot, report)
+        return report
+
+    def normalize(
+        self,
+        input_object: Any,
+        target: Optional[str] = None,
+        report: Optional[Report] = None,
+    ) -> Any:
+        """
+        Normalize an instance according to the schema
+
+        :param input_object:
+        :param target:
+        :param report:
+        :return:
+        """
+        parent_slot = self._create_index_slot(target, input_object)
+        if report is None:
+            report = Report()
+        return self.normalize_slot_value(input_object, parent_slot, report)
+
+    def _create_index_slot(
+        self, target: Optional[str] = None, input_object: Any = None
+    ) -> SlotDefinition:
+        """
+        Create a parent slot that points at the target element.
+
+        :param target:
+        :param input_object:
+        :return:
+        """
+        target = self._schema_root(target)
+        slot = SlotDefinition(name="temp", range=target)
+        if input_object is None or isinstance(input_object, dict):
+            slot.inlined = True
+        elif isinstance(input_object, list):
+            slot.inlined = True
+            slot.inlined_as_list = True
+            slot.multivalued = True
+        return slot
+
+    def _schema_root(
+        self, target: Optional[str] = None
+    ) -> Optional[ClassDefinitionName]:
+        if target is not None:
+            return ClassDefinitionName(target)
+        roots = [r.name for r in self.derived_schema.classes.values() if r.tree_root]
+        if len(roots) != 1:
+            raise ValueError(f"Cannot normalize: {len(roots)} roots found")
+        return roots[0]
+
+    def normalize_slot_value(
+        self, input_object: Any, parent_slot: SlotDefinition, report: Report
+    ) -> Any:
+        pk_slot_name = None
+        range_element = self._slot_range_element(parent_slot)
+        # Infer collection form, and normalize to this form, if necessary
+        form = self.infer_slot_collection_form(parent_slot)
+        normalized_object = copy(input_object)
+        if isinstance(range_element, ClassDefinition):
+            pk_slot_name = self._identifier_slot_name(range_element)
+        normalized_object = self.normalize_to_collection_from(
+            form, normalized_object, parent_slot, pk_slot_name, report
+        )
+        # Validate
+        new_report = Report()
+        if parent_slot.required and not normalized_object:
+            report.add_problem(
+                ConstraintType.RequiredConstraint, parent_slot.range, str(input_object)
+            )
+        if parent_slot.recommended and not normalized_object:
+            report.add_problem(
+                ConstraintType.RecommendedConstraint,
+                parent_slot.range,
+                str(input_object),
+            )
+        simple_dict_value_slot = self._slot_as_simple_dict_value_slot(parent_slot)
+        if isinstance(normalized_object, dict) and parent_slot.multivalued:
+            if not simple_dict_value_slot:
+                output_object = {
+                    k: self.normalize_instance(v, parent_slot, new_report)
+                    for k, v in normalized_object.items()
+                }
+            else:
+                output_object = {
+                    k: self.normalize_instance(v, simple_dict_value_slot, new_report)
+                    for k, v in normalized_object.items()
+                }
+        elif isinstance(normalized_object, list):
+            output_object = [
+                self.normalize_instance(v, parent_slot, new_report)
+                for v in normalized_object
+            ]
+        else:
+            output_object = self.normalize_instance(
+                normalized_object, parent_slot, new_report
+            )
+        report.combine(new_report)
+        return output_object
+
+    def _is_dict_collection(
+        self, input_object: Any, parent_slot: SlotDefinition
+    ) -> bool:
+        if not isinstance(input_object, dict):
+            return False
+        if not parent_slot.multivalued:
+            return False
+        if parent_slot.inlined:
+            return False
+        if self.auto_type_designator and self.auto_type_designator in input_object:
+            return False
+        return True
+
+    def infer_slot_collection_form(self, parent_slot: SlotDefinition) -> CollectionForm:
+        if COLLECTION_FORM_ANNOTATION_KEY in parent_slot.annotations:
+            v = parent_slot.annotations[COLLECTION_FORM_ANNOTATION_KEY].value
+            if v:
+                return CollectionForm[v]
+        if not parent_slot.multivalued:
+            return CollectionForm.NonCollection
+        if not parent_slot.inlined:
+            return CollectionForm.List
+        if parent_slot.inlined_as_list:
+            return CollectionForm.List
+        simple_dict_value_slot = self._slot_as_simple_dict_value_slot(parent_slot)
+        if simple_dict_value_slot:
+            return CollectionForm.SimpleDict
+        # TODO: provide direct metamodel method
+        if (
+            "expanded" in parent_slot.annotations
+            and parent_slot.annotations["expanded"].value
+        ):
+            return CollectionForm.ExpandedDict
+        return CollectionForm.CompactDict
+
+    def normalize_to_collection_from(
+        self,
+        form: CollectionForm,
+        input_object: Any,
+        slot: SlotDefinition,
+        pk_slot_name: SlotDefinitionName,
+        report: Report,
+    ) -> Any:
+        if form == CollectionForm.NonCollection:
+            return self.ensure_non_collection(input_object, slot, pk_slot_name, report)
+        elif form == CollectionForm.List:
+            return self.ensure_list(input_object, slot, pk_slot_name, report)
+        elif form == CollectionForm.ExpandedDict:
+            return self.ensure_expanded_dict(input_object, slot, pk_slot_name, report)
+        elif form == CollectionForm.CompactDict:
+            return self.ensure_compact_dict(input_object, slot, pk_slot_name, report)
+        elif form == CollectionForm.SimpleDict:
+            return self.ensure_simple_dict(input_object, slot, pk_slot_name, report)
+        else:
+            raise AssertionError(f"{form} unrecognized")
+
+    def ensure_non_collection(
+        self,
+        input_object: Any,
+        parent_slot: SlotDefinition,
+        pk_slot_name: SlotDefinitionName,
+        report: Report,
+    ) -> Any:
+        if isinstance(input_object, list):
+            # List -> Atom
+            report.add_normalization(
+                ConstraintType.SingleValuedConstraint,
+                CollectionForm.List,
+                CollectionForm.NonCollection,
+            )
+            if len(input_object) == 0:
+                return None
+            return input_object[0]
+        if self._is_dict_collection(input_object, parent_slot):
+            # Dict -> Atom
+            report.add_normalization(
+                ConstraintType.SingleValuedConstraint,
+                CollectionForm.ExpandedDict,
+                CollectionForm.NonCollection,
+            )
+            return list(input_object.values())[0]
+        return input_object
+
+    def ensure_list(
+        self,
+        input_object: Any,
+        parent_slot: SlotDefinition,
+        pk_slot_name: SlotDefinitionName,
+        report: Report,
+    ) -> Any:
+        if not isinstance(input_object, (list, dict)):
+            # Atom -> List
+            report.add_normalization(
+                ConstraintType.MultiValuedConstraint,
+                CollectionForm.NonCollection,
+                CollectionForm.List,
+            )
+            return [input_object]
+        if isinstance(input_object, dict):
+            # Dict -> List
+            def _obj_from_item(k, v):
+                if pk_slot_name:
+                    v = copy(v)
+                    if pk_slot_name in input_object and input_object[pk_slot_name] != k:
+                        # TODO: account for this differently
+                        report.add_normalization(
+                            ConstraintType.ListCollectionFormConstraint,
+                            CollectionForm.ExpandedDict,
+                            CollectionForm.ExpandedDict,
+                        )
+                    v[str(pk_slot_name)] = k
+                return v
+
+            report.add_normalization(
+                ConstraintType.ListCollectionFormConstraint,
+                CollectionForm.ExpandedDict,
+                CollectionForm.List,
+            )
+            return [_obj_from_item(k, v) for k, v in list(input_object.items())]
+        return input_object
+
+    def ensure_expanded_dict(
+        self,
+        input_object: Any,
+        parent_slot: SlotDefinition,
+        pk_slot_name: SlotDefinitionName,
+        report: Report,
+    ) -> Any:
+        if isinstance(input_object, list):
+            # List -> Dict
+            report.add_normalization(
+                ConstraintType.DictCollectionFormConstraint,
+                CollectionForm.List,
+                CollectionForm.ExpandedDict,
+            )
+            return {v.get(pk_slot_name): v for v in input_object}
+        if isinstance(input_object, dict):
+            simple_dict_value_slot = self._slot_as_simple_dict_value_slot(parent_slot)
+            if simple_dict_value_slot and any(
+                v
+                for v in input_object.values()
+                if v is not None and not isinstance(v, dict)
+            ):
+                # SimpleDict -> ExpandedDict
+                report.add_normalization(
+                    ConstraintType.DictCollectionFormConstraint,
+                    CollectionForm.SimpleDict,
+                    CollectionForm.ExpandedDict,
+                )
+                return {
+                    k: _add_pk(
+                        _simple_to_dict(v, simple_dict_value_slot.name), pk_slot_name, k
+                    )
+                    for k, v in input_object.items()
+                }
+            else:
+                # {ExpandedDict, CompactDict} -> ExpandedDict
+                return {k: _add_pk(v, pk_slot_name, k) for k, v in input_object.items()}
+
+    def ensure_compact_dict(
+        self,
+        input_object: Any,
+        parent_slot: SlotDefinition,
+        pk_slot_name: SlotDefinitionName,
+        report: Report,
+    ) -> Any:
+        if isinstance(input_object, list):
+            # List -> Dict
+            report.add_normalization(
+                ConstraintType.DictCollectionFormConstraint,
+                CollectionForm.List,
+                CollectionForm.CompactDict,
+            )
+            return {
+                v.get(pk_slot_name): _remove_pk(v, pk_slot_name) for v in input_object
+            }
+        elif isinstance(input_object, dict):
+            if pk_slot_name and any(
+                v
+                for k, v in input_object.items()
+                if isinstance(v, dict) and v.get(pk_slot_name, None) is not None
+            ):
+                report.add_normalization(
+                    ConstraintType.DictCollectionFormConstraint,
+                    CollectionForm.ExpandedDict,
+                    CollectionForm.CompactDict,
+                )
+                return {k: _remove_pk(v, pk_slot_name) for k, v in input_object.items()}
+            else:
+                return input_object
+        else:
+            report.add_normalization(
+                ConstraintType.DictCollectionFormConstraint,
+                CollectionForm.List,
+                CollectionForm.CompactDict,
+            )
+            return input_object
+
+    def ensure_simple_dict(
+        self,
+        input_object: Any,
+        parent_slot: SlotDefinition,
+        pk_slot_name: SlotDefinitionName,
+        report: Report,
+    ) -> Any:
+        simple_dict_value_slot = self._slot_as_simple_dict_value_slot(parent_slot)
+        if not simple_dict_value_slot:
+            raise AssertionError(
+                f"Should have simple dict slot valie: {parent_slot.name}"
+            )
+        normalized_object = input_object
+        if isinstance(input_object, list):
+            normalized_object = {v[pk_slot_name]: v for v in input_object}
+            original_form = CollectionForm.List
+        else:
+            original_form = CollectionForm.ExpandedDict
+        # Dict -> SimpleDict
+        new_normalized_object = {}
+        simplified = False
+        for k, v in normalized_object.items():
+            if isinstance(v, dict):
+                v_as_simple = self.normalize_slot_value(
+                    v.get(simple_dict_value_slot.name), simple_dict_value_slot, report
+                )
+                new_normalized_object[k] = v_as_simple
+                simplified = True
+        if simplified:
+            report.add_normalization(
+                ConstraintType.SimpleDictCollectionFormConstraint,
+                original_form,
+                CollectionForm.SimpleDict,
+            )
+            normalized_object = new_normalized_object
+        elif original_form == CollectionForm.List:
+            report.add_normalization(
+                ConstraintType.SimpleDictCollectionFormConstraint,
+                original_form,
+                CollectionForm.SimpleDict,
+            )
+        return normalized_object
+
+    def normalize_instance(
+        self, input_object: Any, parent_slot: SlotDefinition, report: Report
+    ) -> Any:
+        range_element = self._slot_range_element(parent_slot)
+        if input_object is None:
+            return None
+        if isinstance(range_element, ClassDefinition):
+            if parent_slot.inlined:
+                if isinstance(input_object, dict):
+                    return self.normalize_object(input_object, range_element, report)
+                else:
+                    report.add_problem(
+                        ConstraintType.DictCollectionFormConstraint,
+                        parent_slot.range,
+                        input_object,
+                        predicate=parent_slot.name,
+                    )
+                    return input_object
+            else:
+                return self.normalize_reference(input_object, range_element, report)
+        elif isinstance(range_element, EnumDefinition):
+            return self.normalize_enum(input_object, range_element, report)
+        elif isinstance(range_element, TypeDefinition):
+            return self.normalize_type(input_object, range_element, report, parent_slot)
+        else:
+            raise ValueError(f"Cannot normalize: unknown range {parent_slot.range}")
+
+    def normalize_reference(
+        self, input_object: dict, target: ClassDefinition, report: Report
+    ) -> dict:
+        pk_slot = self._identifier_slot(target)
+        if pk_slot is None:
+            raise AssertionError(f"Cannot normalize: no primary key for {target.name}")
+        return self.normalize_type(
+            input_object, self.derived_schema.types[pk_slot.range], report
+        )
+
+    def normalize_object(
+        self, input_object: dict, target: ClassDefinition, report: Report
+    ) -> dict:
+        if not isinstance(input_object, dict):
+            raise AssertionError(
+                f"Cannot normalize: expected dict, got {type(input_object)} for {input_object}"
+            )
+        output_object = {}
+        # Induced slot
+        for slot in target.attributes.values():
+            # TODO: required slots MUST be present UNLESS this is a CompactDict
+            if (
+                slot.required
+                and slot.alias not in input_object
+                and not (slot.identifier or slot.key)
+            ):
+                report.add_problem(
+                    ConstraintType.RequiredConstraint,
+                    slot.name,
+                    input_object,
+                    predicate=target.name,
+                )
+            if (
+                slot.recommended
+                and slot.alias not in input_object
+                and not (slot.identifier or slot.key)
+            ):
+                report.add_problem(
+                    ConstraintType.RecommendedConstraint,
+                    slot.name,
+                    input_object,
+                    predicate=target.name,
+                )
+            if slot.designates_type and slot.name in input_object:
+                induced_class_name = self._class_name_from_value(
+                    input_object[slot.name], slot.range
+                )
+                new_target = self.derived_schema.classes[induced_class_name]
+                if not self.subsumes(target, new_target):
+                    report.add_problem(
+                        ConstraintType.DesignatesTypeConstraint,
+                        slot.name,
+                        new_target.name,
+                    )
+                target = new_target
+        # deepen using classification rules
+        for desc_cn in self.schemaview.class_descendants(target.name, reflexive=False):
+            desc = self.derived_schema.classes[desc_cn]
+            for expr in desc.classification_rules:
+                if self._matches_class_expression(input_object, target, expr):
+                    target = desc
+                    break
+        # Descend into slot values
+        for k, v in input_object.items():
+            actual_k = None
+            if k in target.attributes:
+                actual_k = k
+            else:
+                for a in target.attributes.values():
+                    if a.alias == k:
+                        actual_k = a.name
+                        break
+            if actual_k is None:
+                report.add_problem(
+                    ConstraintType.ClosedClassConstraint,
+                    instantiates=target.name,
+                    subject=input_object,
+                    predicate=k,
+                )
+                if not self.filter_invalid_objects:
+                    output_object[k] = v
+                continue
+            slot = target.attributes[actual_k]
+            output_object[k] = self.normalize_slot_value(v, slot, report)
+            if not self._matches_slot_expression(output_object[k], slot, output_object):
+                report.add_problem(
+                    ConstraintType.ExpressionConstraint, target.name, output_object[k]
+                )
+        for rule in target.rules:
+            self.evaluate_rule(output_object, rule, report)
+        return output_object
+
+    def normalize_enum(
+        self, input_object: Any, target: EnumDefinition, report: Report
+    ) -> Any:
+        if input_object not in target.permissible_values:
+            report.add_problem(
+                ConstraintType.PermissibleValueConstraint, target.name, input_object
+            )
+        return input_object
+
+    def normalize_type(
+        self,
+        input_object: Any,
+        target: TypeDefinition,
+        report: Report,
+        parent_slot: SlotDefinition = None,
+    ) -> Any:
+        if input_object is None:
+            return None
+        output_value = input_object
+        if target.base in XSD_OR_BASE_TO_PYTHON:
+            expected_python_type = XSD_OR_BASE_TO_PYTHON[target.base]
+        elif target.uri in XSD_OR_BASE_TO_PYTHON:
+            expected_python_type = XSD_OR_BASE_TO_PYTHON[target.uri]
+        else:
+            report.add_problem(
+                ConstraintType.UnmappedTypeConstraint, target.name, input_object
+            )
+            return output_value
+        current_python_type = type(input_object)
+        if isinstance(expected_python_type, tuple):
+            expected_python_types = list(expected_python_type)
+            normalize_func = expected_python_types[-1]
+            cast_func = expected_python_types[0]
+            if current_python_type in expected_python_types[:-1]:
+                try:
+                    output_value = cast_func(normalize_func(input_object))
+                except Exception as e:
+                    report.add_problem(
+                        ConstraintType.TypeConstraint,
+                        target.name,
+                        input_object,
+                        info=f"Coercion failed for {normalize_func}: {e}",
+                    )
+        else:
+            normalize_func = expected_python_type
+            cast_func = None
+            expected_python_types = [expected_python_type]
+        if current_python_type == yamlutils.extended_str:
+            current_python_type = str
+        if current_python_type not in expected_python_types:
+            try:
+                output_value = normalize_func(input_object)
+                if cast_func is not None:
+                    output_value = cast_func(output_value)
+                report.add_type_normalization(
+                    current_python_type.__name__, expected_python_types[0].__name__
+                )
+            except (ValueError, decimal.InvalidOperation) as e:
+                problem = ValidationResult(
+                    ConstraintType.TypeConstraint,
+                    instantiates=target.name,
+                    subject=input_object,
+                    info=f"unable to coerce {current_python_type.__name__} to {target.uri}: {e}",
+                )
+                report.results.append(problem)
+        # validation
+        if parent_slot:
+            if (
+                parent_slot.maximum_value is not None
+                and output_value > parent_slot.maximum_value
+            ):
+                report.add_problem(
+                    ConstraintType.MaximumValueConstraint, target.name, input_object
+                )
+            if (
+                parent_slot.minimum_value is not None
+                and output_value < parent_slot.minimum_value
+            ):
+                report.add_problem(
+                    ConstraintType.MinimumValueConstraint, target.name, input_object
+                )
+            if parent_slot.pattern is not None:
+                if not re.match(parent_slot.pattern, output_value):
+                    report.add_problem(
+                        ConstraintType.PatternConstraint, target.name, input_object
+                    )
+            if parent_slot.equals_string is not None:
+                if output_value != parent_slot.equals_string:
+                    report.add_problem(
+                        ConstraintType.ExpressionConstraint, target.name, input_object
+                    )
+        return output_value
+
+    def evaluate_rule(
+        self, input_object: dict, rule: ClassRule, report: Report
+    ) -> None:
+        for cond in rule.preconditions:
+            if not self._matches_class_expression(
+                input_object.get(cond.slot, None), cond, input_object
+            ):
+                return
+        for cond in rule.postconditions:
+            if not self._matches_class_expression(
+                input_object.get(cond.slot, None), cond, input_object
+            ):
+                report.add_problem(ConstraintType.RuleViolation, rule.name)
+                return
+
+    def subsumes(self, parent: ClassDefinition, child: ClassDefinition):
+        return parent.name in self.schemaview.class_ancestors(
+            child.name, reflexive=True
+        )
+
+    def _slot_range_element(self, slot: SlotDefinition) -> Element:
+        ds = self.derived_schema
+        sr = slot.range
+        if sr in ds.classes:
+            return ds.classes[sr]
+        elif sr in ds.enums:
+            return ds.enums[sr]
+        elif sr in ds.types:
+            return ds.types[sr]
+        else:
+            raise ValueError(f"Undefined range {sr}")
+
+    def _slot_collection_form(self, slot: SlotDefinition) -> CollectionForm:
+        if not slot.multivalued:
+            return CollectionForm.NonCollection
+        if slot.inlined_as_list:
+            return CollectionForm.List
+        if not slot.inlined:
+            return CollectionForm.List
+        range_element = self._slot_range_element(slot)
+        if not isinstance(range_element, ClassDefinition):
+            raise AssertionError(f"Should be non-inlined: {slot.name}")
+        if self._slot_as_simple_dict_value_slot(slot):
+            return CollectionForm.SimpleDict
+        if self._slot_inlined_as_compact_dict(slot):
+            return CollectionForm.CompactDict
+        return CollectionForm.ExpandedDict
+
+    def _slot_inlined_as_compact_dict(self, slot: SlotDefinition) -> bool:
+        if not slot.inlined:
+            return False
+        if slot.inlined_as_list:
+            return False
+        if self._slot_as_simple_dict_value_slot(slot):
+            return False
+        # TODO: make this configurable
+        return True
+
+    def _slot_as_simple_dict_value_slot(
+        self, slot: SlotDefinition
+    ) -> Optional[SlotDefinition]:
+        if not slot.inlined or slot.inlined_as_list:
+            return False
+        range_element = self._slot_range_element(slot)
+        if isinstance(range_element, ClassDefinition):
+            non_pk_atts = [
+                s
+                for s in range_element.attributes.values()
+                if not s.identifier and not s.key
+            ]
+            if len(non_pk_atts) == 1:
+                return non_pk_atts[0]
+
+    def _identifier_slot_name(
+        self, cls: ClassDefinition
+    ) -> Optional[SlotDefinitionName]:
+        for slot in cls.attributes.values():
+            if slot.identifier:
+                return slot.name
+            if slot.key:
+                return slot.name
+
+    def _identifier_slot(self, cls: ClassDefinition) -> Optional[SlotDefinition]:
+        for slot in cls.attributes.values():
+            if slot.identifier:
+                return slot
+            if slot.key:
+                return slot
+
+    def _class_name_from_value(self, slot_value: Any, slot_range: str) -> str:
+        if slot_range == "curie":
+            return slot_value.split(":")[0]
+        elif slot_range == "uriorcurie":
+            raise NotImplementedError
+        else:
+            return str(slot_value)
+
+    def _matches_class_expression(
+        self,
+        input_object: dict,
+        target: ClassDefinition,
+        expr: AnonymousClassExpression,
+    ) -> bool:
+        if expr.is_a:
+            if expr.is_a not in self.schemaview.class_ancestors(
+                target.name, reflexive=True
+            ):
+                return False
+            for slot_name, slot_expression in expr.slot_conditions.items():
+                v = input_object.get(slot_name, None)
+                if not self._matches_slot_expression(v, slot_expression, input_object):
+                    return False
+        return True
+
+    def _matches_slot_expression(
+        self,
+        slot_value: Any,
+        expr: Union[SlotDefinition, AnonymousSlotExpression],
+        input_object: dict,
+    ) -> bool:
+        for x in expr.none_of:
+            if self._matches_slot_expression(slot_value, x, input_object):
+                return False
+        if expr.exactly_one_of:
+            vals = [
+                x
+                for x in expr.exactly_one_of
+                if self._matches_slot_expression(slot_value, x, input_object)
+            ]
+            if len(vals) != 1:
+                return False
+        if expr.any_of:
+            vals = [
+                x
+                for x in expr.any_of
+                if self._matches_slot_expression(slot_value, x, input_object)
+            ]
+            if not vals:
+                return False
+        for x in expr.all_of:
+            if not self._matches_slot_expression(slot_value, x, input_object):
+                return False
+        if expr.equals_expression:
+            if eval_expr(expr.equals_expression, **input_object) != slot_value:
+                return False
+        if expr.equals_string:
+            if str(slot_value) != expr.equals_string:
+                return False
+        if expr.equals_number:
+            if slot_value != x.equals_number:
+                return False
+        return True
+
+
+@click.command
+@click.option("--schema", "-s", required=True)
+@click.option("--target", "-C")
+@click.option("--output", "-o", type=click.File("w"), default=sys.stdout)
+@click.argument("input")
+def cli(schema: str, target: str, input: str, output: TextIO) -> None:
+    """
+    Normalizes and validates a YAML document against a schema.
+
+    Normalization is a mix of casting types (e.g. "5" to 5), as well as
+    LinkML *collection forms*, e.g. ExpandedDict to CompactDict.
+
+    Validations is performed using a derived schema, as per part 5 of the specification.
+
+    Note that in future this will be folded into the main linkml-validate command.
+
+    Currently this CLI lacks features such as the ability to customize which
+    severity rules to fail on.
+
+    :param schema:
+    :param target:
+    :param input:
+    :param output:
+    :return:
+    """
+    sv = SchemaView(schema)
+    normalizer = ReferenceValidator(sv)
+    with open(input) as f:
+        input_object = yaml.safe_load(f)
+    report = Report()
+    output_object = normalizer.normalize(input_object, target=target, report=report)
+    if report.repaired():
+        sys.stderr.write("# Repaired:\n")
+        for r in report.repaired():
+            sys.stderr.write(yaml_dumper.dumps(r))
+    if report.unrepaired():
+        sys.stderr.write("# Unrepaired:\n")
+        for r in report.unrepaired():
+            sys.stderr.write(yaml_dumper.dumps(r))
+        sys.exit(1)
+    # TODO: https://stackoverflow.com/questions/45004464/yaml-dump-adding-unwanted-newlines-in-multiline-strings
+    output_str = yaml.dump(output_object, sort_keys=False)
+    output.write(output_str)
+
+
+if __name__ == "__main__":
+    cli()

--- a/linkml_runtime/processing/validation_datamodel.py
+++ b/linkml_runtime/processing/validation_datamodel.py
@@ -1,0 +1,544 @@
+# Auto generated from validation_datamodel.yaml by pythongen.py version: 0.9.0
+# Generation date: 2023-01-27T10:37:33
+# Schema: validaton-results
+#
+# id: https://w3id.org/linkml/validation_results
+# description: A datamodel for data validation results.
+# license: https://creativecommons.org/publicdomain/zero/1.0/
+
+import dataclasses
+import sys
+import re
+from jsonasobj2 import JsonObj, as_dict
+from typing import Optional, List, Union, Dict, ClassVar, Any
+from dataclasses import dataclass
+from linkml_runtime.linkml_model.meta import EnumDefinition, PermissibleValue, PvFormulaOptions
+
+from linkml_runtime.utils.slot import Slot
+from linkml_runtime.utils.metamodelcore import empty_list, empty_dict, bnode
+from linkml_runtime.utils.yamlutils import YAMLRoot, extended_str, extended_float, extended_int
+from linkml_runtime.utils.dataclass_extensions_376 import dataclasses_init_fn_with_kwargs
+from linkml_runtime.utils.formatutils import camelcase, underscore, sfx
+from linkml_runtime.utils.enumerations import EnumDefinitionImpl
+from rdflib import Namespace, URIRef
+from linkml_runtime.utils.curienamespace import CurieNamespace
+from linkml_runtime.linkml_model.types import Boolean, Integer, String, Uriorcurie
+from linkml_runtime.utils.metamodelcore import Bool, URIorCURIE
+
+metamodel_version = "1.7.0"
+version = None
+
+# Overwrite dataclasses _init_fn to add **kwargs in __init__
+dataclasses._init_fn = dataclasses_init_fn_with_kwargs
+
+# Namespaces
+LINKML = CurieNamespace('linkml', 'https://w3id.org/linkml/')
+OWL = CurieNamespace('owl', 'http://www.w3.org/2002/07/owl#')
+PAV = CurieNamespace('pav', 'http://purl.org/pav/')
+RDF = CurieNamespace('rdf', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#')
+RDFS = CurieNamespace('rdfs', 'http://www.w3.org/2000/01/rdf-schema#')
+SCHEMA = CurieNamespace('schema', 'http://schema.org/')
+SH = CurieNamespace('sh', 'http://www.w3.org/ns/shacl#')
+SKOS = CurieNamespace('skos', 'http://www.w3.org/2004/02/skos/core#')
+VM = CurieNamespace('vm', 'https://w3id.org/linkml/validation-model/')
+XSD = CurieNamespace('xsd', 'http://www.w3.org/2001/XMLSchema#')
+DEFAULT_ = VM
+
+
+# Types
+
+# Class references
+class ConstraintCheckId(URIorCURIE):
+    pass
+
+
+class NodeId(URIorCURIE):
+    pass
+
+
+class TypeSeverityKeyValueType(URIorCURIE):
+    pass
+
+
+@dataclass
+class ConstraintCheck(YAMLRoot):
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = VM.ConstraintCheck
+    class_class_curie: ClassVar[str] = "vm:ConstraintCheck"
+    class_name: ClassVar[str] = "ConstraintCheck"
+    class_model_uri: ClassVar[URIRef] = VM.ConstraintCheck
+
+    id: Union[str, ConstraintCheckId] = None
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self._is_empty(self.id):
+            self.MissingRequiredField("id")
+        if not isinstance(self.id, ConstraintCheckId):
+            self.id = ConstraintCheckId(self.id)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass
+class Node(YAMLRoot):
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = VM.Node
+    class_class_curie: ClassVar[str] = "vm:Node"
+    class_name: ClassVar[str] = "Node"
+    class_model_uri: ClassVar[URIRef] = VM.Node
+
+    id: Union[str, NodeId] = None
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self._is_empty(self.id):
+            self.MissingRequiredField("id")
+        if not isinstance(self.id, NodeId):
+            self.id = NodeId(self.id)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass
+class ValidationConfiguration(YAMLRoot):
+    """
+    Configuration parameters for execution of a validation report
+    """
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = VM.ValidationConfiguration
+    class_class_curie: ClassVar[str] = "vm:ValidationConfiguration"
+    class_name: ClassVar[str] = "ValidationConfiguration"
+    class_model_uri: ClassVar[URIRef] = VM.ValidationConfiguration
+
+    max_number_results_per_type: Optional[int] = None
+    type_severity_map: Optional[Union[Dict[Union[str, TypeSeverityKeyValueType], Union[dict, "TypeSeverityKeyValue"]], List[Union[dict, "TypeSeverityKeyValue"]]]] = empty_dict()
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self.max_number_results_per_type is not None and not isinstance(self.max_number_results_per_type, int):
+            self.max_number_results_per_type = int(self.max_number_results_per_type)
+
+        self._normalize_inlined_as_dict(slot_name="type_severity_map", slot_type=TypeSeverityKeyValue, key_name="type", keyed=True)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass
+class RepairConfiguration(YAMLRoot):
+    """
+    Configuration parameters for execution of validation repairs
+    """
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = VM.RepairConfiguration
+    class_class_curie: ClassVar[str] = "vm:RepairConfiguration"
+    class_name: ClassVar[str] = "RepairConfiguration"
+    class_model_uri: ClassVar[URIRef] = VM.RepairConfiguration
+
+    validation_configuration: Optional[Union[dict, ValidationConfiguration]] = None
+    dry_run: Optional[Union[bool, Bool]] = None
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self.validation_configuration is not None and not isinstance(self.validation_configuration, ValidationConfiguration):
+            self.validation_configuration = ValidationConfiguration(**as_dict(self.validation_configuration))
+
+        if self.dry_run is not None and not isinstance(self.dry_run, Bool):
+            self.dry_run = Bool(self.dry_run)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass
+class TypeSeverityKeyValue(YAMLRoot):
+    """
+    key-value pair that maps a validation result type to a severity setting, for overriding default severity
+    """
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = VM.TypeSeverityKeyValue
+    class_class_curie: ClassVar[str] = "vm:TypeSeverityKeyValue"
+    class_name: ClassVar[str] = "TypeSeverityKeyValue"
+    class_model_uri: ClassVar[URIRef] = VM.TypeSeverityKeyValue
+
+    type: Union[str, TypeSeverityKeyValueType] = None
+    severity: Optional[Union[str, "SeverityType"]] = None
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self._is_empty(self.type):
+            self.MissingRequiredField("type")
+        if not isinstance(self.type, TypeSeverityKeyValueType):
+            self.type = TypeSeverityKeyValueType(self.type)
+
+        if self.severity is not None and not isinstance(self.severity, SeverityType):
+            self.severity = SeverityType(self.severity)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass
+class Report(YAMLRoot):
+    """
+    A report object that is a holder to multiple report results
+    """
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = VM.Report
+    class_class_curie: ClassVar[str] = "vm:Report"
+    class_name: ClassVar[str] = "Report"
+    class_model_uri: ClassVar[URIRef] = VM.Report
+
+    results: Optional[Union[Union[dict, "Result"], List[Union[dict, "Result"]]]] = empty_list()
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if not isinstance(self.results, list):
+            self.results = [self.results] if self.results is not None else []
+        self.results = [v if isinstance(v, Result) else Result(**as_dict(v)) for v in self.results]
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass
+class ValidationReport(Report):
+    """
+    A report that consists of validation results
+    """
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = SH.ValidationReport
+    class_class_curie: ClassVar[str] = "sh:ValidationReport"
+    class_name: ClassVar[str] = "ValidationReport"
+    class_model_uri: ClassVar[URIRef] = VM.ValidationReport
+
+    results: Optional[Union[Union[dict, "ValidationResult"], List[Union[dict, "ValidationResult"]]]] = empty_list()
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if not isinstance(self.results, list):
+            self.results = [self.results] if self.results is not None else []
+        self.results = [v if isinstance(v, ValidationResult) else ValidationResult(**as_dict(v)) for v in self.results]
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass
+class RepairReport(Report):
+    """
+    A report that consists of repair operation results
+    """
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = VM.RepairReport
+    class_class_curie: ClassVar[str] = "vm:RepairReport"
+    class_name: ClassVar[str] = "RepairReport"
+    class_model_uri: ClassVar[URIRef] = VM.RepairReport
+
+    results: Optional[Union[Union[dict, "RepairOperation"], List[Union[dict, "RepairOperation"]]]] = empty_list()
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if not isinstance(self.results, list):
+            self.results = [self.results] if self.results is not None else []
+        self.results = [v if isinstance(v, RepairOperation) else RepairOperation(**as_dict(v)) for v in self.results]
+
+        super().__post_init__(**kwargs)
+
+
+class Result(YAMLRoot):
+    """
+    Abstract base class for any individual report result
+    """
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = VM.Result
+    class_class_curie: ClassVar[str] = "vm:Result"
+    class_name: ClassVar[str] = "Result"
+    class_model_uri: ClassVar[URIRef] = VM.Result
+
+
+@dataclass
+class ValidationResult(Result):
+    """
+    An individual result arising from validation of a data instance using a particular rule
+    """
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = SH.ValidationResult
+    class_class_curie: ClassVar[str] = "sh:ValidationResult"
+    class_name: ClassVar[str] = "ValidationResult"
+    class_model_uri: ClassVar[URIRef] = VM.ValidationResult
+
+    type: Union[str, "ConstraintType"] = None
+    severity: Optional[Union[str, "SeverityType"]] = None
+    subject: Optional[str] = None
+    instantiates: Optional[Union[str, NodeId]] = None
+    predicate: Optional[Union[str, NodeId]] = None
+    object: Optional[Union[str, NodeId]] = None
+    object_str: Optional[str] = None
+    source: Optional[str] = None
+    info: Optional[str] = None
+    normalized: Optional[Union[bool, Bool]] = None
+    repaired: Optional[Union[bool, Bool]] = None
+    source_line_number: Optional[int] = None
+    source_column_number: Optional[int] = None
+    source_location: Optional[str] = None
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self._is_empty(self.type):
+            self.MissingRequiredField("type")
+        if not isinstance(self.type, ConstraintType):
+            self.type = ConstraintType(self.type)
+
+        if self.severity is not None and not isinstance(self.severity, SeverityType):
+            self.severity = SeverityType(self.severity)
+
+        if self.subject is not None and not isinstance(self.subject, str):
+            self.subject = str(self.subject)
+
+        if self.instantiates is not None and not isinstance(self.instantiates, NodeId):
+            self.instantiates = NodeId(self.instantiates)
+
+        if self.predicate is not None and not isinstance(self.predicate, NodeId):
+            self.predicate = NodeId(self.predicate)
+
+        if self.object is not None and not isinstance(self.object, NodeId):
+            self.object = NodeId(self.object)
+
+        if self.object_str is not None and not isinstance(self.object_str, str):
+            self.object_str = str(self.object_str)
+
+        if self.source is not None and not isinstance(self.source, str):
+            self.source = str(self.source)
+
+        if self.info is not None and not isinstance(self.info, str):
+            self.info = str(self.info)
+
+        if self.normalized is not None and not isinstance(self.normalized, Bool):
+            self.normalized = Bool(self.normalized)
+
+        if self.repaired is not None and not isinstance(self.repaired, Bool):
+            self.repaired = Bool(self.repaired)
+
+        if self.source_line_number is not None and not isinstance(self.source_line_number, int):
+            self.source_line_number = int(self.source_line_number)
+
+        if self.source_column_number is not None and not isinstance(self.source_column_number, int):
+            self.source_column_number = int(self.source_column_number)
+
+        if self.source_location is not None and not isinstance(self.source_location, str):
+            self.source_location = str(self.source_location)
+
+        super().__post_init__(**kwargs)
+
+
+@dataclass
+class RepairOperation(Result):
+    """
+    The result of performing an individual repair
+    """
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = VM.RepairOperation
+    class_class_curie: ClassVar[str] = "vm:RepairOperation"
+    class_name: ClassVar[str] = "RepairOperation"
+    class_model_uri: ClassVar[URIRef] = VM.RepairOperation
+
+    repairs: Optional[Union[dict, ValidationResult]] = None
+    modified: Optional[Union[bool, Bool]] = None
+    successful: Optional[Union[bool, Bool]] = None
+    info: Optional[str] = None
+
+    def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
+        if self.repairs is not None and not isinstance(self.repairs, ValidationResult):
+            self.repairs = ValidationResult(**as_dict(self.repairs))
+
+        if self.modified is not None and not isinstance(self.modified, Bool):
+            self.modified = Bool(self.modified)
+
+        if self.successful is not None and not isinstance(self.successful, Bool):
+            self.successful = Bool(self.successful)
+
+        if self.info is not None and not isinstance(self.info, str):
+            self.info = str(self.info)
+
+        super().__post_init__(**kwargs)
+
+
+# Enumerations
+class SeverityType(EnumDefinitionImpl):
+
+    FATAL = PermissibleValue(text="FATAL")
+    ERROR = PermissibleValue(text="ERROR",
+                                 meaning=SH.Violation)
+    WARNING = PermissibleValue(text="WARNING",
+                                     meaning=SH.Warning)
+    INFO = PermissibleValue(text="INFO",
+                               meaning=SH.Info)
+
+    _defn = EnumDefinition(
+        name="SeverityType",
+    )
+
+class ConstraintType(EnumDefinitionImpl):
+
+    TypeConstraint = PermissibleValue(text="TypeConstraint",
+                                                   description="constraint in which the range is a type, and the slot value must conform to the type",
+                                                   meaning=SH.DatatypeConstraintComponent)
+    MinCountConstraint = PermissibleValue(text="MinCountConstraint",
+                                                           description="cardinality constraint where the number of values of the slot must be greater or equal to a specified minimum",
+                                                           meaning=SH.MinCountConstraintComponent)
+    RequiredConstraint = PermissibleValue(text="RequiredConstraint",
+                                                           description="cardinality constraint where there MUST be at least one value of the slot",
+                                                           meaning=SH.MinCountConstraintComponent)
+    RecommendedConstraint = PermissibleValue(text="RecommendedConstraint",
+                                                                 description="cardinality constraint where there SHOULD be at least one value of the slot",
+                                                                 meaning=SH.MinCountConstraintComponent)
+    MaxCountConstraint = PermissibleValue(text="MaxCountConstraint",
+                                                           description="cardinality constraint where the number of values of the slot must be less than or equal to a specified maximum",
+                                                           meaning=SH.MaxCountConstraintComponent)
+    SingleValuedConstraint = PermissibleValue(text="SingleValuedConstraint",
+                                                                   description="the value of the slot must be atomic and not a collection")
+    MultiValuedConstraint = PermissibleValue(text="MultiValuedConstraint",
+                                                                 description="the value of the slot must be a collection and not atomic")
+    DeprecatedProperty = PermissibleValue(text="DeprecatedProperty",
+                                                           description="constraint where the instance slot should not be deprecated",
+                                                           meaning=VM.DeprecatedProperty)
+    MaxLengthConstraint = PermissibleValue(text="MaxLengthConstraint",
+                                                             description="constraint where the slot value must have a length equal to or less than a specified maximum",
+                                                             meaning=SH.MaxLengthConstraintComponent)
+    MinLengthConstraint = PermissibleValue(text="MinLengthConstraint",
+                                                             description="constraint where the slot value must have a length equal to or less than a specified maximum",
+                                                             meaning=SH.MinLengthConstraintComponent)
+    PatternConstraint = PermissibleValue(text="PatternConstraint",
+                                                         description="constraint where the slot value must match a given regular expression pattern",
+                                                         meaning=SH.PatternConstraintComponent)
+    ClosedClassConstraint = PermissibleValue(text="ClosedClassConstraint",
+                                                                 description="constraint where the slot value must be allowable for the instantiated class",
+                                                                 meaning=SH.ClosedConstraintComponent)
+    DesignatesTypeConstraint = PermissibleValue(text="DesignatesTypeConstraint")
+    InstanceConstraint = PermissibleValue(text="InstanceConstraint",
+                                                           meaning=SH.NodeConstraintComponent)
+    SlotConstraint = PermissibleValue(text="SlotConstraint",
+                                                   meaning=SH.PropertyConstraintComponent)
+    PermissibleValueConstraint = PermissibleValue(text="PermissibleValueConstraint",
+                                                                           description="constraint where the slot value must be one of a set of permissible values",
+                                                                           meaning=SH.InConstraintComponent)
+    UndeclaredSlotConstraint = PermissibleValue(text="UndeclaredSlotConstraint")
+    RuleConstraint = PermissibleValue(text="RuleConstraint",
+                                                   description="constraint where the structure of an object must conform to a specified rule")
+    ExpressionConstraint = PermissibleValue(text="ExpressionConstraint")
+    EqualsExpressionConstraint = PermissibleValue(text="EqualsExpressionConstraint",
+                                                                           meaning=SH.EqualsConstraintComponent)
+    LessThanExpressionConstraint = PermissibleValue(text="LessThanExpressionConstraint",
+                                                                               meaning=SH.LessThanConstraintComponent)
+    LessThanOrEqualsExpressionConstraint = PermissibleValue(text="LessThanOrEqualsExpressionConstraint",
+                                                                                               meaning=SH.LessThanOrEqualsComponent)
+    DisjointConstraint = PermissibleValue(text="DisjointConstraint",
+                                                           meaning=SH.DisjointConstraintComponent)
+    MinimumValueConstraint = PermissibleValue(text="MinimumValueConstraint",
+                                                                   meaning=SH.MinInclusiveConstraintComponent)
+    MaximumValueConstraint = PermissibleValue(text="MaximumValueConstraint",
+                                                                   meaning=SH.MaxInclusiveConstraintComponent)
+    MinimumExclusiveValueConstraint = PermissibleValue(text="MinimumExclusiveValueConstraint",
+                                                                                     meaning=SH.MinExclusiveInclusiveConstraintComponent)
+    MaximumExclusiveValueConstraint = PermissibleValue(text="MaximumExclusiveValueConstraint",
+                                                                                     meaning=SH.MaxExclusiveInclusiveConstraintComponent)
+    CollectionFormConstraint = PermissibleValue(text="CollectionFormConstraint")
+    ListCollectionFormConstraint = PermissibleValue(text="ListCollectionFormConstraint")
+    DictCollectionFormConstraint = PermissibleValue(text="DictCollectionFormConstraint")
+    SimpleDictCollectionFormConstraint = PermissibleValue(text="SimpleDictCollectionFormConstraint")
+    CompactDictCollectionFormConstraint = PermissibleValue(text="CompactDictCollectionFormConstraint")
+    ExpandedDictCollectionFormConstraint = PermissibleValue(text="ExpandedDictCollectionFormConstraint")
+
+    _defn = EnumDefinition(
+        name="ConstraintType",
+    )
+
+# Slots
+class slots:
+    pass
+
+slots.type = Slot(uri=SH.sourceConstraintComponent, name="type", curie=SH.curie('sourceConstraintComponent'),
+                   model_uri=VM.type, domain=None, range=Union[str, "ConstraintType"])
+
+slots.subject = Slot(uri=SH.focusNode, name="subject", curie=SH.curie('focusNode'),
+                   model_uri=VM.subject, domain=None, range=Optional[str])
+
+slots.instantiates = Slot(uri=VM.instantiates, name="instantiates", curie=VM.curie('instantiates'),
+                   model_uri=VM.instantiates, domain=None, range=Optional[Union[str, NodeId]])
+
+slots.predicate = Slot(uri=VM.predicate, name="predicate", curie=VM.curie('predicate'),
+                   model_uri=VM.predicate, domain=None, range=Optional[Union[str, NodeId]])
+
+slots.object = Slot(uri=SH.value, name="object", curie=SH.curie('value'),
+                   model_uri=VM.object, domain=None, range=Optional[Union[str, NodeId]])
+
+slots.object_str = Slot(uri=VM.object_str, name="object_str", curie=VM.curie('object_str'),
+                   model_uri=VM.object_str, domain=None, range=Optional[str])
+
+slots.source = Slot(uri=VM.source, name="source", curie=VM.curie('source'),
+                   model_uri=VM.source, domain=None, range=Optional[str])
+
+slots.severity = Slot(uri=SH.resultSeverity, name="severity", curie=SH.curie('resultSeverity'),
+                   model_uri=VM.severity, domain=None, range=Optional[Union[str, "SeverityType"]])
+
+slots.info = Slot(uri=SH.resultMessage, name="info", curie=SH.curie('resultMessage'),
+                   model_uri=VM.info, domain=None, range=Optional[str])
+
+slots.results = Slot(uri=SH.result, name="results", curie=SH.curie('result'),
+                   model_uri=VM.results, domain=None, range=Optional[Union[Union[dict, Result], List[Union[dict, Result]]]])
+
+slots.normalized = Slot(uri=VM.normalized, name="normalized", curie=VM.curie('normalized'),
+                   model_uri=VM.normalized, domain=None, range=Optional[Union[bool, Bool]])
+
+slots.repaired = Slot(uri=VM.repaired, name="repaired", curie=VM.curie('repaired'),
+                   model_uri=VM.repaired, domain=None, range=Optional[Union[bool, Bool]])
+
+slots.source_line_number = Slot(uri=VM.source_line_number, name="source_line_number", curie=VM.curie('source_line_number'),
+                   model_uri=VM.source_line_number, domain=None, range=Optional[int])
+
+slots.source_column_number = Slot(uri=VM.source_column_number, name="source_column_number", curie=VM.curie('source_column_number'),
+                   model_uri=VM.source_column_number, domain=None, range=Optional[int])
+
+slots.source_location = Slot(uri=VM.source_location, name="source_location", curie=VM.curie('source_location'),
+                   model_uri=VM.source_location, domain=None, range=Optional[str])
+
+slots.constraintCheck__id = Slot(uri=VM.id, name="constraintCheck__id", curie=VM.curie('id'),
+                   model_uri=VM.constraintCheck__id, domain=None, range=URIRef)
+
+slots.node__id = Slot(uri=VM.id, name="node__id", curie=VM.curie('id'),
+                   model_uri=VM.node__id, domain=None, range=URIRef)
+
+slots.validationConfiguration__max_number_results_per_type = Slot(uri=VM.max_number_results_per_type, name="validationConfiguration__max_number_results_per_type", curie=VM.curie('max_number_results_per_type'),
+                   model_uri=VM.validationConfiguration__max_number_results_per_type, domain=None, range=Optional[int])
+
+slots.validationConfiguration__type_severity_map = Slot(uri=VM.type_severity_map, name="validationConfiguration__type_severity_map", curie=VM.curie('type_severity_map'),
+                   model_uri=VM.validationConfiguration__type_severity_map, domain=None, range=Optional[Union[Dict[Union[str, TypeSeverityKeyValueType], Union[dict, TypeSeverityKeyValue]], List[Union[dict, TypeSeverityKeyValue]]]])
+
+slots.repairConfiguration__validation_configuration = Slot(uri=VM.validation_configuration, name="repairConfiguration__validation_configuration", curie=VM.curie('validation_configuration'),
+                   model_uri=VM.repairConfiguration__validation_configuration, domain=None, range=Optional[Union[dict, ValidationConfiguration]])
+
+slots.repairConfiguration__dry_run = Slot(uri=VM.dry_run, name="repairConfiguration__dry_run", curie=VM.curie('dry_run'),
+                   model_uri=VM.repairConfiguration__dry_run, domain=None, range=Optional[Union[bool, Bool]])
+
+slots.typeSeverityKeyValue__type = Slot(uri=VM.type, name="typeSeverityKeyValue__type", curie=VM.curie('type'),
+                   model_uri=VM.typeSeverityKeyValue__type, domain=None, range=URIRef)
+
+slots.typeSeverityKeyValue__severity = Slot(uri=VM.severity, name="typeSeverityKeyValue__severity", curie=VM.curie('severity'),
+                   model_uri=VM.typeSeverityKeyValue__severity, domain=None, range=Optional[Union[str, "SeverityType"]])
+
+slots.repairOperation__repairs = Slot(uri=VM.repairs, name="repairOperation__repairs", curie=VM.curie('repairs'),
+                   model_uri=VM.repairOperation__repairs, domain=None, range=Optional[Union[dict, ValidationResult]])
+
+slots.repairOperation__modified = Slot(uri=VM.modified, name="repairOperation__modified", curie=VM.curie('modified'),
+                   model_uri=VM.repairOperation__modified, domain=None, range=Optional[Union[bool, Bool]])
+
+slots.repairOperation__successful = Slot(uri=VM.successful, name="repairOperation__successful", curie=VM.curie('successful'),
+                   model_uri=VM.repairOperation__successful, domain=None, range=Optional[Union[bool, Bool]])
+
+slots.repairOperation__info = Slot(uri=VM.info, name="repairOperation__info", curie=VM.curie('info'),
+                   model_uri=VM.repairOperation__info, domain=None, range=Optional[str])
+
+slots.ValidationReport_results = Slot(uri=SH.result, name="ValidationReport_results", curie=SH.curie('result'),
+                   model_uri=VM.ValidationReport_results, domain=ValidationReport, range=Optional[Union[Union[dict, "ValidationResult"], List[Union[dict, "ValidationResult"]]]])
+
+slots.RepairReport_results = Slot(uri=SH.result, name="RepairReport_results", curie=SH.curie('result'),
+                   model_uri=VM.RepairReport_results, domain=RepairReport, range=Optional[Union[Union[dict, "RepairOperation"], List[Union[dict, "RepairOperation"]]]])

--- a/linkml_runtime/processing/validation_datamodel.py
+++ b/linkml_runtime/processing/validation_datamodel.py
@@ -12,12 +12,23 @@ import re
 from jsonasobj2 import JsonObj, as_dict
 from typing import Optional, List, Union, Dict, ClassVar, Any
 from dataclasses import dataclass
-from linkml_runtime.linkml_model.meta import EnumDefinition, PermissibleValue, PvFormulaOptions
+from linkml_runtime.linkml_model.meta import (
+    EnumDefinition,
+    PermissibleValue,
+    PvFormulaOptions,
+)
 
 from linkml_runtime.utils.slot import Slot
 from linkml_runtime.utils.metamodelcore import empty_list, empty_dict, bnode
-from linkml_runtime.utils.yamlutils import YAMLRoot, extended_str, extended_float, extended_int
-from linkml_runtime.utils.dataclass_extensions_376 import dataclasses_init_fn_with_kwargs
+from linkml_runtime.utils.yamlutils import (
+    YAMLRoot,
+    extended_str,
+    extended_float,
+    extended_int,
+)
+from linkml_runtime.utils.dataclass_extensions_376 import (
+    dataclasses_init_fn_with_kwargs,
+)
 from linkml_runtime.utils.formatutils import camelcase, underscore, sfx
 from linkml_runtime.utils.enumerations import EnumDefinitionImpl
 from rdflib import Namespace, URIRef
@@ -32,16 +43,16 @@ version = None
 dataclasses._init_fn = dataclasses_init_fn_with_kwargs
 
 # Namespaces
-LINKML = CurieNamespace('linkml', 'https://w3id.org/linkml/')
-OWL = CurieNamespace('owl', 'http://www.w3.org/2002/07/owl#')
-PAV = CurieNamespace('pav', 'http://purl.org/pav/')
-RDF = CurieNamespace('rdf', 'http://www.w3.org/1999/02/22-rdf-syntax-ns#')
-RDFS = CurieNamespace('rdfs', 'http://www.w3.org/2000/01/rdf-schema#')
-SCHEMA = CurieNamespace('schema', 'http://schema.org/')
-SH = CurieNamespace('sh', 'http://www.w3.org/ns/shacl#')
-SKOS = CurieNamespace('skos', 'http://www.w3.org/2004/02/skos/core#')
-VM = CurieNamespace('vm', 'https://w3id.org/linkml/validation-model/')
-XSD = CurieNamespace('xsd', 'http://www.w3.org/2001/XMLSchema#')
+LINKML = CurieNamespace("linkml", "https://w3id.org/linkml/")
+OWL = CurieNamespace("owl", "http://www.w3.org/2002/07/owl#")
+PAV = CurieNamespace("pav", "http://purl.org/pav/")
+RDF = CurieNamespace("rdf", "http://www.w3.org/1999/02/22-rdf-syntax-ns#")
+RDFS = CurieNamespace("rdfs", "http://www.w3.org/2000/01/rdf-schema#")
+SCHEMA = CurieNamespace("schema", "http://schema.org/")
+SH = CurieNamespace("sh", "http://www.w3.org/ns/shacl#")
+SKOS = CurieNamespace("skos", "http://www.w3.org/2004/02/skos/core#")
+VM = CurieNamespace("vm", "https://w3id.org/linkml/validation-model/")
+XSD = CurieNamespace("xsd", "http://www.w3.org/2001/XMLSchema#")
 DEFAULT_ = VM
 
 
@@ -105,6 +116,7 @@ class ValidationConfiguration(YAMLRoot):
     """
     Configuration parameters for execution of a validation report
     """
+
     _inherited_slots: ClassVar[List[str]] = []
 
     class_class_uri: ClassVar[URIRef] = VM.ValidationConfiguration
@@ -113,13 +125,28 @@ class ValidationConfiguration(YAMLRoot):
     class_model_uri: ClassVar[URIRef] = VM.ValidationConfiguration
 
     max_number_results_per_type: Optional[int] = None
-    type_severity_map: Optional[Union[Dict[Union[str, TypeSeverityKeyValueType], Union[dict, "TypeSeverityKeyValue"]], List[Union[dict, "TypeSeverityKeyValue"]]]] = empty_dict()
+    type_severity_map: Optional[
+        Union[
+            Dict[
+                Union[str, TypeSeverityKeyValueType],
+                Union[dict, "TypeSeverityKeyValue"],
+            ],
+            List[Union[dict, "TypeSeverityKeyValue"]],
+        ]
+    ] = empty_dict()
 
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
-        if self.max_number_results_per_type is not None and not isinstance(self.max_number_results_per_type, int):
+        if self.max_number_results_per_type is not None and not isinstance(
+            self.max_number_results_per_type, int
+        ):
             self.max_number_results_per_type = int(self.max_number_results_per_type)
 
-        self._normalize_inlined_as_dict(slot_name="type_severity_map", slot_type=TypeSeverityKeyValue, key_name="type", keyed=True)
+        self._normalize_inlined_as_dict(
+            slot_name="type_severity_map",
+            slot_type=TypeSeverityKeyValue,
+            key_name="type",
+            keyed=True,
+        )
 
         super().__post_init__(**kwargs)
 
@@ -129,6 +156,7 @@ class RepairConfiguration(YAMLRoot):
     """
     Configuration parameters for execution of validation repairs
     """
+
     _inherited_slots: ClassVar[List[str]] = []
 
     class_class_uri: ClassVar[URIRef] = VM.RepairConfiguration
@@ -140,8 +168,12 @@ class RepairConfiguration(YAMLRoot):
     dry_run: Optional[Union[bool, Bool]] = None
 
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
-        if self.validation_configuration is not None and not isinstance(self.validation_configuration, ValidationConfiguration):
-            self.validation_configuration = ValidationConfiguration(**as_dict(self.validation_configuration))
+        if self.validation_configuration is not None and not isinstance(
+            self.validation_configuration, ValidationConfiguration
+        ):
+            self.validation_configuration = ValidationConfiguration(
+                **as_dict(self.validation_configuration)
+            )
 
         if self.dry_run is not None and not isinstance(self.dry_run, Bool):
             self.dry_run = Bool(self.dry_run)
@@ -154,6 +186,7 @@ class TypeSeverityKeyValue(YAMLRoot):
     """
     key-value pair that maps a validation result type to a severity setting, for overriding default severity
     """
+
     _inherited_slots: ClassVar[List[str]] = []
 
     class_class_uri: ClassVar[URIRef] = VM.TypeSeverityKeyValue
@@ -181,6 +214,7 @@ class Report(YAMLRoot):
     """
     A report object that is a holder to multiple report results
     """
+
     _inherited_slots: ClassVar[List[str]] = []
 
     class_class_uri: ClassVar[URIRef] = VM.Report
@@ -188,12 +222,16 @@ class Report(YAMLRoot):
     class_name: ClassVar[str] = "Report"
     class_model_uri: ClassVar[URIRef] = VM.Report
 
-    results: Optional[Union[Union[dict, "Result"], List[Union[dict, "Result"]]]] = empty_list()
+    results: Optional[
+        Union[Union[dict, "Result"], List[Union[dict, "Result"]]]
+    ] = empty_list()
 
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
         if not isinstance(self.results, list):
             self.results = [self.results] if self.results is not None else []
-        self.results = [v if isinstance(v, Result) else Result(**as_dict(v)) for v in self.results]
+        self.results = [
+            v if isinstance(v, Result) else Result(**as_dict(v)) for v in self.results
+        ]
 
         super().__post_init__(**kwargs)
 
@@ -203,6 +241,7 @@ class ValidationReport(Report):
     """
     A report that consists of validation results
     """
+
     _inherited_slots: ClassVar[List[str]] = []
 
     class_class_uri: ClassVar[URIRef] = SH.ValidationReport
@@ -210,12 +249,17 @@ class ValidationReport(Report):
     class_name: ClassVar[str] = "ValidationReport"
     class_model_uri: ClassVar[URIRef] = VM.ValidationReport
 
-    results: Optional[Union[Union[dict, "ValidationResult"], List[Union[dict, "ValidationResult"]]]] = empty_list()
+    results: Optional[
+        Union[Union[dict, "ValidationResult"], List[Union[dict, "ValidationResult"]]]
+    ] = empty_list()
 
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
         if not isinstance(self.results, list):
             self.results = [self.results] if self.results is not None else []
-        self.results = [v if isinstance(v, ValidationResult) else ValidationResult(**as_dict(v)) for v in self.results]
+        self.results = [
+            v if isinstance(v, ValidationResult) else ValidationResult(**as_dict(v))
+            for v in self.results
+        ]
 
         super().__post_init__(**kwargs)
 
@@ -225,6 +269,7 @@ class RepairReport(Report):
     """
     A report that consists of repair operation results
     """
+
     _inherited_slots: ClassVar[List[str]] = []
 
     class_class_uri: ClassVar[URIRef] = VM.RepairReport
@@ -232,12 +277,17 @@ class RepairReport(Report):
     class_name: ClassVar[str] = "RepairReport"
     class_model_uri: ClassVar[URIRef] = VM.RepairReport
 
-    results: Optional[Union[Union[dict, "RepairOperation"], List[Union[dict, "RepairOperation"]]]] = empty_list()
+    results: Optional[
+        Union[Union[dict, "RepairOperation"], List[Union[dict, "RepairOperation"]]]
+    ] = empty_list()
 
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
         if not isinstance(self.results, list):
             self.results = [self.results] if self.results is not None else []
-        self.results = [v if isinstance(v, RepairOperation) else RepairOperation(**as_dict(v)) for v in self.results]
+        self.results = [
+            v if isinstance(v, RepairOperation) else RepairOperation(**as_dict(v))
+            for v in self.results
+        ]
 
         super().__post_init__(**kwargs)
 
@@ -246,6 +296,7 @@ class Result(YAMLRoot):
     """
     Abstract base class for any individual report result
     """
+
     _inherited_slots: ClassVar[List[str]] = []
 
     class_class_uri: ClassVar[URIRef] = VM.Result
@@ -259,6 +310,7 @@ class ValidationResult(Result):
     """
     An individual result arising from validation of a data instance using a particular rule
     """
+
     _inherited_slots: ClassVar[List[str]] = []
 
     class_class_uri: ClassVar[URIRef] = SH.ValidationResult
@@ -317,13 +369,19 @@ class ValidationResult(Result):
         if self.repaired is not None and not isinstance(self.repaired, Bool):
             self.repaired = Bool(self.repaired)
 
-        if self.source_line_number is not None and not isinstance(self.source_line_number, int):
+        if self.source_line_number is not None and not isinstance(
+            self.source_line_number, int
+        ):
             self.source_line_number = int(self.source_line_number)
 
-        if self.source_column_number is not None and not isinstance(self.source_column_number, int):
+        if self.source_column_number is not None and not isinstance(
+            self.source_column_number, int
+        ):
             self.source_column_number = int(self.source_column_number)
 
-        if self.source_location is not None and not isinstance(self.source_location, str):
+        if self.source_location is not None and not isinstance(
+            self.source_location, str
+        ):
             self.source_location = str(self.source_location)
 
         super().__post_init__(**kwargs)
@@ -334,6 +392,7 @@ class RepairOperation(Result):
     """
     The result of performing an individual repair
     """
+
     _inherited_slots: ClassVar[List[str]] = []
 
     class_class_uri: ClassVar[URIRef] = VM.RepairOperation
@@ -366,179 +425,411 @@ class RepairOperation(Result):
 class SeverityType(EnumDefinitionImpl):
 
     FATAL = PermissibleValue(text="FATAL")
-    ERROR = PermissibleValue(text="ERROR",
-                                 meaning=SH.Violation)
-    WARNING = PermissibleValue(text="WARNING",
-                                     meaning=SH.Warning)
-    INFO = PermissibleValue(text="INFO",
-                               meaning=SH.Info)
+    ERROR = PermissibleValue(text="ERROR", meaning=SH.Violation)
+    WARNING = PermissibleValue(text="WARNING", meaning=SH.Warning)
+    INFO = PermissibleValue(text="INFO", meaning=SH.Info)
 
     _defn = EnumDefinition(
         name="SeverityType",
     )
 
+
 class ConstraintType(EnumDefinitionImpl):
 
-    TypeConstraint = PermissibleValue(text="TypeConstraint",
-                                                   description="constraint in which the range is a type, and the slot value must conform to the type",
-                                                   meaning=SH.DatatypeConstraintComponent)
-    MinCountConstraint = PermissibleValue(text="MinCountConstraint",
-                                                           description="cardinality constraint where the number of values of the slot must be greater or equal to a specified minimum",
-                                                           meaning=SH.MinCountConstraintComponent)
-    RequiredConstraint = PermissibleValue(text="RequiredConstraint",
-                                                           description="cardinality constraint where there MUST be at least one value of the slot",
-                                                           meaning=SH.MinCountConstraintComponent)
-    RecommendedConstraint = PermissibleValue(text="RecommendedConstraint",
-                                                                 description="cardinality constraint where there SHOULD be at least one value of the slot",
-                                                                 meaning=SH.MinCountConstraintComponent)
-    MaxCountConstraint = PermissibleValue(text="MaxCountConstraint",
-                                                           description="cardinality constraint where the number of values of the slot must be less than or equal to a specified maximum",
-                                                           meaning=SH.MaxCountConstraintComponent)
-    SingleValuedConstraint = PermissibleValue(text="SingleValuedConstraint",
-                                                                   description="the value of the slot must be atomic and not a collection")
-    MultiValuedConstraint = PermissibleValue(text="MultiValuedConstraint",
-                                                                 description="the value of the slot must be a collection and not atomic")
-    DeprecatedProperty = PermissibleValue(text="DeprecatedProperty",
-                                                           description="constraint where the instance slot should not be deprecated",
-                                                           meaning=VM.DeprecatedProperty)
-    MaxLengthConstraint = PermissibleValue(text="MaxLengthConstraint",
-                                                             description="constraint where the slot value must have a length equal to or less than a specified maximum",
-                                                             meaning=SH.MaxLengthConstraintComponent)
-    MinLengthConstraint = PermissibleValue(text="MinLengthConstraint",
-                                                             description="constraint where the slot value must have a length equal to or less than a specified maximum",
-                                                             meaning=SH.MinLengthConstraintComponent)
-    PatternConstraint = PermissibleValue(text="PatternConstraint",
-                                                         description="constraint where the slot value must match a given regular expression pattern",
-                                                         meaning=SH.PatternConstraintComponent)
-    ClosedClassConstraint = PermissibleValue(text="ClosedClassConstraint",
-                                                                 description="constraint where the slot value must be allowable for the instantiated class",
-                                                                 meaning=SH.ClosedConstraintComponent)
+    TypeConstraint = PermissibleValue(
+        text="TypeConstraint",
+        description="constraint in which the range is a type, and the slot value must conform to the type",
+        meaning=SH.DatatypeConstraintComponent,
+    )
+    MinCountConstraint = PermissibleValue(
+        text="MinCountConstraint",
+        description="cardinality constraint where the number of values of the slot must be greater or equal to a specified minimum",
+        meaning=SH.MinCountConstraintComponent,
+    )
+    RequiredConstraint = PermissibleValue(
+        text="RequiredConstraint",
+        description="cardinality constraint where there MUST be at least one value of the slot",
+        meaning=SH.MinCountConstraintComponent,
+    )
+    RecommendedConstraint = PermissibleValue(
+        text="RecommendedConstraint",
+        description="cardinality constraint where there SHOULD be at least one value of the slot",
+        meaning=SH.MinCountConstraintComponent,
+    )
+    MaxCountConstraint = PermissibleValue(
+        text="MaxCountConstraint",
+        description="cardinality constraint where the number of values of the slot must be less than or equal to a specified maximum",
+        meaning=SH.MaxCountConstraintComponent,
+    )
+    SingleValuedConstraint = PermissibleValue(
+        text="SingleValuedConstraint",
+        description="the value of the slot must be atomic and not a collection",
+    )
+    MultiValuedConstraint = PermissibleValue(
+        text="MultiValuedConstraint",
+        description="the value of the slot must be a collection and not atomic",
+    )
+    DeprecatedProperty = PermissibleValue(
+        text="DeprecatedProperty",
+        description="constraint where the instance slot should not be deprecated",
+        meaning=VM.DeprecatedProperty,
+    )
+    MaxLengthConstraint = PermissibleValue(
+        text="MaxLengthConstraint",
+        description="constraint where the slot value must have a length equal to or less than a specified maximum",
+        meaning=SH.MaxLengthConstraintComponent,
+    )
+    MinLengthConstraint = PermissibleValue(
+        text="MinLengthConstraint",
+        description="constraint where the slot value must have a length equal to or less than a specified maximum",
+        meaning=SH.MinLengthConstraintComponent,
+    )
+    PatternConstraint = PermissibleValue(
+        text="PatternConstraint",
+        description="constraint where the slot value must match a given regular expression pattern",
+        meaning=SH.PatternConstraintComponent,
+    )
+    ClosedClassConstraint = PermissibleValue(
+        text="ClosedClassConstraint",
+        description="constraint where the slot value must be allowable for the instantiated class",
+        meaning=SH.ClosedConstraintComponent,
+    )
     DesignatesTypeConstraint = PermissibleValue(text="DesignatesTypeConstraint")
-    InstanceConstraint = PermissibleValue(text="InstanceConstraint",
-                                                           meaning=SH.NodeConstraintComponent)
-    SlotConstraint = PermissibleValue(text="SlotConstraint",
-                                                   meaning=SH.PropertyConstraintComponent)
-    PermissibleValueConstraint = PermissibleValue(text="PermissibleValueConstraint",
-                                                                           description="constraint where the slot value must be one of a set of permissible values",
-                                                                           meaning=SH.InConstraintComponent)
+    InstanceConstraint = PermissibleValue(
+        text="InstanceConstraint", meaning=SH.NodeConstraintComponent
+    )
+    SlotConstraint = PermissibleValue(
+        text="SlotConstraint", meaning=SH.PropertyConstraintComponent
+    )
+    PermissibleValueConstraint = PermissibleValue(
+        text="PermissibleValueConstraint",
+        description="constraint where the slot value must be one of a set of permissible values",
+        meaning=SH.InConstraintComponent,
+    )
     UndeclaredSlotConstraint = PermissibleValue(text="UndeclaredSlotConstraint")
-    RuleConstraint = PermissibleValue(text="RuleConstraint",
-                                                   description="constraint where the structure of an object must conform to a specified rule")
+    RuleConstraint = PermissibleValue(
+        text="RuleConstraint",
+        description="constraint where the structure of an object must conform to a specified rule",
+    )
     ExpressionConstraint = PermissibleValue(text="ExpressionConstraint")
-    EqualsExpressionConstraint = PermissibleValue(text="EqualsExpressionConstraint",
-                                                                           meaning=SH.EqualsConstraintComponent)
-    LessThanExpressionConstraint = PermissibleValue(text="LessThanExpressionConstraint",
-                                                                               meaning=SH.LessThanConstraintComponent)
-    LessThanOrEqualsExpressionConstraint = PermissibleValue(text="LessThanOrEqualsExpressionConstraint",
-                                                                                               meaning=SH.LessThanOrEqualsComponent)
-    DisjointConstraint = PermissibleValue(text="DisjointConstraint",
-                                                           meaning=SH.DisjointConstraintComponent)
-    MinimumValueConstraint = PermissibleValue(text="MinimumValueConstraint",
-                                                                   meaning=SH.MinInclusiveConstraintComponent)
-    MaximumValueConstraint = PermissibleValue(text="MaximumValueConstraint",
-                                                                   meaning=SH.MaxInclusiveConstraintComponent)
-    MinimumExclusiveValueConstraint = PermissibleValue(text="MinimumExclusiveValueConstraint",
-                                                                                     meaning=SH.MinExclusiveInclusiveConstraintComponent)
-    MaximumExclusiveValueConstraint = PermissibleValue(text="MaximumExclusiveValueConstraint",
-                                                                                     meaning=SH.MaxExclusiveInclusiveConstraintComponent)
+    EqualsExpressionConstraint = PermissibleValue(
+        text="EqualsExpressionConstraint", meaning=SH.EqualsConstraintComponent
+    )
+    LessThanExpressionConstraint = PermissibleValue(
+        text="LessThanExpressionConstraint", meaning=SH.LessThanConstraintComponent
+    )
+    LessThanOrEqualsExpressionConstraint = PermissibleValue(
+        text="LessThanOrEqualsExpressionConstraint",
+        meaning=SH.LessThanOrEqualsComponent,
+    )
+    DisjointConstraint = PermissibleValue(
+        text="DisjointConstraint", meaning=SH.DisjointConstraintComponent
+    )
+    MinimumValueConstraint = PermissibleValue(
+        text="MinimumValueConstraint", meaning=SH.MinInclusiveConstraintComponent
+    )
+    MaximumValueConstraint = PermissibleValue(
+        text="MaximumValueConstraint", meaning=SH.MaxInclusiveConstraintComponent
+    )
+    MinimumExclusiveValueConstraint = PermissibleValue(
+        text="MinimumExclusiveValueConstraint",
+        meaning=SH.MinExclusiveInclusiveConstraintComponent,
+    )
+    MaximumExclusiveValueConstraint = PermissibleValue(
+        text="MaximumExclusiveValueConstraint",
+        meaning=SH.MaxExclusiveInclusiveConstraintComponent,
+    )
     CollectionFormConstraint = PermissibleValue(text="CollectionFormConstraint")
     ListCollectionFormConstraint = PermissibleValue(text="ListCollectionFormConstraint")
     DictCollectionFormConstraint = PermissibleValue(text="DictCollectionFormConstraint")
-    SimpleDictCollectionFormConstraint = PermissibleValue(text="SimpleDictCollectionFormConstraint")
-    CompactDictCollectionFormConstraint = PermissibleValue(text="CompactDictCollectionFormConstraint")
-    ExpandedDictCollectionFormConstraint = PermissibleValue(text="ExpandedDictCollectionFormConstraint")
+    SimpleDictCollectionFormConstraint = PermissibleValue(
+        text="SimpleDictCollectionFormConstraint"
+    )
+    CompactDictCollectionFormConstraint = PermissibleValue(
+        text="CompactDictCollectionFormConstraint"
+    )
+    ExpandedDictCollectionFormConstraint = PermissibleValue(
+        text="ExpandedDictCollectionFormConstraint"
+    )
 
     _defn = EnumDefinition(
         name="ConstraintType",
     )
 
+
 # Slots
 class slots:
     pass
 
-slots.type = Slot(uri=SH.sourceConstraintComponent, name="type", curie=SH.curie('sourceConstraintComponent'),
-                   model_uri=VM.type, domain=None, range=Union[str, "ConstraintType"])
 
-slots.subject = Slot(uri=SH.focusNode, name="subject", curie=SH.curie('focusNode'),
-                   model_uri=VM.subject, domain=None, range=Optional[str])
+slots.type = Slot(
+    uri=SH.sourceConstraintComponent,
+    name="type",
+    curie=SH.curie("sourceConstraintComponent"),
+    model_uri=VM.type,
+    domain=None,
+    range=Union[str, "ConstraintType"],
+)
 
-slots.instantiates = Slot(uri=VM.instantiates, name="instantiates", curie=VM.curie('instantiates'),
-                   model_uri=VM.instantiates, domain=None, range=Optional[Union[str, NodeId]])
+slots.subject = Slot(
+    uri=SH.focusNode,
+    name="subject",
+    curie=SH.curie("focusNode"),
+    model_uri=VM.subject,
+    domain=None,
+    range=Optional[str],
+)
 
-slots.predicate = Slot(uri=VM.predicate, name="predicate", curie=VM.curie('predicate'),
-                   model_uri=VM.predicate, domain=None, range=Optional[Union[str, NodeId]])
+slots.instantiates = Slot(
+    uri=VM.instantiates,
+    name="instantiates",
+    curie=VM.curie("instantiates"),
+    model_uri=VM.instantiates,
+    domain=None,
+    range=Optional[Union[str, NodeId]],
+)
 
-slots.object = Slot(uri=SH.value, name="object", curie=SH.curie('value'),
-                   model_uri=VM.object, domain=None, range=Optional[Union[str, NodeId]])
+slots.predicate = Slot(
+    uri=VM.predicate,
+    name="predicate",
+    curie=VM.curie("predicate"),
+    model_uri=VM.predicate,
+    domain=None,
+    range=Optional[Union[str, NodeId]],
+)
 
-slots.object_str = Slot(uri=VM.object_str, name="object_str", curie=VM.curie('object_str'),
-                   model_uri=VM.object_str, domain=None, range=Optional[str])
+slots.object = Slot(
+    uri=SH.value,
+    name="object",
+    curie=SH.curie("value"),
+    model_uri=VM.object,
+    domain=None,
+    range=Optional[Union[str, NodeId]],
+)
 
-slots.source = Slot(uri=VM.source, name="source", curie=VM.curie('source'),
-                   model_uri=VM.source, domain=None, range=Optional[str])
+slots.object_str = Slot(
+    uri=VM.object_str,
+    name="object_str",
+    curie=VM.curie("object_str"),
+    model_uri=VM.object_str,
+    domain=None,
+    range=Optional[str],
+)
 
-slots.severity = Slot(uri=SH.resultSeverity, name="severity", curie=SH.curie('resultSeverity'),
-                   model_uri=VM.severity, domain=None, range=Optional[Union[str, "SeverityType"]])
+slots.source = Slot(
+    uri=VM.source,
+    name="source",
+    curie=VM.curie("source"),
+    model_uri=VM.source,
+    domain=None,
+    range=Optional[str],
+)
 
-slots.info = Slot(uri=SH.resultMessage, name="info", curie=SH.curie('resultMessage'),
-                   model_uri=VM.info, domain=None, range=Optional[str])
+slots.severity = Slot(
+    uri=SH.resultSeverity,
+    name="severity",
+    curie=SH.curie("resultSeverity"),
+    model_uri=VM.severity,
+    domain=None,
+    range=Optional[Union[str, "SeverityType"]],
+)
 
-slots.results = Slot(uri=SH.result, name="results", curie=SH.curie('result'),
-                   model_uri=VM.results, domain=None, range=Optional[Union[Union[dict, Result], List[Union[dict, Result]]]])
+slots.info = Slot(
+    uri=SH.resultMessage,
+    name="info",
+    curie=SH.curie("resultMessage"),
+    model_uri=VM.info,
+    domain=None,
+    range=Optional[str],
+)
 
-slots.normalized = Slot(uri=VM.normalized, name="normalized", curie=VM.curie('normalized'),
-                   model_uri=VM.normalized, domain=None, range=Optional[Union[bool, Bool]])
+slots.results = Slot(
+    uri=SH.result,
+    name="results",
+    curie=SH.curie("result"),
+    model_uri=VM.results,
+    domain=None,
+    range=Optional[Union[Union[dict, Result], List[Union[dict, Result]]]],
+)
 
-slots.repaired = Slot(uri=VM.repaired, name="repaired", curie=VM.curie('repaired'),
-                   model_uri=VM.repaired, domain=None, range=Optional[Union[bool, Bool]])
+slots.normalized = Slot(
+    uri=VM.normalized,
+    name="normalized",
+    curie=VM.curie("normalized"),
+    model_uri=VM.normalized,
+    domain=None,
+    range=Optional[Union[bool, Bool]],
+)
 
-slots.source_line_number = Slot(uri=VM.source_line_number, name="source_line_number", curie=VM.curie('source_line_number'),
-                   model_uri=VM.source_line_number, domain=None, range=Optional[int])
+slots.repaired = Slot(
+    uri=VM.repaired,
+    name="repaired",
+    curie=VM.curie("repaired"),
+    model_uri=VM.repaired,
+    domain=None,
+    range=Optional[Union[bool, Bool]],
+)
 
-slots.source_column_number = Slot(uri=VM.source_column_number, name="source_column_number", curie=VM.curie('source_column_number'),
-                   model_uri=VM.source_column_number, domain=None, range=Optional[int])
+slots.source_line_number = Slot(
+    uri=VM.source_line_number,
+    name="source_line_number",
+    curie=VM.curie("source_line_number"),
+    model_uri=VM.source_line_number,
+    domain=None,
+    range=Optional[int],
+)
 
-slots.source_location = Slot(uri=VM.source_location, name="source_location", curie=VM.curie('source_location'),
-                   model_uri=VM.source_location, domain=None, range=Optional[str])
+slots.source_column_number = Slot(
+    uri=VM.source_column_number,
+    name="source_column_number",
+    curie=VM.curie("source_column_number"),
+    model_uri=VM.source_column_number,
+    domain=None,
+    range=Optional[int],
+)
 
-slots.constraintCheck__id = Slot(uri=VM.id, name="constraintCheck__id", curie=VM.curie('id'),
-                   model_uri=VM.constraintCheck__id, domain=None, range=URIRef)
+slots.source_location = Slot(
+    uri=VM.source_location,
+    name="source_location",
+    curie=VM.curie("source_location"),
+    model_uri=VM.source_location,
+    domain=None,
+    range=Optional[str],
+)
 
-slots.node__id = Slot(uri=VM.id, name="node__id", curie=VM.curie('id'),
-                   model_uri=VM.node__id, domain=None, range=URIRef)
+slots.constraintCheck__id = Slot(
+    uri=VM.id,
+    name="constraintCheck__id",
+    curie=VM.curie("id"),
+    model_uri=VM.constraintCheck__id,
+    domain=None,
+    range=URIRef,
+)
 
-slots.validationConfiguration__max_number_results_per_type = Slot(uri=VM.max_number_results_per_type, name="validationConfiguration__max_number_results_per_type", curie=VM.curie('max_number_results_per_type'),
-                   model_uri=VM.validationConfiguration__max_number_results_per_type, domain=None, range=Optional[int])
+slots.node__id = Slot(
+    uri=VM.id,
+    name="node__id",
+    curie=VM.curie("id"),
+    model_uri=VM.node__id,
+    domain=None,
+    range=URIRef,
+)
 
-slots.validationConfiguration__type_severity_map = Slot(uri=VM.type_severity_map, name="validationConfiguration__type_severity_map", curie=VM.curie('type_severity_map'),
-                   model_uri=VM.validationConfiguration__type_severity_map, domain=None, range=Optional[Union[Dict[Union[str, TypeSeverityKeyValueType], Union[dict, TypeSeverityKeyValue]], List[Union[dict, TypeSeverityKeyValue]]]])
+slots.validationConfiguration__max_number_results_per_type = Slot(
+    uri=VM.max_number_results_per_type,
+    name="validationConfiguration__max_number_results_per_type",
+    curie=VM.curie("max_number_results_per_type"),
+    model_uri=VM.validationConfiguration__max_number_results_per_type,
+    domain=None,
+    range=Optional[int],
+)
 
-slots.repairConfiguration__validation_configuration = Slot(uri=VM.validation_configuration, name="repairConfiguration__validation_configuration", curie=VM.curie('validation_configuration'),
-                   model_uri=VM.repairConfiguration__validation_configuration, domain=None, range=Optional[Union[dict, ValidationConfiguration]])
+slots.validationConfiguration__type_severity_map = Slot(
+    uri=VM.type_severity_map,
+    name="validationConfiguration__type_severity_map",
+    curie=VM.curie("type_severity_map"),
+    model_uri=VM.validationConfiguration__type_severity_map,
+    domain=None,
+    range=Optional[
+        Union[
+            Dict[
+                Union[str, TypeSeverityKeyValueType], Union[dict, TypeSeverityKeyValue]
+            ],
+            List[Union[dict, TypeSeverityKeyValue]],
+        ]
+    ],
+)
 
-slots.repairConfiguration__dry_run = Slot(uri=VM.dry_run, name="repairConfiguration__dry_run", curie=VM.curie('dry_run'),
-                   model_uri=VM.repairConfiguration__dry_run, domain=None, range=Optional[Union[bool, Bool]])
+slots.repairConfiguration__validation_configuration = Slot(
+    uri=VM.validation_configuration,
+    name="repairConfiguration__validation_configuration",
+    curie=VM.curie("validation_configuration"),
+    model_uri=VM.repairConfiguration__validation_configuration,
+    domain=None,
+    range=Optional[Union[dict, ValidationConfiguration]],
+)
 
-slots.typeSeverityKeyValue__type = Slot(uri=VM.type, name="typeSeverityKeyValue__type", curie=VM.curie('type'),
-                   model_uri=VM.typeSeverityKeyValue__type, domain=None, range=URIRef)
+slots.repairConfiguration__dry_run = Slot(
+    uri=VM.dry_run,
+    name="repairConfiguration__dry_run",
+    curie=VM.curie("dry_run"),
+    model_uri=VM.repairConfiguration__dry_run,
+    domain=None,
+    range=Optional[Union[bool, Bool]],
+)
 
-slots.typeSeverityKeyValue__severity = Slot(uri=VM.severity, name="typeSeverityKeyValue__severity", curie=VM.curie('severity'),
-                   model_uri=VM.typeSeverityKeyValue__severity, domain=None, range=Optional[Union[str, "SeverityType"]])
+slots.typeSeverityKeyValue__type = Slot(
+    uri=VM.type,
+    name="typeSeverityKeyValue__type",
+    curie=VM.curie("type"),
+    model_uri=VM.typeSeverityKeyValue__type,
+    domain=None,
+    range=URIRef,
+)
 
-slots.repairOperation__repairs = Slot(uri=VM.repairs, name="repairOperation__repairs", curie=VM.curie('repairs'),
-                   model_uri=VM.repairOperation__repairs, domain=None, range=Optional[Union[dict, ValidationResult]])
+slots.typeSeverityKeyValue__severity = Slot(
+    uri=VM.severity,
+    name="typeSeverityKeyValue__severity",
+    curie=VM.curie("severity"),
+    model_uri=VM.typeSeverityKeyValue__severity,
+    domain=None,
+    range=Optional[Union[str, "SeverityType"]],
+)
 
-slots.repairOperation__modified = Slot(uri=VM.modified, name="repairOperation__modified", curie=VM.curie('modified'),
-                   model_uri=VM.repairOperation__modified, domain=None, range=Optional[Union[bool, Bool]])
+slots.repairOperation__repairs = Slot(
+    uri=VM.repairs,
+    name="repairOperation__repairs",
+    curie=VM.curie("repairs"),
+    model_uri=VM.repairOperation__repairs,
+    domain=None,
+    range=Optional[Union[dict, ValidationResult]],
+)
 
-slots.repairOperation__successful = Slot(uri=VM.successful, name="repairOperation__successful", curie=VM.curie('successful'),
-                   model_uri=VM.repairOperation__successful, domain=None, range=Optional[Union[bool, Bool]])
+slots.repairOperation__modified = Slot(
+    uri=VM.modified,
+    name="repairOperation__modified",
+    curie=VM.curie("modified"),
+    model_uri=VM.repairOperation__modified,
+    domain=None,
+    range=Optional[Union[bool, Bool]],
+)
 
-slots.repairOperation__info = Slot(uri=VM.info, name="repairOperation__info", curie=VM.curie('info'),
-                   model_uri=VM.repairOperation__info, domain=None, range=Optional[str])
+slots.repairOperation__successful = Slot(
+    uri=VM.successful,
+    name="repairOperation__successful",
+    curie=VM.curie("successful"),
+    model_uri=VM.repairOperation__successful,
+    domain=None,
+    range=Optional[Union[bool, Bool]],
+)
 
-slots.ValidationReport_results = Slot(uri=SH.result, name="ValidationReport_results", curie=SH.curie('result'),
-                   model_uri=VM.ValidationReport_results, domain=ValidationReport, range=Optional[Union[Union[dict, "ValidationResult"], List[Union[dict, "ValidationResult"]]]])
+slots.repairOperation__info = Slot(
+    uri=VM.info,
+    name="repairOperation__info",
+    curie=VM.curie("info"),
+    model_uri=VM.repairOperation__info,
+    domain=None,
+    range=Optional[str],
+)
 
-slots.RepairReport_results = Slot(uri=SH.result, name="RepairReport_results", curie=SH.curie('result'),
-                   model_uri=VM.RepairReport_results, domain=RepairReport, range=Optional[Union[Union[dict, "RepairOperation"], List[Union[dict, "RepairOperation"]]]])
+slots.ValidationReport_results = Slot(
+    uri=SH.result,
+    name="ValidationReport_results",
+    curie=SH.curie("result"),
+    model_uri=VM.ValidationReport_results,
+    domain=ValidationReport,
+    range=Optional[
+        Union[Union[dict, "ValidationResult"], List[Union[dict, "ValidationResult"]]]
+    ],
+)
+
+slots.RepairReport_results = Slot(
+    uri=SH.result,
+    name="RepairReport_results",
+    curie=SH.curie("result"),
+    model_uri=VM.RepairReport_results,
+    domain=RepairReport,
+    range=Optional[
+        Union[Union[dict, "RepairOperation"], List[Union[dict, "RepairOperation"]]]
+    ],
+)

--- a/linkml_runtime/processing/validation_datamodel.yaml
+++ b/linkml_runtime/processing/validation_datamodel.yaml
@@ -1,0 +1,335 @@
+# TODO: fold this back into linkml-model
+id: https://w3id.org/linkml/validation_results
+title: Validation Results Datamodel
+name: validaton-results
+description: |-
+  A datamodel for data validation results.
+license: https://creativecommons.org/publicdomain/zero/1.0/
+
+prefixes:
+  linkml: https://w3id.org/linkml/
+  vm: https://w3id.org/linkml/validation-model/
+  skos: http://www.w3.org/2004/02/skos/core#
+  pav: http://purl.org/pav/
+  schema: http://schema.org/
+  sh: http://www.w3.org/ns/shacl#
+
+default_prefix: vm
+default_range: string
+
+default_curi_maps:
+  - semweb_context
+
+emit_prefixes:
+  - linkml
+  - rdf
+  - rdfs
+  - xsd
+  - owl
+
+imports:
+  - linkml:types
+
+#==================================
+# Classes                         #
+#==================================
+classes:
+
+
+  ConstraintCheck:
+    attributes:
+      id:
+        range: uriorcurie
+        identifier: true
+
+  Node:
+    attributes:
+      id:
+        range: uriorcurie
+        identifier: true
+
+  ValidationConfiguration:
+    description: Configuration parameters for execution of a validation report
+    attributes:
+      max_number_results_per_type:
+        range: integer
+        description: if set then truncate results such that no more than this number of results are reported per type
+      type_severity_map:
+        description: Allows overriding of severity of a particular type
+        range: TypeSeverityKeyValue
+        inlined: true
+        multivalued: true
+
+  RepairConfiguration:
+    description: Configuration parameters for execution of validation repairs
+    attributes:
+      validation_configuration:
+        description: repair configurations include validation configurations
+        range: ValidationConfiguration
+      dry_run:
+        range: boolean
+
+
+  TypeSeverityKeyValue:
+    description: key-value pair that maps a validation result type to a severity setting, for overriding default severity
+    conforms_to: wikidata:Q4818718
+    attributes:
+      type:
+        key: true
+        range: uriorcurie
+      severity:
+        range: SeverityType
+
+  Report:
+    abstract: true
+    description: A report object that is a holder to multiple report results
+    slots:
+      - results
+
+  ValidationReport:
+    is_a: Report
+    class_uri: sh:ValidationReport
+    description: A report that consists of validation results
+    slot_usage:
+      results:
+        range: ValidationResult
+    todos:
+      - add prov object
+
+  RepairReport:
+    is_a: Report
+    description: A report that consists of repair operation results
+    slot_usage:
+      results:
+        range: RepairOperation
+
+  Result:
+    abstract: true
+    description: Abstract base class for any individual report result
+
+  ValidationResult:
+    is_a: Result
+    class_uri: sh:ValidationResult
+    description: An individual result arising from validation of a data instance using a particular rule
+    slots:
+      - type
+      - severity
+      - subject
+      - instantiates
+      - predicate
+      - object
+      - object_str
+      - source
+      - info
+      - normalized
+      - repaired
+      - source_line_number
+      - source_column_number
+      - source_location
+
+  RepairOperation:
+    is_a: Result
+    description: The result of performing an individual repair
+    todos:
+      - integrate with kgcl data model, to be able to describe changes
+    attributes:
+      repairs:
+        range: ValidationResult
+      modified:
+        range: boolean
+      successful:
+        range: boolean
+      info:
+        range: string
+
+
+#==================================
+# Slots                           #
+#==================================
+slots:
+  type:
+    range: ConstraintType
+    slot_uri: sh:sourceConstraintComponent
+    description: >-
+      The type of validation result. SHACL validation vocabulary is recommended for checks against a datamodel.
+      For principle checks use the corresponding rule or principle, e.g. GO RULE ID, OBO Principle ID
+    required: true
+  subject:
+    description: The instance which the result is about
+    #range: Node
+    slot_uri: sh:focusNode
+    #required: true
+  instantiates:
+    description: The type of the subject
+    range: Node
+    exact_mappings:
+      - sh:sourceShape
+  predicate:
+    description: The predicate or property of the subject which the result is about
+    range: Node
+    related_mappings:
+      - sh:resultPath
+  object:
+    range: Node
+    slot_uri: sh:value
+  object_str:
+    range: string
+  source:
+    range: string
+  severity:
+    description: the severity of the issue
+    range: SeverityType
+    slot_uri: sh:resultSeverity
+  info:
+    description: additional information about the issue
+    range: string
+    slot_uri: sh:resultMessage
+  results:
+    description: collection of results
+    slot_uri: sh:result
+    range: Result
+    multivalued: true
+    inlined: true
+    inlined_as_list: true
+  normalized:
+    range: boolean
+  repaired:
+    range: boolean
+  source_line_number:
+    range: integer
+  source_column_number:
+    range: integer
+  source_location:
+
+#==================================
+# Enumerations                    #
+#==================================
+enums:
+  SeverityType:
+    exact_mappings:
+      - sh:Severity
+    permissible_values:
+      FATAL:
+      ERROR:
+        meaning: sh:Violation
+      WARNING:
+        meaning: sh:Warning
+      INFO:
+        meaning: sh:Info
+
+  ConstraintType:
+    # sh:sourceConstraintComponent
+    permissible_values:
+      TypeConstraint:
+        meaning: sh:DatatypeConstraintComponent
+        description: constraint in which the range is a type, and the slot value must conform to the type
+        annotations:
+          element: linkml:range
+      MinCountConstraint:
+        meaning: sh:MinCountConstraintComponent
+        description: cardinality constraint where the number of values of the slot must be greater or equal to a specified minimum
+        annotations:
+          element: linkml:minimum_value
+      RequiredConstraint:
+        is_a: MinCountConstraint
+        meaning: sh:MinCountConstraintComponent
+        description: cardinality constraint where there MUST be at least one value of the slot
+        annotations:
+          element: linkml:required
+      RecommendedConstraint:
+        is_a: MinCountConstraint
+        meaning: sh:MinCountConstraintComponent
+        description: cardinality constraint where there SHOULD be at least one value of the slot
+        annotations:
+          element: linkml:recommended
+          severity: WARNING
+      MaxCountConstraint:
+        meaning: sh:MaxCountConstraintComponent
+        description: cardinality constraint where the number of values of the slot must be less than or equal to a specified maximum
+        annotations:
+          element: linkml:maximum_value
+      SingleValuedConstraint:
+        is_a: MaxCountConstraint
+        description: the value of the slot must be atomic and not a collection
+      MultiValuedConstraint:
+        description: the value of the slot must be a collection and not atomic
+      DeprecatedProperty:
+        meaning: vm:DeprecatedProperty
+        description: constraint where the instance slot should not be deprecated
+        annotations:
+          element: linkml:deprecated
+      MaxLengthConstraint:
+        meaning: sh:MaxLengthConstraintComponent
+        description: constraint where the slot value must have a length equal to or less than a specified maximum
+      MinLengthConstraint:
+        meaning: sh:MinLengthConstraintComponent
+        description: constraint where the slot value must have a length equal to or less than a specified maximum
+      PatternConstraint:
+        meaning: sh:PatternConstraintComponent
+        description: constraint where the slot value must match a given regular expression pattern
+        annotations:
+          element: linkml:pattern
+      ClosedClassConstraint:
+        meaning: sh:ClosedConstraintComponent
+        description: constraint where the slot value must be allowable for the instantiated class
+        annotations:
+          element: linkml:attributes
+      DesignatesTypeConstraint:
+      InstanceConstraint:
+        meaning: sh:NodeConstraintComponent
+      SlotConstraint:
+        meaning: sh:PropertyConstraintComponent
+      PermissibleValueConstraint:
+        meaning: sh:InConstraintComponent
+        description: constraint where the slot value must be one of a set of permissible values
+        annotations:
+          element: linkml:permissible_values
+      UndeclaredSlotConstraint:
+        is_a: ClosedClassConstraint
+      RuleConstraint:
+        description: constraint where the structure of an object must conform to a specified rule
+      ExpressionConstraint:
+      EqualsExpressionConstraint:
+        is_a: ExpressionConstraint
+        meaning: sh:EqualsConstraintComponent
+        annotations:
+          element: linkml:equals_expression
+      LessThanExpressionConstraint:
+        is_a: ExpressionConstraint
+        meaning: sh:LessThanConstraintComponent
+      LessThanOrEqualsExpressionConstraint:
+        is_a: ExpressionConstraint
+        meaning: sh:LessThanOrEqualsComponent
+      DisjointConstraint:
+        is_a: ExpressionConstraint
+        meaning: sh:DisjointConstraintComponent
+      MinimumValueConstraint:
+        meaning: sh:MinInclusiveConstraintComponent
+        annotations:
+          element: linkml:minimum_value
+      MaximumValueConstraint:
+        meaning: sh:MaxInclusiveConstraintComponent
+        annotations:
+          element: linkml:maximum_exclusive_value
+      MinimumExclusiveValueConstraint:
+        meaning: sh:MinExclusiveInclusiveConstraintComponent
+        annotations:
+          element: linkml:minimum_value
+      MaximumExclusiveValueConstraint:
+        meaning: sh:MaxExclusiveInclusiveConstraintComponent
+        annotations:
+          element: linkml:maximum_exclusive_value
+      CollectionFormConstraint:
+      ListCollectionFormConstraint:
+        is_a: CollectionFormConstraint
+      DictCollectionFormConstraint:
+        is_a: CollectionFormConstraint
+      SimpleDictCollectionFormConstraint:
+        is_a: DictCollectionFormConstraint
+      CompactDictCollectionFormConstraint:
+        is_a: DictCollectionFormConstraint
+      ExpandedDictCollectionFormConstraint:
+        is_a: DictCollectionFormConstraint
+      
+
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ packages = [
 
 [tool.poetry.scripts]
 comparefiles = "linkml_runtime.utils.comparefiles:cli"
+linkml-normalize = "linkml_runtime.processing.referencevalidator:cli"
 
 [tool.poetry.dependencies]
 python = "^3.7.6"

--- a/tests/test_processing/test_referencevalidator.py
+++ b/tests/test_processing/test_referencevalidator.py
@@ -1,0 +1,1168 @@
+import json
+import unittest
+import datetime
+from collections import namedtuple
+from dataclasses import dataclass, field
+from decimal import Decimal
+from io import StringIO
+from pathlib import Path
+from typing import Optional, Any, List, Union
+
+import yaml
+
+from examples import PermissibleValue
+from linkml_runtime.dumpers import yaml_dumper, json_dumper
+from linkml_runtime.linkml_model import SlotDefinition, SlotDefinitionName
+from linkml_runtime.utils.introspection import package_schemaview
+from linkml_runtime.utils.schemaview import SchemaView
+
+from linkml_runtime.utils.schema_builder import SchemaBuilder
+from linkml_runtime.processing.referencevalidator import (
+    ReferenceValidator,
+    Report,
+    ConstraintType,
+    CollectionForm,
+)
+from linkml_runtime.utils.yamlutils import DupCheckYamlLoader
+
+
+@dataclass
+class MarkdownDocument:
+    """
+    Convenience class for generating markdown
+    """
+
+    writer: StringIO = field(default_factory=lambda: StringIO())
+
+    def h1(self, header: str, text: Optional[str] = None):
+        self.h("#", header, text)
+
+    def h2(self, header: str, text: Optional[str] = None):
+        self.h("##", header, text)
+
+    def h3(self, header: str, text: Optional[str] = None):
+        self.h("###", header, text)
+
+    def h4(self, header: str, text: Optional[str] = None):
+        self.h("####", header, text)
+
+    def h(self, level: str, header: str, text: Optional[str] = None):
+        self.w(f"\n{level} {header}\n\n")
+        if text:
+            self.w(f"{text}\n")
+
+    def li(self, item: str):
+        self.w(f" * {item}\n")
+
+    def object(self, obj: Any):
+        if isinstance(obj, dict):
+            obj = yaml.dump(obj)
+        self.w(f"```yaml\n{obj}\n```\n\n")
+
+    def text(self, text: str):
+        self.w(text)
+        self.w("\n\n")
+
+    def italics(self, text: str):
+        self.text(f"_{text.replace('_', '-')}_")
+
+    def w(self, text: str):
+        self.writer.write(text)
+
+    def th(self, cols: List[str]):
+        self.w("\n")
+        self.tr(cols)
+        self.tr(["---" for _ in cols])
+
+    def tr(self, cols: List[str]):
+        self.w(f"|{'|'.join([str(c) for c in cols])}|\n")
+
+    def __repr__(self) -> str:
+        return self.writer.getvalue()
+
+
+OUTPUT_DIRECTORY = Path(__file__).parent / "output" / "suite"
+TEST_TIME = datetime.datetime(2023, 1, 21, 17, 24, 36, 385155)
+
+
+def _add_core_schema_elements(
+    sb: SchemaBuilder, test_slot: Optional[SlotDefinition] = None
+):
+    sb.add_slot("id", range="string", identifier=True)
+    sb.add_class("Identified", slots=["id", "name", "description"])
+    sb.add_class("NonIdentified", slots=["name", "description"])
+    sb.add_class("Simple", slots=["id", "name"])
+    if test_slot:
+        sb.add_class("TestClass", slots=[test_slot])
+
+
+METASLOTS = ["range", "multivalued", "inlined", "inlined_as_list"]
+
+
+def _slot_metaslot_values(slot: SlotDefinition) -> List[Any]:
+    return [
+        slot.range or "string",
+        slot.multivalued or False,
+        slot.inlined or False,
+        slot.inlined_as_list or False,
+    ]
+
+
+def _serialize(obj: Any) -> str:
+    return json.dumps(obj)
+
+
+def _normalizations(report: Report) -> str:
+    return ", ".join(
+        [
+            f"{f1.value}->{f2.value}"
+            for f1, f2 in report.collection_form_normalizations()
+        ]
+    )
+
+
+class ReferenceValidatorTestCase(unittest.TestCase):
+    """
+    This unit test will run the core LinkML validation suite.
+
+    This test is auto-documenting:
+
+    A side-effect of running this test is a markdown file
+    that generates a report of all inputs and outputs;
+    this is to be copied back to the linkml-model repo where
+    it resides as an appendix to the specification.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Class-level setup.
+
+        Sets up a document object that each test will contribute to.
+        """
+        print("Setting up class...")
+        doc = MarkdownDocument()
+        doc.h1("Validation Suite")
+        doc.text("This document describes the validation suite for the LinkML model.")
+        doc.h2("Core schema")
+        doc.text("Most tests use the core minimal test schema:")
+        sb = SchemaBuilder()
+        _add_core_schema_elements(sb)
+        doc.object(yaml_dumper.dumps(sb.schema))
+        cls.doc = doc
+
+    def setUp(self) -> None:
+        OUTPUT_DIRECTORY.mkdir(parents=True, exist_ok=True)
+
+    @classmethod
+    def tearDownClass(cls):
+        """Write out the document object to a markdown file."""
+        cls.doc.text("End of report")
+        with open(str(OUTPUT_DIRECTORY / "results.md"), "w", encoding="UTF-8") as f:
+            f.write(str(cls.doc))
+
+    def _get_normalizer(self, sb: Optional[SchemaBuilder] = None) -> ReferenceValidator:
+        if sb is None:
+            sb = SchemaBuilder()
+        sb.add_defaults()
+        sv = SchemaView(sb.schema)
+        return ReferenceValidator(sv)
+
+    def _assert_unrepaired_types_the_same(
+        self, report: Report, expected_unrepaired, input_object: Any, output_object: Any
+    ):
+        # TODO: simplify after https://github.com/linkml/linkml/issues/1203
+        unrepaired_problem_types = report.unrepaired_problem_types()
+
+        def _as_type(x: Union[ConstraintType, PermissibleValue]) -> str:
+            if not isinstance(x, ConstraintType):
+                return ConstraintType(x.text)
+            return x
+
+        expected_unrepaired_vals = [_as_type(v) for v in expected_unrepaired]
+        unrepaired_problem_types_vals = [_as_type(v) for v in unrepaired_problem_types]
+        self.assertCountEqual(
+            expected_unrepaired_vals,
+            unrepaired_problem_types_vals,
+            f"{input_object} -> {output_object}",
+        )
+
+    def test_01_infer_collection_form(self):
+        """Test that we can infer the collection form of a slot."""
+        doc = self.doc
+        doc.h2(
+            "Collection Form Inference Tests",
+            "Tests that the correct CollectionForm is inferred based on slot properties.",
+        )
+        cases = [
+            (SlotDefinition("s", multivalued=False), CollectionForm.NonCollection),
+            (
+                SlotDefinition("s", multivalued=False, range="string"),
+                CollectionForm.NonCollection,
+            ),
+            (
+                SlotDefinition("s", multivalued=False, range="Simple"),
+                CollectionForm.NonCollection,
+            ),
+            (
+                SlotDefinition("s", multivalued=False, range="Identified"),
+                CollectionForm.NonCollection,
+            ),
+            (
+                SlotDefinition("s", multivalued=False, range="NonIdentified"),
+                CollectionForm.NonCollection,
+            ),
+            (SlotDefinition("s", multivalued=True), CollectionForm.List),
+            (
+                SlotDefinition("s", multivalued=True, range="string"),
+                CollectionForm.List,
+            ),
+            (
+                SlotDefinition("s", multivalued=True, range="NonIdentified"),
+                CollectionForm.List,
+            ),
+            (
+                SlotDefinition("s", multivalued=True, range="Identified"),
+                CollectionForm.List,
+            ),
+            (
+                SlotDefinition("s", multivalued=True, range="Simple"),
+                CollectionForm.List,
+            ),
+            (
+                SlotDefinition("s", multivalued=True, inlined=True, range="Identified"),
+                CollectionForm.CompactDict,
+            ),
+            (
+                SlotDefinition(
+                    "s", multivalued=True, inlined=True, range="NonIdentified"
+                ),
+                CollectionForm.CompactDict,
+            ),
+            (
+                SlotDefinition("s", multivalued=True, inlined=True, range="Simple"),
+                CollectionForm.SimpleDict,
+            ),
+            (
+                SlotDefinition(
+                    "s", multivalued=True, inlined_as_list=True, range="Identified"
+                ),
+                CollectionForm.List,
+            ),
+            (
+                SlotDefinition(
+                    "s", multivalued=True, inlined_as_list=True, range="NonIdentified"
+                ),
+                CollectionForm.List,
+            ),
+            (
+                SlotDefinition(
+                    "s", multivalued=True, inlined_as_list=True, range="Simple"
+                ),
+                CollectionForm.List,
+            ),
+        ]
+        doc.text(
+            "Expected collection form for different combinations of slot properties:"
+        )
+        doc.th(METASLOTS + ["CollectionForm"])
+        for slot, expected in cases:
+            sb = SchemaBuilder()
+            _add_core_schema_elements(sb, slot)
+            normalizer = self._get_normalizer(sb)
+            self.assertEqual(
+                expected,
+                normalizer.infer_slot_collection_form(slot),
+                f"{slot} -> {expected}",
+            )
+            doc.tr(_slot_metaslot_values(slot) + [expected])
+
+    def test_02_ensure_collection_forms(self):
+        """Test normalization into a collection form."""
+        doc = self.doc
+        doc.h2(
+            "Collection Form Coercion Tests",
+            "Test cases for coercing input objects to a specified collection form.",
+        )
+        obj_identified_minimal = {"id": "id1"}
+        obj_non_identified_minimal = {"name": "name1"}
+        obj_simple = {"id": "id1", "name": "name1"}
+        cases = [
+            (
+                CollectionForm.NonCollection,
+                SlotDefinition("s", range="string"),
+                [
+                    ("x", [], [], "x"),
+                    ("", [], [], ""),
+                    (
+                        ["x"],
+                        [(CollectionForm.List, CollectionForm.NonCollection)],
+                        [],
+                        "x",
+                    ),
+                    (
+                        [],
+                        [(CollectionForm.List, CollectionForm.NonCollection)],
+                        [],
+                        None,
+                    ),
+                ],
+            ),
+            (
+                CollectionForm.NonCollection,
+                SlotDefinition("s", range="NonIdentified"),
+                [
+                    (obj_non_identified_minimal, [], [], obj_non_identified_minimal),
+                    (
+                        [obj_non_identified_minimal],
+                        [(CollectionForm.List, CollectionForm.NonCollection)],
+                        [],
+                        obj_non_identified_minimal,
+                    ),
+                ],
+            ),
+            (
+                CollectionForm.NonCollection,
+                SlotDefinition("s", range="Identified", inlined=False),
+                [
+                    ("id1", [], [], "id1"),
+                    (
+                        ["id1"],
+                        [(CollectionForm.List, CollectionForm.NonCollection)],
+                        [],
+                        "id1",
+                    ),
+                ],
+            ),
+            (
+                CollectionForm.NonCollection,
+                SlotDefinition("s", range="Simple", inlined=True),
+                [
+                    (obj_simple, [], [], obj_simple),
+                    # ({"id1": obj_simple}, [], [], obj_simple),
+                ],
+            ),
+            (
+                CollectionForm.List,
+                SlotDefinition("s", range="string", multivalued=True),
+                [
+                    (["x"], [], [], ["x"]),
+                    (
+                        "x",
+                        [(CollectionForm.NonCollection, CollectionForm.List)],
+                        [],
+                        ["x"],
+                    ),
+                    ([], [], [], []),
+                ],
+            ),
+            (
+                CollectionForm.List,
+                SlotDefinition(
+                    "s", range="NonIdentified", multivalued=True
+                ),  # inlined is inferred
+                [
+                    (
+                        [obj_non_identified_minimal],
+                        [],
+                        [],
+                        [obj_non_identified_minimal],
+                    ),
+                    # indistinguishable from dict
+                    # (obj_non_identified_minimal, [(CollectionForm.NonCollection, CollectionForm.List)], [], [obj_non_identified_minimal]),
+                ],
+            ),
+            (
+                CollectionForm.List,
+                SlotDefinition("s", range="Identified", multivalued=True, inlined=True),
+                [
+                    ([obj_identified_minimal], [], [], [obj_identified_minimal]),
+                    (
+                        {"id1": obj_identified_minimal},
+                        [(CollectionForm.ExpandedDict, CollectionForm.List)],
+                        [],
+                        [obj_identified_minimal],
+                    ),
+                    (
+                        {"id1": obj_simple},
+                        [(CollectionForm.ExpandedDict, CollectionForm.List)],
+                        [],
+                        [obj_simple],
+                    ),
+                    # TODO: SimpleDict to List
+                    # ({"id1": "name1"}, [(CollectionForm.SimpleDict, CollectionForm.List)], [], [obj_simple]),
+                ],
+            ),
+            (
+                CollectionForm.List,
+                SlotDefinition(
+                    "s", range="Identified", multivalued=True, inlined=False
+                ),
+                [
+                    (["id1"], [], [], ["id1"]),
+                ],
+            ),
+            (
+                CollectionForm.List,
+                SlotDefinition("s", range="Simple", multivalued=True, inlined=True),
+                [
+                    ([obj_simple], [], [], [obj_simple]),
+                ],
+            ),
+            (
+                CollectionForm.ExpandedDict,
+                SlotDefinition("s", range="Identified", multivalued=True, inlined=True),
+                [
+                    (
+                        {"id1": obj_identified_minimal},
+                        [],
+                        [],
+                        {"id1": obj_identified_minimal},
+                    ),
+                ],
+            ),
+            (
+                CollectionForm.ExpandedDict,
+                SlotDefinition("s", range="Simple", multivalued=True, inlined=True),
+                [
+                    ({"id1": {}}, [], [], {"id1": obj_identified_minimal}),
+                    (
+                        {"id1": "name1"},
+                        [(CollectionForm.SimpleDict, CollectionForm.ExpandedDict)],
+                        [],
+                        {"id1": obj_simple},
+                    ),
+                ],
+            ),
+            (
+                CollectionForm.CompactDict,
+                {"range": "Identified", "inlined": True},
+                [
+                    ({}, [], [], {}),
+                    ({"id1": {"name": "name1"}}, [], [], {"id1": {"name": "name1"}}),
+                    (
+                        {"id1": {"id": "id1", "name": "name1"}},
+                        [(CollectionForm.ExpandedDict, CollectionForm.CompactDict)],
+                        [],
+                        {"id1": {"name": "name1"}},
+                    ),
+                ],
+            ),
+            (
+                CollectionForm.SimpleDict,
+                {"range": "Simple", "inlined": True},
+                [
+                    ({}, [], [], {}),
+                    ({"id1": "name1"}, [], [], {"id1": "name1"}),
+                    # ([{"id1": "name1"}], [(CollectionForm.List, CollectionForm.SimpleDict)], [], {"id1": "name1"}),
+                    (
+                        {"id1": obj_simple},
+                        [(CollectionForm.ExpandedDict, CollectionForm.SimpleDict)],
+                        [],
+                        {"id1": "name1"},
+                    ),
+                    (
+                        {"id1": {"name": "name1"}},
+                        [(CollectionForm.CompactDict, CollectionForm.SimpleDict)],
+                        [],
+                        {"id1": "name1"},
+                    ),
+                    (
+                        [obj_simple],
+                        [(CollectionForm.List, CollectionForm.SimpleDict)],
+                        [],
+                        {"id1": "name1"},
+                    ),
+                    ([], [(CollectionForm.List, CollectionForm.SimpleDict)], [], {}),
+                ],
+            ),
+        ]
+        doc.th(METASLOTS + ["input", "output", "coerced_form", "normalizations"])
+        for case in cases:
+            form, slot_info, examples = case
+            sb = SchemaBuilder()
+            if isinstance(slot_info, dict):
+                slot = SlotDefinition("s", **slot_info)
+            else:
+                slot = slot_info
+            slot.multivalued = form != CollectionForm.NonCollection
+            _add_core_schema_elements(sb, slot)
+            normalizer = self._get_normalizer(sb)
+            if slot.range in ["Identified", "Simple"]:
+                pk_slot_name = SlotDefinitionName("id")
+            else:
+                pk_slot_name = None
+            for example in examples:
+                input, expected_repairs, expected_unrepaired, expected_output = example
+                report = Report()
+                if form == CollectionForm.NonCollection:
+                    output = normalizer.ensure_non_collection(
+                        input, slot, pk_slot_name, report
+                    )
+                elif form == CollectionForm.List:
+                    output = normalizer.ensure_list(input, slot, pk_slot_name, report)
+                elif form == CollectionForm.ExpandedDict:
+                    output = normalizer.ensure_expanded_dict(
+                        input, slot, pk_slot_name, report
+                    )
+                elif form == CollectionForm.CompactDict:
+                    output = normalizer.ensure_compact_dict(
+                        input, slot, pk_slot_name, report
+                    )
+                elif form == CollectionForm.SimpleDict:
+                    output = normalizer.ensure_simple_dict(
+                        input, slot, pk_slot_name, report
+                    )
+                else:
+                    raise AssertionError(f"{form} unrecognized")
+                doc.tr(
+                    _slot_metaslot_values(slot)
+                    + [
+                        _serialize(input),
+                        _serialize(output),
+                        form.value,
+                        _normalizations(report),
+                    ]
+                )
+                self.assertEqual(expected_output, output)
+                self.assertEqual(
+                    len(expected_unrepaired),
+                    len(report.unrepaired()),
+                    f"case: {case} {report.unrepaired()}",
+                )
+                self.assertEqual(
+                    len(expected_repairs),
+                    len(report.repaired()),
+                    f"case: {case} {report.repaired()}",
+                )
+
+    def test_03_slot_values(self):
+        doc = self.doc
+        doc.h2("Slot Value Tests")
+        doc.text("Validation and normalization of collection forms.")
+        Inst_nt = namedtuple(
+            "Inst",
+            [
+                "desc",
+                "svs",
+                "expected_repairs",
+                "expected_unrepaired",
+                "expected_output",
+            ],
+        )
+        ref1 = {"id": "id1", "name": "name1"}
+        ref1ni = {"name": "name1"}
+        cases = [
+            (
+                SlotDefinition(
+                    "s",
+                    multivalued=True,
+                    range="Identified",
+                    inlined=True,
+                    inlined_as_list=True,
+                    description="List of inlined objects",
+                ),
+                [
+                    Inst_nt("empty parent object", {}, [], [], {}),
+                    Inst_nt(
+                        "slot value is valid empty list", {"s": []}, [], [], {"s": []}
+                    ),
+                    Inst_nt(
+                        "slot value is valid list", {"s": [ref1]}, [], [], {"s": [ref1]}
+                    ),
+                    Inst_nt(
+                        "slot value is expanded dict",
+                        {"s": {ref1["id"]: ref1}},
+                        [(CollectionForm.ExpandedDict, CollectionForm.List)],
+                        [],
+                        {"s": [ref1]},
+                    ),
+                    Inst_nt(
+                        "slot valid is empty dict",
+                        {"s": {}},
+                        [(CollectionForm.ExpandedDict, CollectionForm.List)],
+                        [],
+                        {"s": []},
+                    ),
+                    Inst_nt(
+                        "incorrect slot",
+                        {"t": "x"},
+                        [],
+                        [ConstraintType.ClosedClassConstraint],
+                        {"t": "x"},
+                    ),
+                    Inst_nt(
+                        "slot value is a list containing a non-object",
+                        {"s": ["x"]},
+                        [],
+                        [ConstraintType.DictCollectionFormConstraint],
+                        {"s": ["x"]},
+                    ),
+                    # Note: this is indistinguishable from a dict serialization
+                    # Inst_nt("...", {"s": ref1}, [(Form.Atom, Form.List)], [], {"s": [ref1]}),
+                ],
+            ),
+            (
+                SlotDefinition(
+                    "s",
+                    multivalued=True,
+                    range="NonIdentified",
+                    description="List of necessarily inlined objects",
+                ),
+                [
+                    Inst_nt("parent object is empty", {}, [], [], {}),
+                    Inst_nt(
+                        "slot value is valid empty list", {"s": []}, [], [], {"s": []}
+                    ),
+                    Inst_nt(
+                        "slot value is object list",
+                        {"s": [ref1ni]},
+                        [],
+                        [],
+                        {"s": [ref1ni]},
+                    ),
+                    # Inst_nt("...", {"s": ref1ni}, [(Form.NonCollection, Form.List)], [], {"s": [ref1ni]}),
+                    # Inst_nt("...", {"s": {}}, [(Form.ExpandedDict, Form.List)], [], {"s": []}),
+                    Inst_nt(
+                        "incorrect slot",
+                        {"t": "x"},
+                        [],
+                        [ConstraintType.ClosedClassConstraint],
+                        {"t": "x"},
+                    ),
+                ],
+            ),
+            (
+                SlotDefinition(
+                    "s",
+                    multivalued=True,
+                    range="Identified",
+                    inlined=True,
+                    inlined_as_list=False,
+                    description="Dict of inlined objects",
+                ),
+                [
+                    Inst_nt("parent object is empty", {}, [], [], {}),
+                    Inst_nt(
+                        "slot value is empty dictionary", {"s": {}}, [], [], {"s": {}}
+                    ),
+                    Inst_nt(
+                        "slot value is inlined list",
+                        {"s": [ref1]},
+                        [(CollectionForm.List, CollectionForm.CompactDict)],
+                        [],
+                        {"s": {ref1["id"]: {"name": "name1"}}},
+                    ),
+                    Inst_nt(
+                        "slot value is expanded dict",
+                        {"s": {ref1["id"]: ref1}},
+                        [(CollectionForm.ExpandedDict, CollectionForm.CompactDict)],
+                        [],
+                        {"s": {ref1["id"]: {"name": "name1"}}},
+                    ),
+                    Inst_nt(
+                        "slot value is compact dict",
+                        {"s": {ref1["id"]: {"name": "name1"}}},
+                        [],
+                        [],
+                        {"s": {ref1["id"]: {"name": "name1"}}},
+                    ),
+                    Inst_nt(
+                        "slot value is empty list",
+                        {"s": []},
+                        [(CollectionForm.List, CollectionForm.ExpandedDict)],
+                        [],
+                        {"s": {}},
+                    ),
+                    Inst_nt(
+                        "incorrect slot",
+                        {"t": "x"},
+                        [],
+                        [ConstraintType.ClosedClassConstraint],
+                        {"t": "x"},
+                    ),
+                    # Inst_nt("...", {"s": ref1}, [(Form.Atom, Form.List)], [], {"s": [ref1]}),
+                ],
+            ),
+            (
+                SlotDefinition(
+                    "s",
+                    multivalued=True,
+                    range="Simple",
+                    inlined=True,
+                    description="Simple dict",
+                ),
+                [
+                    Inst_nt("empty parent object", {}, [], [], {}),
+                    Inst_nt(
+                        "slot value is simple dict",
+                        {"s": {"id1": "name1"}},
+                        [],
+                        [],
+                        {"s": {"id1": "name1"}},
+                    ),
+                    # Inst_nt(
+                    #    "slot value is empty dict",
+                    #    {"s": {"id1": None}},
+                    #    [],
+                    #    [],
+                    #    {"s": {"id1": None}},
+                    # ),
+                    Inst_nt(
+                        "slot value is expanded dict",
+                        {"s": {ref1["id"]: ref1}},
+                        [(CollectionForm.ExpandedDict, CollectionForm.SimpleDict)],
+                        [],
+                        {"s": {"id1": "name1"}},
+                    ),
+                    Inst_nt(
+                        "slot value is compact dict",
+                        {"s": {ref1["id"]: {"name": "name1"}}},
+                        [(CollectionForm.CompactDict, CollectionForm.SimpleDict)],
+                        [],
+                        {"s": {"id1": "name1"}},
+                    ),
+                    Inst_nt(
+                        "slot value is list of objects",
+                        {"s": [ref1]},
+                        # TODO: compress into single operation
+                        [
+                            (CollectionForm.List, CollectionForm.SimpleDict),
+                        ],
+                        [],
+                        {"s": {"id1": "name1"}},
+                    ),
+                ],
+            ),
+            (
+                SlotDefinition(
+                    "s",
+                    multivalued=True,
+                    range="Identified",
+                    inlined=False,
+                    description="List of references",
+                ),
+                [
+                    Inst_nt("parent object is empty", {}, [], [], {}),
+                    Inst_nt(
+                        "slot value is list of references",
+                        {"s": ["x"]},
+                        [],
+                        [],
+                        {"s": ["x"]},
+                    ),
+                    Inst_nt(
+                        "slot value is a single reference",
+                        {"s": "x"},
+                        [(CollectionForm.NonCollection, CollectionForm.List)],
+                        [],
+                        {"s": ["x"]},
+                    ),
+                    Inst_nt(
+                        "...",
+                        {"t": "x"},
+                        [],
+                        [ConstraintType.ClosedClassConstraint],
+                        {"t": "x"},
+                    ),
+                ],
+            ),
+            (
+                SlotDefinition(
+                    "s",
+                    multivalued=False,
+                    range="Identified",
+                    inlined=True,
+                    description="Single inlined object",
+                ),
+                [
+                    Inst_nt("...", {}, [], [], {}),
+                    Inst_nt("...", {"s": ref1}, [], [], {"s": ref1}),
+                    Inst_nt(
+                        "...",
+                        {"s": [ref1]},
+                        [(CollectionForm.List, CollectionForm.NonCollection)],
+                        [],
+                        {"s": ref1},
+                    ),
+                    Inst_nt(
+                        "...",
+                        {"t": "x"},
+                        [],
+                        [ConstraintType.ClosedClassConstraint],
+                        {"t": "x"},
+                    ),
+                ],
+            ),
+        ]
+        for slot, examples in cases:
+            doc.h3(f"Case: {slot.description}")
+            doc.text("Slot Properties:")
+            doc.object(yaml_dumper.dumps(slot))
+            sb = SchemaBuilder()
+            sb.add_slot("id", range="string", identifier=True)
+            sb.add_class("Identified", slots=["id", "name", "description"])
+            sb.add_class("NonIdentified", slots=["name", "description"])
+            sb.add_class("Simple", slots=["id", "name"])
+            sb.add_class("TestClass", slots=[slot])
+            normalizer = self._get_normalizer(sb)
+            base_name = slot.description.lower().replace(" ", "-")
+            yaml_dumper.dump(
+                normalizer.derived_schema,
+                OUTPUT_DIRECTORY / f"SchemaDefinition-{base_name}-derived.yaml",
+            )
+            tc = normalizer.derived_schema.classes["TestClass"]
+            for example in examples:
+                (
+                    inst_description,
+                    inst,
+                    expected_repairs,
+                    expected_unrepaired,
+                    expected_output,
+                ) = example
+                inst_yaml = yaml_dumper.dumps(inst)
+                report = Report()
+                output_object = normalizer.normalize_object(inst, tc, report)
+                self.assertEqual(
+                    inst_yaml,
+                    yaml_dumper.dumps(inst),
+                    f"input should be immutable; {inst_yaml} changed to {yaml_dumper.dumps(inst)}",
+                )
+                self.assertEqual(
+                    expected_output,
+                    output_object,
+                    f"Mismatch for {slot.description} => {inst_description}",
+                )
+                self.assertEqual(
+                    len(expected_repairs),
+                    len(report.repaired()),
+                    f"Mismatch for {slot.description} =>  => {inst_description} . {report.repaired()}",
+                )
+                self._assert_unrepaired_types_the_same(
+                    report, expected_unrepaired, inst, output_object
+                )
+                doc.h4("Example")
+                if not expected_repairs and not expected_unrepaired:
+                    valid = "Valid"
+                elif not expected_unrepaired:
+                    valid = "Repairable"
+                else:
+                    valid = "Invalid"
+                doc.text(f"{valid} Input:")
+                doc.object(inst)
+                doc.italics(inst_description)
+                if report.repaired():
+                    doc.text("Normalized Output:")
+                    doc.object(output_object)
+                    doc.text("Normalizations Applied:")
+                    for r in report.repaired():
+                        doc.li(str(r))
+                if report.unrepaired():
+                    doc.text("Validation Errors (Post-Normalization)")
+                    for r in report.unrepaired():
+                        doc.object(r)
+
+    def test_05_type_ranges(self):
+        cases = [
+            ("maximum_value", "integer", 10, [5, 10], [11]),
+            ("minimum_value", "integer", 10, [11, 10], [5]),
+            ("pattern", "string", "^[a-z]+$", ["a", "abc"], ["", "a b", "A"]),
+            ("equals_string", "string", "abc", ["abc"], ["ab"]),
+            ("equals_expression", "integer", "5*5", [25], [24]),
+        ]
+        for metaslot, range, metaval, valid_examples, invalid_examples in cases:
+            sb = SchemaBuilder()
+            sb.add_slot("s", range=range, **{metaslot: metaval})
+            sb.add_class("TestClass", slots=["s"])
+            normalizer = self._get_normalizer(sb)
+            derived_schema = normalizer.derived_schema
+            tc = derived_schema.classes["TestClass"]
+            for ex in valid_examples:
+                report = Report()
+                normalizer.normalize_object({"s": ex}, tc, report)
+                self.assertEqual([], report.results, f"{metaslot} = {ex}")
+            for ex in invalid_examples:
+                report = Report()
+                normalizer.normalize_object({"s": ex}, tc, report)
+                self.assertNotEqual([], report.results, f"{metaslot} = {ex}")
+
+    def test_06_object_ranges(self):
+        cases = [
+            ("TestClass", {"aref_A": {"id": "a", "name": "n", "ms": "v"}}, []),
+            (
+                "TestClass",
+                {"aref_A": {"id": "a", "name": "n", "m1s": "v"}},
+                [ConstraintType.ClosedClassConstraint],
+            ),
+            ("TestClass", {"aref_A1": {"id": "a", "a1s": "v", "m1s": "v"}}, []),
+            ("TestClass", {"aref_A": {"id": "a", "type": "A"}}, []),
+            ("TestClass", {"aref_A": {"id": "a", "type": "A1"}}, []),
+            (
+                "TestClass",
+                {"aref_A11": {"id": "a", "type": "A12"}},
+                [ConstraintType.DesignatesTypeConstraint],
+            ),
+        ]
+        sb = SchemaBuilder()
+        sb.add_slot("id", identifier=True)
+        sb.add_slot("type", designates_type=True)
+        sb.add_class("A", slots=["id", "name", "type"], mixins=["M"])
+        sb.add_class("A1", slots=["a1s"], is_a="A", mixins=["M1"])
+        sb.add_class("A11", slots=["a11s"], is_a="A1", mixins=["M11"])
+        sb.add_class("A12", slots=["a12s"], is_a="A1", mixins=["M12"])
+        sb.add_class("M", slots=["ms", "self"], mixin=True)
+        sb.add_class("M1", slots=["m1s"], mixin=True)
+        sb.add_class("M11", slots=["m11s"], mixin=True)
+        sb.add_class("M12", slots=["m12s"], mixin=True)
+        sb.add_class("TestClass", slots=["s", "type"])
+        for c in sb.schema.classes.values():
+            c.slot_usage["self"] = SlotDefinition("self", range=c.name, inlined=True)
+            sb.add_slot(f"aref_{c.name}", range=c.name, inlined=True)
+            sb.schema.classes["TestClass"].slots.append(f"aref_{c.name}")
+        normalizer = self._get_normalizer(sb)
+        derived_schema = normalizer.derived_schema
+        for case in cases:
+            cn, inst, expected_problems = case
+            report = Report()
+            normalizer.normalize_object(inst, derived_schema.classes[cn], report)
+            self._assert_unrepaired_types_the_same(
+                report, expected_problems, inst, inst
+            )
+
+    def test_07_normalize_enums(self):
+        sb = SchemaBuilder()
+        self.doc.h2("Enum Tests")
+        sb.add_enum("TestEnum", permissible_values=["A", "B", "C"])
+        normalizer = self._get_normalizer(sb)
+        derived_schema = normalizer.derived_schema
+        cases = [
+            ("A", [], [], "A"),
+            ("D", [], [ConstraintType.PermissibleValueConstraint], "D"),
+        ]
+        for (
+            input_object,
+            expected_repairs,
+            expected_unrepaired,
+            expected_output,
+        ) in cases:
+            report = Report()
+            output = normalizer.normalize_enum(
+                input_object, derived_schema.enums["TestEnum"], report
+            )
+            self.assertEqual(expected_output, output)
+            self.assertCountEqual(expected_repairs, report.repaired())
+            self._assert_unrepaired_types_the_same(
+                report, expected_unrepaired, input_object, output
+            )
+
+    def test_08_normalize_types(self):
+        doc = self.doc
+        doc.h2("Type Tests")
+        sb = SchemaBuilder()
+        cases = {
+            "string": [
+                ("foo", [], [], "foo"),
+                ("", [], [], ""),
+                (5, [("integer", "string")], [], "5"),
+                (5.0, [("float", "string")], [], "5.0"),
+                (None, [], [], None),
+            ],
+            "integer": [
+                (5, [], [], 5),
+                ("5", [("string", "integer")], [], 5),
+                (5.0, [("float", "integer")], [], 5),
+                (5.5, [("float", "integer")], [], 5),
+                ("5x", [], [ConstraintType.TypeConstraint], "5x"),
+                (None, [], [], None),
+            ],
+            "float": [
+                (5.5, [], [], 5.5),
+                ("5.5", [("string", "float")], [], 5.5),
+                (5, [("integer", "float")], [], 5.0),
+                ("5x", [], [ConstraintType.TypeConstraint], "5x"),
+                (None, [], [], None),
+            ],
+            "double": [
+                (5.5, [], [], 5.5),
+                ("5.5", [("string", "float")], [], 5.5),
+                (5, [("integer", "float")], [], 5.0),
+                ("5x", [], [ConstraintType.TypeConstraint], "5x"),
+                (None, [], [], None),
+            ],
+            "decimal": [
+                (Decimal("5"), [], [], Decimal("5")),
+                (Decimal("5.5"), [], [], Decimal("5.5")),
+                (Decimal(5), [], [], Decimal(5)),
+                (Decimal(5.5), [], [], Decimal(5.5)),
+                ("5.5", [("string", "decimal")], [], Decimal(5.5)),
+                (5, [("integer", "decimal")], [], Decimal(5)),
+                ("5x", [], [ConstraintType.TypeConstraint], "5x"),
+                (None, [], [], None),
+            ],
+            "boolean": [
+                (True, [], [], True),
+                (False, [], [], False),
+                ("True", [("string", "boolean")], [], True),
+                ("False", [("string", "boolean")], [], False),
+                ("true", [("string", "boolean")], [], True),
+                ("false", [("string", "boolean")], [], False),
+                ("", [], [ConstraintType.TypeConstraint], ""),
+                (1, [("integer", "boolean")], [], True),
+                (0, [("integer", "boolean")], [], False),
+                (2, [], [ConstraintType.TypeConstraint], 2),
+                (None, [], [], None),
+            ],
+            "uriorcurie": [
+                ("X:1", [], [], "X:1"),
+                ("http://example.org", [], [], "http://example.org"),
+                ("", [], [ConstraintType.TypeConstraint], ""),
+                ("a b", [], [ConstraintType.TypeConstraint], "a b"),
+                (None, [], [], None),
+            ],
+            "uri": [
+                ("http://example.org", [], [], "http://example.org"),
+                ("a b", [], [ConstraintType.TypeConstraint], "a b"),
+                (None, [], [], None),
+            ],
+            "date": [
+                ("2020-01-01", [], [], "2020-01-01"),
+                ("not-a-date", [], [ConstraintType.TypeConstraint], "not-a-date"),
+                (None, [], [], None),
+            ],
+            "datetime": [
+                # TODO: fix metamodelcore
+                # (TEST_TIME.isoformat(), [], [], TEST_TIME.isoformat()),
+                (
+                    "not-a-datetime",
+                    [],
+                    [ConstraintType.TypeConstraint],
+                    "not-a-datetime",
+                ),
+                (None, [], [], None),
+            ],
+            "time": [
+                ("17:24:36", [], [], "17:24:36"),
+                (datetime.time(0), [], [], "00:00:00"),
+                ("not-a-time", [], [ConstraintType.TypeConstraint], "not-a-time"),
+                (None, [], [], None),
+            ],
+            "ncname": [
+                ("foo", [], [], "foo"),
+                ("foo bar", [], [ConstraintType.TypeConstraint], "foo bar"),
+                (None, [], [], None),
+            ],
+        }
+        for t in cases.keys():
+            sb.add_type(f"my_{t}", typeof=t)
+        sb.add_defaults()
+        sv = SchemaView(sb.schema)
+        normalizer = ReferenceValidator(sv)
+        derived_schema = normalizer.derived_schema
+        for t, examples in cases.items():
+            for v, expected_repairs, expected_unrepaired, expected_value in examples:
+                # test with custom type
+                report = Report()
+                normalized_value = normalizer.normalize_type(
+                    v, derived_schema.types[f"my_{t}"], report
+                )
+                self.assertEqual(
+                    expected_value, normalized_value, f"Failed to normalize {v} to {t}"
+                )
+                self.assertEqual(
+                    len(report.repaired()),
+                    len(expected_repairs),
+                    f"{v} -> {expected_value} type {t}: Expected {expected_repairs} repairs, got {report.repaired()}",
+                )
+                self._assert_unrepaired_types_the_same(
+                    report, expected_unrepaired, v, expected_value
+                )
+                # test with built-in type
+                report = Report()
+                normalized_value = normalizer.normalize_type(
+                    v, derived_schema.types[t], report
+                )
+                self.assertEqual(expected_value, normalized_value)
+                self.assertEqual(len(report.repaired()), len(expected_repairs))
+                self._assert_unrepaired_types_the_same(
+                    report, expected_unrepaired, v, expected_value
+                )
+
+    def test_derived_schema_for_metadata(self):
+        view = package_schemaview("linkml_runtime.linkml_model.meta")
+        validator = ReferenceValidator(view)
+        derived_schema = validator.derived_schema
+        self.assertIsNotNone(view.get_identifier_slot("prefix", use_key=True))
+        sdc = derived_schema.classes["schema_definition"]
+        prefix_slot = sdc.attributes["prefixes"]
+        self.assertEqual(prefix_slot.range, "prefix")
+
+    def test_line_number(self):
+        view = package_schemaview("linkml_runtime.linkml_model.meta")
+        validator = ReferenceValidator(view)
+        s = """
+        id: s1
+        name: schema1
+        invented_field: foo
+        """
+        obj = yaml.load(s, DupCheckYamlLoader)
+        report = validator.validate(obj)
+        # for r in report.unrepaired():
+        #    print(r)
+        self.assertEqual(1, len(report.unrepaired()))
+        r = report.unrepaired()[0]
+        self.assertEqual(3, r.source_line_number)
+        self.assertEqual(8, r.source_column_number)
+
+    def test_examples_against_metamodel(self):
+        view = package_schemaview("linkml_runtime.linkml_model.meta")
+        validator = ReferenceValidator(view)
+        derived_schema = validator.derived_schema
+        self.assertIsNotNone(view.get_identifier_slot("prefix", use_key=True))
+        sdc = derived_schema.classes["schema_definition"]
+        prefixes_slot = sdc.attributes["prefixes"]
+        cf = validator.infer_slot_collection_form(prefixes_slot)
+        simple_dict_value_slot = validator._slot_as_simple_dict_value_slot(
+            sdc.attributes["prefixes"]
+        )
+        # print(simple_dict_value_slot.name)
+        # print(cf)
+        self.assertEqual(CollectionForm.SimpleDict, cf)
+        sb = SchemaBuilder("test")
+        sb.add_slot("s1", range="string", description="test1")
+        sb.add_class("C", ["s1", "s2"])
+        sb.add_defaults()
+        for s in ["imports", "prefixes", "slot_definitions", "classes"]:
+            att = sdc.attributes[s]
+            # print(yaml_dumper.dumps(att))
+        self.assertFalse(sdc.attributes["prefixes"].inlined_as_list)
+        schema_dict = json_dumper.to_dict(sb.schema)
+        # print(schema_dict)
+        report = Report()
+        schema_norm = validator.normalize(schema_dict, target=sdc.name, report=report)
+        # print("Normalized:")
+        # print(yaml.dump(schema_norm, sort_keys=False))
+        self.assertEqual(dict, type(schema_norm["prefixes"]))
+        # for r in report.unrepaired():
+        #    print(r)
+        self.assertEqual(len(report.unrepaired()), 0)
+        # for r in report.repaired():
+        #    print(r)
+        self.assertEqual(len(report.repaired()), 3)
+        report = validator.validate(schema_norm, target=sdc.name)
+        self.assertEqual(0, len(report.results))
+
+    def test_metamodel(self):
+        view = package_schemaview("linkml_runtime.linkml_model.meta")
+        validator = ReferenceValidator(view)
+        derived_schema = validator.derived_schema
+        sdc = derived_schema.classes["schema_definition"]
+        self.assertIn("name", sdc.attributes)
+        schema_string = yaml_dumper.dumps(view.schema)
+        report = Report()
+        # print(schema_string)
+        schema_dict = yaml.load(schema_string, DupCheckYamlLoader)
+        schema_norm = validator.normalize(schema_dict, target=sdc.name, report=report)
+        self.assertEqual([], report.unrepaired())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_utils/test_yaml_utils.py
+++ b/tests/test_utils/test_yaml_utils.py
@@ -25,6 +25,27 @@ class YamlUtilTestCase(TestEnvironmentTestCase):
             s1 = yaml.load(f, DupCheckYamlLoader)
             self.assertEqual('schema1', s1['name'])
 
+    def test_line_numbers(self):
+        s = """
+        name: schema1
+        info: foo
+        x:
+           a: 1
+           b: 2
+        l: [1, 2, 3]
+        """
+        obj = yaml.load(s, DupCheckYamlLoader)
+        cases = [
+            ('name', 1),
+            ('info', 2),
+            ('x', 3),
+            ('l', 6),
+        ]
+        key_to_lines = [(k, k._s.line) for k in obj.keys()]
+        self.assertCountEqual(cases, key_to_lines)
+
+
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR implements a *reference validator*, which is intended to be a *direct* implementation of [part 5 of the spec](https://linkml.io/linkml-model/docs/specification/05validation)

This also performs *instance normalization* as defined in [part 6 of the spec](https://linkml.io/linkml-model/docs/specification/06mapping/)

The test suite performs *auto-documentation*, generating a markdown file as output that will serve as a reference document for validators.

The PR also introduces a temporary validation datamodel that forks the core linkml-model one, with the plan to fold these changes back in.

Note the current implementation may be incomplete.

There is a very preliminary CLI:

```
linkml-normalize --help
Usage: linkml-normalize [OPTIONS] INPUT

  Normalizes and validates a YAML document against a schema.

  Normalization is a mix of casting types (e.g. "5" to 5), as well as LinkML
  *collection forms*, e.g. ExpandedDict to CompactDict.

  Validations is performed using a derived schema, as per part 5 of the
  specification.

  Note that in future this will be folded into the main linkml-validate
  command.

  Currently this CLI lacks features such as the ability to customize which
  severity rules to fail on.

  :param schema: :param target: :param input: :param output: :return:

Options:
  -s, --schema TEXT      [required]
  -C, --target TEXT
  -o, --output FILENAME
  --help                 Show this message and exit.
```