### PR TITLE
Enable passing a converter to RDFLib dumper

### DIFF
--- a/linkml_runtime/dumpers/rdflib_dumper.py
+++ b/linkml_runtime/dumpers/rdflib_dumper.py
@@ -145,10 +145,15 @@ class RDFLibDumper(Dumper):
             graph.add((element_uri, RDF.type, URIRef(schemaview.get_uri(cn, expand=True))))
         return element_uri
 
-    def dump(self, element: Union[BaseModel, YAMLRoot],
-             to_file: str,
-             schemaview: SchemaView = None,
-             fmt: str = 'turtle', prefix_map: Dict[str, str] = None, **args) -> None:
+    def dump(
+        self,
+        element: Union[BaseModel, YAMLRoot],
+        to_file: str,
+        schemaview: SchemaView = None,
+        fmt: str = 'turtle',
+        prefix_map: Union[Dict[str, str], Converter, None] = None,
+        **args,
+    ) -> None:
         """
         Write element as rdf to to_file
 
@@ -161,8 +166,13 @@ class RDFLibDumper(Dumper):
         """
         super().dump(element, to_file, schemaview=schemaview, fmt=fmt, prefix_map=prefix_map)
 
-    def dumps(self, element: Union[BaseModel, YAMLRoot], schemaview: SchemaView = None,
-              fmt: Optional[str] = 'turtle', prefix_map: Dict[str, str] = None) -> str:
+    def dumps(
+        self,
+        element: Union[BaseModel, YAMLRoot],
+        schemaview: SchemaView = None,
+        fmt: Optional[str] = 'turtle',
+        prefix_map: Union[Dict[str, str], Converter, None] = None,
+    ) -> str:
         """
         Convert element into an RDF graph guided by the schema
 

--- a/linkml_runtime/dumpers/rdflib_dumper.py
+++ b/linkml_runtime/dumpers/rdflib_dumper.py
@@ -42,7 +42,8 @@ class RDFLibDumper(Dumper):
         """
         g = Graph()
         if isinstance(prefix_map, Converter):
-            prefix_map = prefix_map.bimap
+            # TODO replace with `prefix_map = prefix_map.bimap` after making minimum requirement on python 3.8
+            prefix_map = {record.prefix: record.uri_prefix for record in prefix_map.records}
         logging.debug(f'PREFIXMAP={prefix_map}')
         if prefix_map:
             for k, v in prefix_map.items():

--- a/linkml_runtime/dumpers/rdflib_dumper.py
+++ b/linkml_runtime/dumpers/rdflib_dumper.py
@@ -4,6 +4,7 @@ from abc import abstractmethod
 from typing import Optional, Any, Dict, Union
 from pydantic import BaseModel
 
+from curies import Converter
 from rdflib import Graph, URIRef, XSD
 from rdflib.term import Node, BNode, Literal
 from rdflib.namespace import RDF
@@ -24,7 +25,12 @@ class RDFLibDumper(Dumper):
     This requires a SchemaView object
 
     """
-    def as_rdf_graph(self, element: Union[BaseModel, YAMLRoot], schemaview: SchemaView, prefix_map: Dict[str, str] = None) -> Graph:
+    def as_rdf_graph(
+        self,
+        element: Union[BaseModel, YAMLRoot],
+        schemaview: SchemaView,
+        prefix_map: Union[Dict[str, str], Converter, None] = None,
+    ) -> Graph:
         """
         Dumps from element to an rdflib Graph,
         following a schema
@@ -35,6 +41,8 @@ class RDFLibDumper(Dumper):
         :return:
         """
         g = Graph()
+        if isinstance(prefix_map, Converter):
+            prefix_map = prefix_map.bimap
         logging.debug(f'PREFIXMAP={prefix_map}')
         if prefix_map:
             for k, v in prefix_map.items():

--- a/linkml_runtime/loaders/rdflib_loader.py
+++ b/linkml_runtime/loaders/rdflib_loader.py
@@ -64,7 +64,8 @@ class RDFLibLoader(Loader):
             uri_to_class_map[uri] = c
         # data prefix map: supplements or overrides existing schema prefix map
         if isinstance(prefix_map, Converter):
-            prefix_map = prefix_map.bimap
+            # TODO replace with `prefix_map = prefix_map.bimap` after making minimum requirement on python 3.8
+            prefix_map = {record.prefix: record.uri_prefix for record in prefix_map.records}
         if prefix_map:
             for k, v in prefix_map.items():
                 namespaces[k] = v

--- a/linkml_runtime/loaders/rdflib_loader.py
+++ b/linkml_runtime/loaders/rdflib_loader.py
@@ -4,6 +4,7 @@ from copy import copy
 from dataclasses import dataclass
 from typing import Optional, Any, Dict, Type, Union, TextIO, List, Tuple, Set
 
+from curies import Converter
 from hbreader import FileInfo
 from rdflib import Graph, URIRef
 from rdflib.term import Node, BNode, Literal
@@ -31,7 +32,7 @@ class RDFLibLoader(Loader):
     Note: this is a more complete replacement for rdf_loader
     """
     def from_rdf_graph(self, graph: Graph, schemaview: SchemaView, target_class: Type[Union[BaseModel, YAMLRoot]],
-                       prefix_map: Dict[str, str] = None,
+                       prefix_map: Union[Dict[str, str], Converter, None] = None,
                        cast_literals: bool = True,
                        allow_unprocessed_triples: bool = True,
                        ignore_unmapped_predicates: bool = False) -> List[Union[BaseModel, YAMLRoot]]:
