### PR TITLE
fix: replace deprecated method

### DIFF
--- a/tests/test_utils/test_schemaview.py
+++ b/tests/test_utils/test_schemaview.py
@@ -66,7 +66,7 @@ class SchemaViewTestCase(unittest.TestCase):
                     if pv == "ANGRY_LION":
                         self.assertEqual(view.permissible_value_parent(pv, e.name), ['LION'])
                         self.assertEqual(view.permissible_value_ancestors(pv, e.name), ['ANGRY_LION', 'LION', 'CAT'])
-                        self.assertEquals(["ANGRY_LION"], view.permissible_value_descendants(pv, e.name))
+                        self.assertEqual(["ANGRY_LION"], view.permissible_value_descendants(pv, e.name))
         for cn, c in view.all_classes().items():
             if c.name == "Adult":
                 self.assertEqual(view.class_ancestors(c.name), ['Adult', 'Person', 'HasAliases', 'Thing'])


### PR DESCRIPTION
Unittest method "assertEquals" is deprecated since Python 3.1, but was still present in the code.

The deprecated method was removed with bpo-45162 [1] and [merged on 3.11](https://github.com/python/cpython/pull/28268/files#diff-78f24041d66ab8ed2ae1aee94bcd42396d27af833cb96a3c506294c6d6dce82d).

[1]: https://github.com/python/cpython/pull/28268