### PR TITLE
test: improve coverage of curie validation

### DIFF
--- a/linkml_runtime/utils/uri_validator.py
+++ b/linkml_runtime/utils/uri_validator.py
@@ -42,7 +42,7 @@ unreserved = rf"(?: {ALPHA} | {DIGIT} | \- | \. | _ | ~ )"
 gen_delims = r"(?: : | / | \? | \# | \[ | \] | @ )"
 
 #   sub-delims    = "!" / "$" / "&" / "'" / "("
-sub_delims = r"(?: ! | \$ | & | ' | \( | \) | \* | \+ | , | ; | = )"
+sub_delims = r"(?: ! | \$ | & | ' | \( | \) | \* | \+ | , | ; | = )"
 
 #   pchar         = unreserved / pct-encoded / sub-delims / ":" / "@"
 pchar = rf"(?: {unreserved} | {pct_encoded} | {sub_delims} | : | @ )"
@@ -295,7 +295,7 @@ absolute_URI = rf"(?P<absolute_URI> {scheme} : {hier_part} (?: \? {query} )? )"
 # As of now this module doesn't support NCNameChar IRI, but
 # relative-refs as defined in URI,
 # NCNameChar	::=	Letter | Digit | '.' | '-' | '_'
-NCNameChar = rf"(?: {ALPHA} | {DIGIT} | \. | \- | _ )"
+NCNameChar = rf"(?: {ALPHA} | {DIGIT} | \. | \- | _ )"
 
 # prefix      :=   NCName
 # NCName  :=   (Letter | '_') (NCNameChar)*

--- a/linkml_runtime/utils/uri_validator.py
+++ b/linkml_runtime/utils/uri_validator.py
@@ -324,17 +324,17 @@ safe_CURIE = rf"""(?P<safe_CURIE>
 #
 ### Compile the regular expressions for better performance
 
-uri_validator = re.compile("^{}$".format(URI), re.VERBOSE)
+uri_validator = re.compile(f"^{URI}$", re.VERBOSE)
 
-#uri_ref_validator = re.compile("^{}$".format(URI_reference), re.VERBOSE)
+#uri_ref_validator = re.compile(f"^{URI_reference}$", re.VERBOSE)
 
-uri_relative_ref_validator = re.compile("^{}$".format(relative_ref), re.VERBOSE)
+uri_relative_ref_validator = re.compile(f"^{relative_ref}$", re.VERBOSE)
 
-abs_uri_validator = re.compile("^{}$".format(absolute_URI), re.VERBOSE)
+abs_uri_validator = re.compile(f"^{absolute_URI}$", re.VERBOSE)
 
-curie_validator = re.compile("^{}$".format(CURIE), re.VERBOSE)
+curie_validator = re.compile(f"^{CURIE}$", re.VERBOSE)
 
-safe_curie_validator = re.compile("^{}$".format(safe_CURIE), re.VERBOSE)
+safe_curie_validator = re.compile(f"^{safe_CURIE}$", re.VERBOSE)
 
 # -----------------------------------------------------------------------------
 #

--- a/linkml_runtime/utils/uri_validator.py
+++ b/linkml_runtime/utils/uri_validator.py
@@ -357,6 +357,5 @@ def validate_uri_reference(input):
 
 
 def validate_curie(input):
-    #    print(CURIE)
     return curie_validator.match(input)
 

--- a/tests/test_utils/test_metamodelcore.py
+++ b/tests/test_utils/test_metamodelcore.py
@@ -64,6 +64,8 @@ class MetamodelCoreTest(unittest.TestCase):
         self.assertFalse(Curie.is_valid("type"))
         self.assertEqual(":type", Curie(":type"))
         self.assertTrue(Curie.is_valid(':type'))
+        self.assertTrue(Curie.is_valid('WIKIDATA_PROPERTY:P854'))
+        self.assertTrue(Curie.is_valid('WIKIDATA.PROPERTY:P854'))
         with self.assertRaises(ValueError):
             Curie("1df:type")
         self.assertFalse(Curie.is_valid('1df:type'))


### PR DESCRIPTION
According issue linkml/linkml#1701 apparently legal CURIEs like `WIKIDATA_PROPERTY:P854` and `WIKIDATA.PROPERTY:P854` are being rejected by the validation module.

This PR provides:
1. Tests to reproduce the issue and avoid regressions, once fixed.
2. A fix for the issue.

Closes linkml/linkml#1701.