### PR TITLE
SchemaView initialization from a PosixPath

### DIFF
--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -5,6 +5,7 @@ import collections
 from functools import lru_cache
 from copy import copy, deepcopy
 from collections import defaultdict, OrderedDict
+from pathlib import PosixPath
 from typing import Mapping, Tuple, Type, Union, Optional, List, Any
 
 from linkml_runtime.linkml_model import PermissibleValue, PermissibleValueText
@@ -111,9 +112,9 @@ class SchemaView(object):
     modifications: int = 0
     uuid: str = None
 
-    def __init__(self, schema: Union[str, SchemaDefinition],
+    def __init__(self, schema: Union[str, PosixPath, SchemaDefinition],
                  importmap: Optional[Mapping[str, str]] = None, merge_imports: bool = False):
-        if isinstance(schema, str):
+        if isinstance(schema, str) or isinstance(schema, PosixPath):
             schema = load_schema_wrap(schema)
         self.schema = schema
         self.schema_map = {schema.name: schema}

--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -4,11 +4,10 @@ import logging
 import collections
 from functools import lru_cache
 from copy import copy, deepcopy
-from collections import defaultdict, OrderedDict
-from pathlib import PosixPath
-from typing import Mapping, Tuple, Type, Union, Optional, List, Any
+from collections import defaultdict
+from pathlib import Path
+from typing import Mapping, Tuple
 
-from linkml_runtime.linkml_model import PermissibleValue, PermissibleValueText
 from linkml_runtime.utils.namespaces import Namespaces
 from deprecated.classic import deprecated
 from linkml_runtime.utils.context_utils import parse_import_map, map_import
@@ -112,9 +111,11 @@ class SchemaView(object):
     modifications: int = 0
     uuid: str = None
 
-    def __init__(self, schema: Union[str, PosixPath, SchemaDefinition],
+    def __init__(self, schema: Union[str, Path, SchemaDefinition],
                  importmap: Optional[Mapping[str, str]] = None, merge_imports: bool = False):
-        if isinstance(schema, str) or isinstance(schema, PosixPath):
+        if isinstance(schema, Path):
+            schema = str(schema)
+        if isinstance(schema, str):
             schema = load_schema_wrap(schema)
         self.schema = schema
         self.schema_map = {schema.name: schema}

--- a/tests/test_utils/test_schemaview.py
+++ b/tests/test_utils/test_schemaview.py
@@ -2,6 +2,7 @@ import os
 import unittest
 import logging
 from copy import copy
+from pathlib import Path
 from typing import List
 from unittest import TestCase
 
@@ -14,9 +15,9 @@ from linkml_runtime.utils.schemaview import SchemaView, SchemaUsage, OrderedBy
 from linkml_runtime.utils.schemaops import roll_up, roll_down
 from tests.test_utils import INPUT_DIR
 
-SCHEMA_NO_IMPORTS = os.path.join(INPUT_DIR, 'kitchen_sink_noimports.yaml')
-SCHEMA_WITH_IMPORTS = os.path.join(INPUT_DIR, 'kitchen_sink.yaml')
-SCHEMA_WITH_STRUCTURED_PATTERNS = os.path.join(INPUT_DIR, "pattern-example.yaml")
+SCHEMA_NO_IMPORTS = Path(INPUT_DIR) / 'kitchen_sink_noimports.yaml'
+SCHEMA_WITH_IMPORTS = Path(INPUT_DIR) / 'kitchen_sink.yaml'
+SCHEMA_WITH_STRUCTURED_PATTERNS = Path(INPUT_DIR) / "pattern-example.yaml"
 
 yaml_loader = YAMLLoader()
 IS_CURRENT = 'is current'
@@ -727,6 +728,7 @@ class SchemaViewTestCase(unittest.TestCase):
                 slot = sv.get_slot(slot_name)
                 actual_result = sv.is_inlined(slot)
                 self.assertEqual(actual_result, expected_result)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Updates
```
- Update: UX: SchemaView: Creating a new instance now accepts a PosixPath rather than just a string representation of a file path.
```