### PR TITLE
Optimize implementation of SchemaView `get_classes_by_slot()` method

### DIFF
--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -1435,7 +1435,7 @@ class SchemaView(object):
             if x.range:
                 range_union_of.append(x.range)
         return range_union_of
-
+    
     def get_classes_by_slot(self, slot: SlotDefinition, include_induced: bool = False) -> List[ClassDefinitionName]:
         """Get all classes that use a given slot, either as a direct or induced slot.
 
@@ -1443,21 +1443,21 @@ class SchemaView(object):
         :param include_induced: supplement all direct slots with induced slots, defaults to False
         :return: list of slots, either direct, or both direct and induced
         """
-        slots_list = []  # list of all direct or induced slots
+        direct_slots_list = []  # list of classes with direct slots
+        induced_slots_list = []  # list of classes with induced slots
 
         for c_name, c in self.all_classes().items():
-            # check if slot is direct specification on class
             if slot.name in c.slots:
-                slots_list.append(c_name)
-
-        # include induced classes also if requested
-        if include_induced:
-            for c_name, c in self.all_classes().items():
+                direct_slots_list.append(c_name)
+            elif include_induced:
                 for ind_slot in self.class_induced_slots(c_name):
                     if ind_slot.name == slot.name:
-                        slots_list.append(c_name)
+                        induced_slots_list.append(c_name)
 
-        return list(dict.fromkeys(slots_list))
+        if include_induced:
+            return list(set(direct_slots_list + induced_slots_list))
+        else:
+            return list(set(direct_slots_list))
 
     @lru_cache()
     def get_slots_by_enum(self, enum_name: ENUM_NAME = None) -> List[SlotDefinition]:


### PR DESCRIPTION
The `get_classes_by_slot()` method in SchemaView takes an extremely long time to run on the MIxS schema and generate the _Applicable Classes_ table on slot documentation pages because of which we are having to explore ways to optimize the runtime for the `get_classes_by_slot()` method.