### PR TITLE
check that install of "latest dependent packages" of linkml_runtime still results in tests passing (as opposed to running tests only on the poetry.lock dependencies)

### DIFF
--- a/.github/workflows/check-dependencies.yaml
+++ b/.github/workflows/check-dependencies.yaml
@@ -1,8 +1,4 @@
-# Built from:
-# https://docs.github.com/en/actions/guides/building-and-testing-python
-# https://github.com/actions/setup-python/
-
-name: Build and test linkml-runtime
+name: Build and test linkml-runtime package dependencies
 
 on: [pull_request]
 
@@ -50,10 +46,17 @@ jobs:
 
       # this step we remove and rebuild the poetry.lock file to ensure that the tests that follow can be run
       # with the latest dependencies
-      - name: Install dependencies
-        run: |
-          rm -rf poetry.lock
-          poetry install 
+
+      #----------------------------------------------
+      # Remove and Rebuild the poetry.lock File
+      #----------------------------------------------
+      - name: Remove poetry.lock (Unix)
+        if: runner.os != 'Windows'
+        run: rm -rf poetry.lock
+
+      - name: Remove poetry.lock (Windows)
+        if: runner.os == 'Windows'
+        run: Remove-Item poetry.lock -Force
 
       - name: Run tests
         run: poetry run python -m unittest discover

--- a/.github/workflows/check-dependencies.yaml
+++ b/.github/workflows/check-dependencies.yaml
@@ -1,0 +1,59 @@
+# Built from:
+# https://docs.github.com/en/actions/guides/building-and-testing-python
+# https://github.com/actions/setup-python/
+
+name: Build and test linkml-runtime
+
+on: [pull_request]
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        exclude:
+        - os: windows-latest
+          python-version: "3.7"
+        - os: windows-latest
+          python-version: "3.8"
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+
+      #----------------------------------------------
+      #          install poetry
+      #----------------------------------------------
+      - name: Install Poetry
+        # Pin to 1.3.2 to workaround https://github.com/python-poetry/poetry/issues/7611
+        run: pipx install poetry==1.3.2
+
+      #----------------------------------------------
+      #       check-out repo and set-up python
+      #----------------------------------------------
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: 'poetry'
+
+      #----------------------------------------------
+      #    install your root project, if required
+      #----------------------------------------------
+      - name: Install library
+        run: poetry install --no-interaction
+
+      # this step we remove and rebuild the poetry.lock file to ensure that the tests that follow can be run
+      # with the latest dependencies
+      - name: Install dependencies
+        run: |
+          rm -rf poetry.lock
+          poetry install 
+
+      - name: Run tests
+        run: poetry run python -m unittest discover

--- a/linkml_runtime/loaders/yaml_loader.py
+++ b/linkml_runtime/loaders/yaml_loader.py
@@ -9,6 +9,7 @@ from linkml_runtime.loaders.loader_root import Loader
 from linkml_runtime.utils.yamlutils import YAMLRoot, DupCheckYamlLoader
 from pydantic import BaseModel
 
+
 class YAMLLoader(Loader):
     """
     A Loader that is capable of instantiating LinkML data objects from a YAML file
@@ -34,7 +35,7 @@ class YAMLLoader(Loader):
 
     def load_any(self,
                  source: Union[str, dict, TextIO],
-                 target_class: Union[Type[YAMLRoot],Type[BaseModel]],
+                 target_class: Union[Type[YAMLRoot], Type[BaseModel]],
                  *, base_dir: Optional[str] = None,
                  metadata: Optional[FileInfo] = None, **_) -> Union[YAMLRoot, List[YAMLRoot]]:
         data_as_dict = self.load_as_dict(source, base_dir=base_dir, metadata=metadata)


### PR DESCRIPTION
add a check dependencies action that removes the poetry.lock file and reinstalls the linkml-runtime environment (getting the latest compatible packages in the pyproject.toml specification) and then runs the tests as a way of testing the code in a PR on the latest package dependencies

partially resolves #1749.  

After discussion during developer days hackathon, we want to limit our downstream build dependencies (e.g. not build out bmt, etc from LinkML packages directly), but makes sense to take this first step towards "latest possible" dependency checking. 