### PR TITLE
Fix warning in regex

### DIFF
--- a/linkml_runtime/utils/pattern.py
+++ b/linkml_runtime/utils/pattern.py
@@ -31,7 +31,7 @@ class PatternResolver():
 
     # regular expression capturing the various use cases
     # for the optionally dot separated, curly braces bound, pattern syntax
-    var_name = re.compile("{([a-z0-9_-]+([\.-_ ][a-z0-9]+)*)}", re.IGNORECASE)
+    var_name = re.compile(r"{([a-z0-9_-]+([\.-_ ][a-z0-9]+)*)}", re.IGNORECASE)
 
     def __init__(self, schema_view):
         # fetch settings from schema_view


### PR DESCRIPTION
I get warnings like the following because there's an unescaped slash. It either needs to be `\\.` or make the string a raw string, which is preferred for regex legibility.

```
.venv/lib/python3.10/site-packages/linkml_runtime/utils/pattern.py:34
  /home/runner/work/go-fastapi/go-fastapi/.venv/lib/python3.10/site-packages/linkml_runtime/utils/pattern.py:34: DeprecationWarning: invalid escape sequence '\.'
    var_name = re.compile("{([a-z0-9_-]+([\.-_ ][a-z0-9]+)*)}", re.IGNORECASE)
```