### PR TITLE
Add functions to look up a LinkML python class by URI or CURIE

### DIFF
--- a/linkml_runtime/utils/yamlutils.py
+++ b/linkml_runtime/utils/yamlutils.py
@@ -254,14 +254,16 @@ class YAMLRoot(JsonObj):
                 return match
         return None
 
-    def _class_for_uri(self, uri: str, use_model_uri: bool = False) -> Optional["YAMLRoot"]:
+    @classmethod
+    def _class_for_uri(cls: Type["YAMLRoot"], uri: str, use_model_uri: bool = False) -> Optional[Type["YAMLRoot"]]:
         """
         Return the self or descendant of self having with a matching class uri
         """
-        return self.__class__._class_for('class_model_uri' if use_model_uri else 'class_class_uri', URIRef(uri))
+        return cls._class_for('class_model_uri' if use_model_uri else 'class_class_uri', URIRef(uri))
 
-    def _class_for_curie(self, curie: str) -> Optional["YAMLRoot"]:
-        return self.__class__._class_for('class_class_curie', curie)
+    @classmethod
+    def _class_for_curie(cls: Type["YAMLRoot"], curie: str) -> Optional[Type["YAMLRoot"]]:
+        return cls._class_for('class_class_curie', curie)
 
     # ==================
     # Error intercepts

--- a/linkml_runtime/utils/yamlutils.py
+++ b/linkml_runtime/utils/yamlutils.py
@@ -6,7 +6,7 @@ import yaml
 from deprecated.classic import deprecated
 from jsonasobj2 import JsonObj, as_json, as_dict, JsonObjTypes, items
 import jsonasobj2
-from rdflib import Graph
+from rdflib import Graph, URIRef
 from yaml.constructor import ConstructorError
 
 from linkml_runtime.utils.context_utils import CONTEXTS_PARAM_TYPE, merge_contexts
@@ -242,6 +242,26 @@ class YAMLRoot(JsonObj):
                 if len(dict_slot) == 1 and not isinstance(dict_slot[0], (list, dict)):
                     self[slot_name] = dict_slot[0]
             self._normalize_inlined_as_dict(slot_name, slot_type, key_name, keyed)
+
+    @classmethod
+    def _class_for(cls, attribute: str, uri_or_curie: Union[str, URIRef]) -> Optional[Type["YAMLRoot"]]:
+        """ Locate self or descendant class that has attribute == uri_or_curie """
+        if getattr(cls, attribute, None) == uri_or_curie:
+            return cls
+        for subclass in cls.__subclasses__():
+            match = subclass._class_for(attribute, uri_or_curie)
+            if match:
+                return match
+        return None
+
+    def _class_for_uri(self, uri: str, use_model_uri: bool = False) -> Optional["YAMLRoot"]:
+        """
+        Return the self or descendant of self having with a matching class uri
+        """
+        return self.__class__._class_for('class_model_uri' if use_model_uri else 'class_class_uri', URIRef(uri))
+
+    def _class_for_curie(self, curie: str) -> Optional["YAMLRoot"]:
+        return self.__class__._class_for('class_class_curie', curie)
 
     # ==================
     # Error intercepts

--- a/tests/test_utils/test_poly_dataclasses.py
+++ b/tests/test_utils/test_poly_dataclasses.py
@@ -4,7 +4,7 @@ from linkml_runtime.linkml_model.meta import Element, LINKML
 class PolyDataclassTestCase(unittest.TestCase):
     def test_class_for_uri(self):
         """ Test various class lookup options """
-        e = Element(name="Test")
+        e = Element
 
         # Test class URI
         cls = e._class_for_uri(LINKML.ClassDefinition)

--- a/tests/test_utils/test_poly_dataclasses.py
+++ b/tests/test_utils/test_poly_dataclasses.py
@@ -1,0 +1,31 @@
+import unittest
+from linkml_runtime.linkml_model.meta import Element, LINKML
+
+class PolyDataclassTestCase(unittest.TestCase):
+    def test_class_for_uri(self):
+        """ Test various class lookup options """
+        e = Element(name="Test")
+
+        # Test class URI
+        cls = e._class_for_uri(LINKML.ClassDefinition)
+        self.assertEqual('ClassDefinition', cls.__name__)
+
+        # Test model URI
+        cls = e._class_for_uri(LINKML.TypeDefinition, use_model_uri=True)
+        self.assertEqual('TypeDefinition', cls.__name__)
+
+        # Test class curie (note there isn't any model curie
+        cls = e._class_for_curie("linkml:TypeDefinition")
+        self.assertEqual('TypeDefinition', cls.__name__)
+
+        # Make sure the self test works
+        cls = e._class_for_uri(LINKML.Element)
+        self.assertEqual('Element', cls.__name__)
+
+        # Make sure we fail gracefully
+        cls = e._class_for_uri("linkml:Missing")
+        self.assertIsNone(cls)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Any LinkML class derived from YAMLRoot can find a descendant by URI or CURIE.  If it is a URI, one can search for either a model or a class URI.  This is meant to be the support needed for the polymorphic class tweak in the LinkML python generator.