### PR TITLE
Check inlined or inlined_as_list slots only if range is class in schema

### DIFF
--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -1317,22 +1317,22 @@ class SchemaView(object):
         :param imports:
         :return:
         """
-        if slot.inlined:
-            return True
-        elif slot.inlined_as_list:
-            return True
-        else:
-            range = slot.range
-            if range in self.all_classes():
-                id_slot = self.get_identifier_slot(range, imports=imports)
-                if id_slot is None:
-                    # must be inlined as has no identifier
-                    return True
-                else:
-                    # not explicitly declared inline and has an identifier: assume is ref, not inlined
-                    return False
+        range = slot.range
+        if range in self.all_classes():
+            if slot.inlined:
+                return True
+            elif slot.inlined_as_list:
+                return True
+            
+            id_slot = self.get_identifier_slot(range, imports=imports)
+            if id_slot is None:
+                # must be inlined as has no identifier
+                return True
             else:
+                # not explicitly declared inline and has an identifier: assume is ref, not inlined
                 return False
+        else:
+            return False
 
     def slot_applicable_range_elements(self, slot: SlotDefinition) -> List[ClassDefinitionName]:
         """

--- a/tests/test_utils/input/schemaview_is_inlined.yaml
+++ b/tests/test_utils/input/schemaview_is_inlined.yaml
@@ -1,0 +1,56 @@
+id: http://example.org/schemaview_is_inlined
+name: schemaview_is_inlined
+description: This schema defines various slots that exercise the SchemaView.is_inlined() method
+prefixes:
+  linkml: https://w3id.org/linkml/
+imports:
+  - linkml:types
+default_range: string
+
+classes:
+  ThingWithId:
+    slots:
+      - id
+      - value
+  ThingWithoutId:
+    slots:
+      - value
+
+slots:
+  id:
+    identifier: true
+  value:
+
+  a_thing_with_id:
+    range: ThingWithId
+
+  inlined_thing_with_id:
+    range: ThingWithId
+    inlined: true
+
+  inlined_as_list_thing_with_id:
+    range: ThingWithId
+    inlined_as_list: true
+
+  a_thing_without_id:
+    range: ThingWithoutId
+
+  inlined_thing_without_id:
+    range: ThingWithoutId
+    inlined: true
+
+  inlined_as_list_thing_without_id:
+    range: ThingWithoutId
+    inlined_as_list: true
+
+  an_integer:
+    range: integer
+  
+  # Pathological cases
+  inlined_integer:
+    range: integer
+    inlined: true
+
+  inlined_as_list_integer:
+    range: integer
+    inlined_as_list: true

--- a/tests/test_utils/test_schemaview.py
+++ b/tests/test_utils/test_schemaview.py
@@ -706,6 +706,26 @@ class SchemaViewTestCase(unittest.TestCase):
                 prefixes_list
         )
 
+    def test_is_inlined(self):
+        schema_path = os.path.join(INPUT_DIR, "schemaview_is_inlined.yaml")
+        sv = SchemaView(schema_path)
+        cases = [
+            # slot name, expected is_inline
+            ("a_thing_with_id", False),
+            ("inlined_thing_with_id", True),
+            ("inlined_as_list_thing_with_id", True),
+            ("a_thing_without_id", True),
+            ("inlined_thing_without_id", True),
+            ("inlined_as_list_thing_without_id", True),
+            ("an_integer", False),
+            ("inlined_integer", False),
+            ("inlined_as_list_integer", False)
+        ]
+        for slot_name, expected_result in cases:
+            with self.subTest(slot_name=slot_name):
+                slot = sv.get_slot(slot_name)
+                actual_result = sv.is_inlined(slot)
+                self.assertEqual(actual_result, expected_result)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The root cause of https://github.com/linkml/linkml/issues/1266 is that the schema includes a slot defined like so:

```yaml
slots:
  see_also:
    range: uriorcurie
    description: Links to useful info
    multivalued: true
    inlined_as_list: true
```

When `JsonSchemaGenerator` switched from using `SchemaLoader` to `SchemaView` it introduced a call to `SchemaView.is_inlined()`. Currently that method will return `True` for the above slot definition. Regardless of whether you _should_ put `inlined_as_list` on a slot with a type range (as opposed to a class range), that feels like the wrong answer to me (I can already hear @cmungall saying "Postel-ian"). A `uriorcurie` can't really _be_ inlined because there's nothing _to_ inline, right?

The change here swaps the order of some logical checks in `is_inlined` so that the `inlined` and `inlined_as_list` metaslots are only checked if the range is a class in the schema. I added a test that attempts to enumerate all the possibilities. 

Fixes https://github.com/linkml/linkml/issues/1266