### PR TITLE
Add `load_as_dict` method to Loader class

### DIFF
--- a/linkml_runtime/loaders/json_loader.py
+++ b/linkml_runtime/loaders/json_loader.py
@@ -10,20 +10,27 @@ from pydantic import BaseModel
 
 class JSONLoader(Loader):
 
-    def load_any(self, source: Union[str, dict, TextIO], target_class: Type[Union[BaseModel, YAMLRoot]], *, base_dir: Optional[str] = None,
-             metadata: Optional[FileInfo] = None, **_) -> Union[BaseModel, YAMLRoot, List[BaseModel], List[YAMLRoot]]:
-        def loader(data: Union[str, dict], _: FileInfo) -> Optional[Dict]:
-            data_as_dict = json.loads(data) if isinstance(data, str) else data
-            if isinstance(data_as_dict, list):
-                return self.json_clean(data_as_dict)
+    def load_as_dict(self, 
+                     source: Union[str, dict, TextIO], 
+                     *, 
+                     base_dir: Optional[str] = None,
+                     metadata: Optional[FileInfo] = None) -> Union[dict, List[dict]]:
+        data = self._read_source(source, base_dir=base_dir, metadata=metadata, accept_header="application/ld+json, application/json, text/json")
+        data_as_dict = json.loads(data) if isinstance(data, str) else data
+        return self.json_clean(data_as_dict)
+
+    def load_any(self, 
+                 source: Union[str, dict, TextIO], 
+                 target_class: Type[Union[BaseModel, YAMLRoot]], 
+                 *, 
+                 base_dir: Optional[str] = None,
+                 metadata: Optional[FileInfo] = None, 
+                 **_) -> Union[BaseModel, YAMLRoot, List[BaseModel], List[YAMLRoot]]:
+        data_as_dict = self.load_as_dict(source, base_dir=base_dir, metadata=metadata)
+
+        if isinstance(data_as_dict, dict):
             typ = data_as_dict.pop('@type', None)
             if typ and typ != target_class.__name__:
                 logging.warning(f"Warning: input type mismatch. Expected: {target_class.__name__}, Actual: {typ}")
-            return self.json_clean(data_as_dict)
 
-        if not metadata:
-            metadata = FileInfo()
-        if base_dir and not metadata.base_path:
-            metadata.base_path = base_dir
-        return self.load_source(source, loader, target_class,
-                                accept_header="application/ld+json, application/json, text/json", metadata=metadata)
+        return self._construct_target_class(data_as_dict, target_class)

--- a/linkml_runtime/loaders/yaml_loader.py
+++ b/linkml_runtime/loaders/yaml_loader.py
@@ -14,26 +14,31 @@ class YAMLLoader(Loader):
     A Loader that is capable of instantiating LinkML data objects from a YAML file
     """
 
+    def load_as_dict(self, 
+                     source: Union[str, dict, TextIO], 
+                     *, 
+                     base_dir: Optional[str] = None,
+                     metadata: Optional[FileInfo] = None) -> Union[dict, List[dict]]:
+        if metadata is None:
+            metadata = FileInfo()
+        if base_dir and not metadata.base_path:
+            metadata.base_path = base_dir
+        data = self._read_source(source, base_dir=base_dir, metadata=metadata, accept_header="text/yaml, application/yaml;q=0.9")
+        if isinstance(data, str):
+            data = StringIO(data)
+            if metadata and metadata.source_file:
+                data.name = os.path.relpath(metadata.source_file, metadata.base_path)
+            return yaml.load(data, DupCheckYamlLoader)
+        else:
+            return data
+
     def load_any(self,
                  source: Union[str, dict, TextIO],
                  target_class: Union[Type[YAMLRoot],Type[BaseModel]],
                  *, base_dir: Optional[str] = None,
                  metadata: Optional[FileInfo] = None, **_) -> Union[YAMLRoot, List[YAMLRoot]]:
-        def loader(data: Union[str, dict], source_file: FileInfo) -> Optional[Dict]:
-            if isinstance(data, str):
-                data = StringIO(data)
-                if source_file and source_file.source_file:
-                    data.name = os.path.relpath(source_file.source_file, source_file.base_path)
-                return yaml.load(data, DupCheckYamlLoader)
-            else:
-                return data
-
-        if not metadata:
-            metadata = FileInfo()
-        if base_dir and not metadata.base_path:
-            metadata.base_path = base_dir
-        return self.load_source(source, loader, target_class, accept_header="text/yaml, application/yaml;q=0.9",
-                                metadata=metadata)
+        data_as_dict = self.load_as_dict(source, base_dir=base_dir, metadata=metadata)
+        return self._construct_target_class(data_as_dict, target_class)
 
     def loads_any(self, source: str, target_class: Type[Union[BaseModel, YAMLRoot]], *, metadata: Optional[FileInfo] = None, **_) -> Union[BaseModel, YAMLRoot, List[BaseModel], List[YAMLRoot]]:
         """

