### PR TITLE
chore: upgrading poetry

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,8 +25,7 @@ jobs:
       #          install poetry
       #----------------------------------------------
       - name: Install Poetry
-        # Pin to 1.3.2 to workaround https://github.com/python-poetry/poetry/issues/7611
-        run: pipx install poetry==1.3.2
+        run: pipx install poetry==1.4.0
         
       #----------------------------------------------
       #       check-out repo and set-up python


### PR DESCRIPTION
GitHub test workflow was pinning Poetry to v1.3.2 due to issue 7611 [1]. But that Poetry version blocks the installation of typing-extensions 4.7.1 on Python 3.12 due to multiple deprecated methods and classes being removed.

Since Poetry v1.4.0 resolved 7611 [1], it unblocks the installation of typing-extensions >4.7.1 on Python 3.12 for Windows.

[1]: https://github.com/python-poetry/poetry/issues/7611