@@ -58,6 +59,8 @@ class RDFLibLoader(Loader):
                     logging.error(f'Inconsistent URI to class map: {uri} -> {c2.name}, {c.name}')
             uri_to_class_map[uri] = c
         # data prefix map: supplements or overrides existing schema prefix map
+        if isinstance(prefix_map, Converter):
+            prefix_map = prefix_map.bimap
         if prefix_map:
             for k, v in prefix_map.items():
                 namespaces[k] = v
@@ -224,12 +227,16 @@ class RDFLibLoader(Loader):
             return schemaview.namespaces().curie_for(node)
 
 
-    def load(self, source: Union[str, TextIO, Graph], target_class: Type[Union[BaseModel, YAMLRoot]], *,
-             schemaview: SchemaView = None,
-             prefix_map: Dict[str, str] = None,
-             fmt: Optional[str] = 'turtle',
-             metadata: Optional[FileInfo] = None,
-             **kwargs) -> Union[BaseModel, YAMLRoot]:
+    def load(
+        self,
+        source: Union[str, TextIO, Graph],
+        target_class: Type[Union[BaseModel, YAMLRoot]], *,
+        schemaview: SchemaView = None,
+        prefix_map: Union[Dict[str, str], Converter, None] = None,
+        fmt: Optional[str] = 'turtle',
+        metadata: Optional[FileInfo] = None,
+        **kwargs,
+    ) -> Union[BaseModel, YAMLRoot]:
         """
         Load the RDF in source into the python target_class structure
 

--- a/linkml_runtime/loaders/rdflib_loader.py
+++ b/linkml_runtime/loaders/rdflib_loader.py
@@ -31,11 +31,15 @@ class RDFLibLoader(Loader):
 
     Note: this is a more complete replacement for rdf_loader
     """
-    def from_rdf_graph(self, graph: Graph, schemaview: SchemaView, target_class: Type[Union[BaseModel, YAMLRoot]],
-                       prefix_map: Union[Dict[str, str], Converter, None] = None,
-                       cast_literals: bool = True,
-                       allow_unprocessed_triples: bool = True,
-                       ignore_unmapped_predicates: bool = False) -> List[Union[BaseModel, YAMLRoot]]:
+    def from_rdf_graph(
+        self, graph: Graph,
+        schemaview: SchemaView,
+        target_class: Type[Union[BaseModel, YAMLRoot]],
+        prefix_map: Union[Dict[str, str], Converter, None] = None,
+        cast_literals: bool = True,
+        allow_unprocessed_triples: bool = True,
+        ignore_unmapped_predicates: bool = False,
+    ) -> List[Union[BaseModel, YAMLRoot]]:
         """
         Loads objects from graph into lists of the python target_class structure,
         recursively walking RDF graph from instances of target_class.

--- a/tests/test_loaders_dumpers/test_rdflib_dumper.py
+++ b/tests/test_loaders_dumpers/test_rdflib_dumper.py
@@ -385,6 +385,7 @@ class RdfLibDumperTestCase(unittest.TestCase):
 
 class RDFlibConverterDumperTestCase(RdfLibDumperTestCase):
     """A test case that uses a :class:`curies.Converter` for testing loading and dumping with RDFlib."""
+
     def setUp(self) -> None:
         """Set up the test case using a :class:`curies.Converter` instead of a simple prefix map."""
         self.prefix_map = Converter.from_prefix_map(PREFIX_MAP)

--- a/tests/test_loaders_dumpers/test_rdflib_dumper.py
+++ b/tests/test_loaders_dumpers/test_rdflib_dumper.py
@@ -383,8 +383,8 @@ class RdfLibDumperTestCase(unittest.TestCase):
 
 
 
-class RDFlibConverterDumperTestCase(RdfLibDumperTestCase):
-    """A test case that uses a :class:`curies.Converter` for testing loading and dumping with RDFlib."""
+class RDFLibConverterDumperTestCase(RdfLibDumperTestCase):
+    """A test case that uses a :class:`curies.Converter` for testing loading and dumping with RDFLib."""
 
     def setUp(self) -> None:
         """Set up the test case using a :class:`curies.Converter` instead of a simple prefix map."""

--- a/tests/test_loaders_dumpers/test_rdflib_dumper.py
+++ b/tests/test_loaders_dumpers/test_rdflib_dumper.py
@@ -361,7 +361,7 @@ class RdfLibDumperTestCase(unittest.TestCase):
         for id, expected_uri, prefix_map in cases:
 
             c = OntologyClass(id=id, label=test_label)
-            ttl = rdflib_dumper.dumps(c, view, prefix_map=self.prefix_map)
+            ttl = rdflib_dumper.dumps(c, view, prefix_map=prefix_map)
             g = Graph()
             g.parse(data=ttl, format='ttl')
             self.assertEqual(len(g), 2)


### PR DESCRIPTION
Closes https://github.com/linkml/linkml/issues/1619

This pull request extends the type signature of functions in the RDFlib loader and dumper to allow passing a `curies.Converter` instead of a simple prefix map (if desired). The bidirected map is extracted from the converter and the respective loading/dumping procedures are not modified.