--- a/tests/test_loaders_dumpers/test_csv_tsv_loader_dumper.py
+++ b/tests/test_loaders_dumpers/test_csv_tsv_loader_dumper.py
@@ -62,12 +62,26 @@ class CsvAndTsvGenTestCase(unittest.TestCase):
         logging.debug(f'COMPARE 2: {data}')
         assert roundtrip == data
 
+    def test_csvgen_roundtrip_to_dict(self):
+        schemaview = SchemaView(SCHEMA)
+        data = yaml_loader.load(DATA, target_class=Shop)
+        csv_dumper.dump(data, to_file=OUTPUT, index_slot='all_book_series', schemaview=schemaview)
+        roundtrip = csv_loader.load_as_dict(OUTPUT, index_slot='all_book_series', schemaview=schemaview)
+        assert roundtrip == json_dumper.to_dict(data)
+
     def test_tsvgen_roundtrip(self):
         schemaview = SchemaView(SCHEMA)
         data = yaml_loader.load(DATA, target_class=Shop)
         tsv_dumper.dump(data, to_file=OUTPUT, index_slot='all_book_series', schemaview=schemaview)
         roundtrip = tsv_loader.load(OUTPUT, target_class=Shop, index_slot='all_book_series', schemaview=schemaview)
         assert roundtrip == data
+
+    def test_tsvgen_roundtrip_to_dict(self):
+        schemaview = SchemaView(SCHEMA)
+        data = yaml_loader.load(DATA, target_class=Shop)
+        tsv_dumper.dump(data, to_file=OUTPUT, index_slot='all_book_series', schemaview=schemaview)
+        roundtrip = tsv_loader.load_as_dict(OUTPUT, index_slot='all_book_series', schemaview=schemaview)
+        assert roundtrip == json_dumper.to_dict(data)
 
     def test_csvgen_unroundtrippable(self):
         schemaview = SchemaView(SCHEMA)

--- a/tests/test_loaders_dumpers/test_loaders.py
+++ b/tests/test_loaders_dumpers/test_loaders.py
@@ -29,6 +29,16 @@ class LoadersUnitTest(LoaderDumperTestCase):
         """ Load obo_sample.json, emit obo_sample_json.yaml and check the results """
         self.loader_test('obo_sample.json', Package, json_loader)
 
+    def test_json_load_to_dict(self):
+        data = json_loader.load_as_dict('obo_sample.json', base_dir=self.env.indir)
+        assert isinstance(data, dict)
+        assert "system" in data
+
+    def test_yaml_load_to_dict(self):
+        data = yaml_loader.load_as_dict('obo_sample.yaml', base_dir=self.env.indir)
+        assert isinstance(data, dict)
+        assert "system" in data
+
     @unittest.skipIf(True, "This test will not work until https://github.com/digitalbazaar/pyld/issues/149 is fixed")
     def test_rdf_loader(self):
         """ Load obo_sample.ttl, emit obo_sample_ttl.yaml and check the results


### PR DESCRIPTION
This is in support of https://github.com/linkml/linkml/issues/1404, https://github.com/linkml/linkml/issues/891, and others. It adds a `load_as_dict` method to the `Loader` base class. It's up to subclasses to actually implement it, and these changes include an implementation for JSON, YAML, CSV, and TSV loaders. It wasn't immediately clear how to make it work for RDF formats, but if anyone has thoughts on that I'd be glad to get some help. 