### PR TITLE
Regenerate python dataclasses for validation models

### DIFF
--- a/linkml_runtime/linkml_model/validation.py
+++ b/linkml_runtime/linkml_model/validation.py
@@ -1,17 +1,17 @@
 # Auto generated from validation.yaml by pythongen.py version: 0.9.0
-# Generation date: 2022-05-19T21:54:12
+# Generation date: 2023-06-29T10:29:33
 # Schema: reporting
 #
 # id: https://w3id.org/linkml/reporting
-# description: A datamodel for reports on data
+# description: A datamodel for reports on data, based on SHACL
 # license: https://creativecommons.org/publicdomain/zero/1.0/
 
 import dataclasses
-import sys
 import re
 from jsonasobj2 import JsonObj, as_dict
 from typing import Optional, List, Union, Dict, ClassVar, Any
 from dataclasses import dataclass
+from linkml_runtime.linkml_model.meta import EnumDefinition, PermissibleValue, PvFormulaOptions
 
 from linkml_runtime.utils.slot import Slot
 from linkml_runtime.utils.metamodelcore import empty_list, empty_dict, bnode
@@ -21,7 +21,7 @@ from linkml_runtime.utils.formatutils import camelcase, underscore, sfx
 from linkml_runtime.utils.enumerations import EnumDefinitionImpl
 from rdflib import Namespace, URIRef
 from linkml_runtime.utils.curienamespace import CurieNamespace
-from .types import Nodeidentifier, String
+from linkml_runtime.linkml_model.types import Nodeidentifier, String
 from linkml_runtime.utils.metamodelcore import NodeIdentifier
 
 metamodel_version = "1.7.0"
@@ -91,7 +91,7 @@ class ValidationResult(YAMLRoot):
     predicate: Optional[Union[str, NodeIdentifier]] = None
     object: Optional[Union[str, NodeIdentifier]] = None
     object_str: Optional[str] = None
-    source: Optional[Union[str, NodeIdentifier]] = None
+    node_source: Optional[Union[str, NodeIdentifier]] = None
     info: Optional[str] = None
 
     def __post_init__(self, *_: List[str], **kwargs: Dict[str, Any]):
@@ -116,8 +116,8 @@ class ValidationResult(YAMLRoot):
         if self.object_str is not None and not isinstance(self.object_str, str):
             self.object_str = str(self.object_str)
 
-        if self.source is not None and not isinstance(self.source, NodeIdentifier):
-            self.source = NodeIdentifier(self.source)
+        if self.node_source is not None and not isinstance(self.node_source, NodeIdentifier):
+            self.node_source = NodeIdentifier(self.node_source)
 
         if self.info is not None and not isinstance(self.info, str):
             self.info = str(self.info)
@@ -128,18 +128,24 @@ class ValidationResult(YAMLRoot):
 # Enumerations
 class ProblemType(EnumDefinitionImpl):
 
