### PR TITLE
Fixed typos in schemview.py functions: delete_enum(), delete_slot(), delete_subset()

### DIFF
--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -1652,7 +1652,7 @@ class SchemaView(object):
         :param slot_name: slot to be deleted
         :return:
         """
-        del self.schema.slotes[slot_name]
+        del self.schema.slots[slot_name]
         self.set_modified()
 
     def delete_enum(self, enum_name: EnumDefinitionName) -> None:
@@ -1660,7 +1660,7 @@ class SchemaView(object):
         :param enum_name: enum to be deleted
         :return:
         """
-        del self.schema.enumes[enum_name]
+        del self.schema.enums[enum_name]
         self.set_modified()
 
     def delete_type(self, type_name: TypeDefinitionName) -> None:
@@ -1676,7 +1676,7 @@ class SchemaView(object):
         :param subset_name: subset to be deleted
         :return:
         """
-        del self.schema.subsetes[subset_name]
+        del self.schema.subsets[subset_name]
         self.set_modified()
 
     # def rename(self, old_name: str, new_name: str):


### PR DESCRIPTION
When using the functions delete_enum, delete_slot, and delete_subset I was getting these errors:

1. `AttributeError: 'SchemaDefinition' object has no attribute 'enumes'.`  
Which traces back to line 1663, in delete_enum: `del self.schema.enumes[enum_name]`

2.` AttributeError: 'SchemaDefinition' object has no attribute 'slotes'.`
Which traces back to line 1655, in delete_slot: `del self.schema.slotes[slot_name]`

3. `AttributeError: 'SchemaDefinition' object has no attribute 'subsetes'. `
Which traces back to line 1679, in delete_subset: `del self.schema.subsetes[subset_name]`

When I change enumes to enums, slotes to slots, and subsetes to subsets the functions seem to work as expected. 