### PR TITLE
bug fix in _construct_target_class()

### DIFF
--- a/linkml_runtime/loaders/loader_root.py
+++ b/linkml_runtime/loaders/loader_root.py
@@ -122,7 +122,7 @@ class Loader(ABC):
                if issubclass(target_class, YAMLRoot):
                    return [target_class(**as_dict(x)) for x in data_as_dict]
                elif issubclass(target_class, BaseModel):
-                   return [target_class.parse_obj(**as_dict(x)) for x in data_as_dict]
+                   return [target_class.parse_obj(as_dict(x)) for x in data_as_dict]
                else:
                    raise ValueError(f'Cannot load list of {target_class}')
             elif isinstance(data_as_dict, dict):


### PR DESCRIPTION
The use case in which the input to the patched code is a simple JSON List of (otherwise LinkML-schema compliant) class objects crashes with the code. I noted that the case of a single JSON dictionary object works fine in the line below the patched one (that processes a list of objects).

One notes that **`BaseModel.parse_obj()`** appears to only want a dictionary as its argument, not ****kwargs** from the 'x' dictionary object. 

It is suggested that some kind of LinkML defined 'collection' class slot needs be present to constrain data entry.  I understand the motivation for that. I suppose there is an argument here that the Model should constraint the presence or absence of "multivalued" inputs. 

That said, it seems in fact,  However, reading in a simple list of instances of data seems a helpful use case to support by default.

However, this tiny PR patch to the code allows the otherwise correct code to validate and correctly return a JSON List of (LinkML schema class compliant and wrapped) data objects.