-    undeclared_slot = PermissibleValue(text="undeclared_slot",
-                                                     description="Applies when a slot is used in data but the slot is undeclared in the datamodel")
-    inapplicable_slot = PermissibleValue(text="inapplicable_slot",
-                                                         description="Applies when a slot is used in an instance of a class where the slot is not applicable for that class")
-    missing_slot_value = PermissibleValue(text="missing_slot_value",
-                                                           description="Applies when an instance of a class has a required slot which is not filled in")
-    slot_range_violation = PermissibleValue(text="slot_range_violation",
-                                                               description="Applies when the value of a slot is inconsistent with the declared range")
-    max_count_violation = PermissibleValue(text="max_count_violation",
-                                                             meaning=SH.MaxCountConstraintComponent)
-    parsing_error = PermissibleValue(text="parsing_error",
-                                                 description="The data could not be parsed")
+    undeclared_slot = PermissibleValue(
+        text="undeclared_slot",
+        description="Applies when a slot is used in data but the slot is undeclared in the datamodel")
+    inapplicable_slot = PermissibleValue(
+        text="inapplicable_slot",
+        description="""Applies when a slot is used in an instance of a class where the slot is not applicable for that class""")
+    missing_slot_value = PermissibleValue(
+        text="missing_slot_value",
+        description="Applies when an instance of a class has a required slot which is not filled in")
+    slot_range_violation = PermissibleValue(
+        text="slot_range_violation",
+        description="Applies when the value of a slot is inconsistent with the declared range")
+    max_count_violation = PermissibleValue(
+        text="max_count_violation",
+        meaning=SH.MaxCountConstraintComponent)
+    parsing_error = PermissibleValue(
+        text="parsing_error",
+        description="The data could not be parsed")
 
     _defn = EnumDefinition(
         name="ProblemType",
@@ -148,16 +154,50 @@ class ProblemType(EnumDefinitionImpl):
 class SeverityOptions(EnumDefinitionImpl):
 
     FATAL = PermissibleValue(text="FATAL")
-    ERROR = PermissibleValue(text="ERROR",
-                                 meaning=SH.Violation)
-    WARNING = PermissibleValue(text="WARNING",
-                                     meaning=SH.Warning)
-    INFO = PermissibleValue(text="INFO",
-                               meaning=SH.Info)
+    ERROR = PermissibleValue(
+        text="ERROR",
+        meaning=SH.Violation)
+    WARNING = PermissibleValue(
+        text="WARNING",
+        meaning=SH.Warning)
+    INFO = PermissibleValue(
+        text="INFO",
+        meaning=SH.Info)
 
     _defn = EnumDefinition(
         name="SeverityOptions",
     )
 
 # Slots
+class slots:
+    pass
 
+slots.type = Slot(uri=SH.sourceConstraintComponent, name="type", curie=SH.curie('sourceConstraintComponent'),
+                   model_uri=REPORTING.type, domain=None, range=Optional[Union[str, NodeIdentifier]])
+
+slots.subject = Slot(uri=SH.focusNode, name="subject", curie=SH.curie('focusNode'),
+                   model_uri=REPORTING.subject, domain=None, range=Optional[Union[str, NodeIdentifier]])
+
+slots.instantiates = Slot(uri=REPORTING.instantiates, name="instantiates", curie=REPORTING.curie('instantiates'),
+                   model_uri=REPORTING.instantiates, domain=None, range=Optional[Union[str, NodeIdentifier]])
+
+slots.predicate = Slot(uri=REPORTING.predicate, name="predicate", curie=REPORTING.curie('predicate'),
+                   model_uri=REPORTING.predicate, domain=None, range=Optional[Union[str, NodeIdentifier]])
+
+slots.object = Slot(uri=SH.value, name="object", curie=SH.curie('value'),
+                   model_uri=REPORTING.object, domain=None, range=Optional[Union[str, NodeIdentifier]])
+
+slots.object_str = Slot(uri=REPORTING.object_str, name="object_str", curie=REPORTING.curie('object_str'),
+                   model_uri=REPORTING.object_str, domain=None, range=Optional[str])
+
+slots.node_source = Slot(uri=REPORTING.node_source, name="node_source", curie=REPORTING.curie('node_source'),
+                   model_uri=REPORTING.node_source, domain=None, range=Optional[Union[str, NodeIdentifier]])
+
+slots.severity = Slot(uri=REPORTING.severity, name="severity", curie=REPORTING.curie('severity'),
+                   model_uri=REPORTING.severity, domain=None, range=Optional[Union[str, "SeverityOptions"]])
+
+slots.info = Slot(uri=REPORTING.info, name="info", curie=REPORTING.curie('info'),
+                   model_uri=REPORTING.info, domain=None, range=Optional[str])
+
+slots.validationReport__results = Slot(uri=REPORTING.results, name="validationReport__results", curie=REPORTING.curie('results'),
+                   model_uri=REPORTING.validationReport__results, domain=None, range=Optional[Union[Union[dict, ValidationResult], List[Union[dict, ValidationResult]]]])


### PR DESCRIPTION
Currently the `linkml_runtime/linkml_model/validation.py` is broken because of missing imports.

This PR regenerates the python dataclasses for validation models defined in `linkml_runtime/linkml_model/model/schema/validation.yaml`.

