### PR TITLE
Fix `Schemaview.import_closure` order

### DIFF
--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -1,4 +1,5 @@
 import os
+import pdb
 import uuid
 import logging
 import collections
@@ -231,6 +232,7 @@ class SchemaView(object):
                 self.schema_map[sn] = imported_schema
             s = self.schema_map[sn]
             if sn not in closure:
+                #closure.insert(0, sn)
                 closure.append(sn)
             for i in s.imports:
                 if i not in visited:
@@ -434,6 +436,7 @@ class SchemaView(object):
     def _get_dict(self, slot_name: str, imports=True) -> Dict:
         schemas = self.all_schema(imports)
         d = {}
+        # pdb.set_trace()
         # iterate through all schemas and merge the list together
         for s in schemas:
             # get the value of element name from the schema, if empty, return empty dictionary.

--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -212,7 +212,29 @@ class SchemaView(object):
         """
         Return all imports
 
-        :param traverse: if true, traverse recursively
+        Objects in imported classes override one another in a "python-like" order -
+        from the point of view of the importing schema, imports will override one
+        another from first to last, recursively for each layer of imports.
+
+        An import tree like::
+
+            - main
+              - s1
+                - s1_1
+                - s1_2
+                    - s1_2_1
+                    - s1_2_2
+              - s2
+                - s2_1
+                - s2_2
+
+        will override objects with the same name, in order::
+
+            ['s1_1', 's1_2_1', 's1_2_2', 's1_2', 's1', 's2_1', 's2_2', 's2']
+
+        :param imports: bool (default: ``True`` ) include imported schemas, recursively
+        :param traverse: bool, optional (default: ``True`` ) (Deprecated, use
+            ``imports`` ). if true, traverse recursively
         :return: all schema names in the transitive reflexive imports closure
         """
         if self.schema_map is None:

--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -207,7 +207,7 @@ class SchemaView(object):
         return schema
 
     @lru_cache()
-    def imports_closure(self, imports: bool = True, inject_metadata=True) -> List[SchemaDefinitionName]:
+    def imports_closure(self, imports: bool = True, traverse: Optional[bool] = None, inject_metadata=True) -> List[SchemaDefinitionName]:
         """
         Return all imports
 
@@ -221,7 +221,10 @@ class SchemaView(object):
         visited = set()
         todo = [self.schema.name]
 
-        if not imports:
+        if traverse is not None:
+            DeprecationWarning('traverse behaves identically to imports and will be removed in a future version. Use imports instead.')
+
+        if not imports or (not traverse and traverse is not None):
             return todo
 
         while len(todo) > 0:

--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -7,6 +7,7 @@ from copy import copy, deepcopy
 from collections import defaultdict, deque
 from pathlib import Path
 from typing import Mapping, Tuple
+import warnings
 
 from linkml_runtime.utils.namespaces import Namespaces
 from deprecated.classic import deprecated
@@ -222,7 +223,10 @@ class SchemaView(object):
         todo = [self.schema.name]
 
         if traverse is not None:
-            DeprecationWarning('traverse behaves identically to imports and will be removed in a future version. Use imports instead.')
+            warnings.warn(
+                'traverse behaves identically to imports and will be removed in a future version. Use imports instead.',
+                DeprecationWarning
+            )
 
         if not imports or (not traverse and traverse is not None):
             return todo

--- a/tests/test_issues/test_linkml_issue_998.py
+++ b/tests/test_issues/test_linkml_issue_998.py
@@ -81,8 +81,8 @@ def test_slots_are_not_duplicated(view):
 
 def test_issue_998_attribute_slot(view):
     enum_slots = view.get_slots_by_enum("EmploymentStatusEnum")
-    assert len(enum_slots) == 1
-    assert enum_slots[0].name == "employed"
+    assert len(enum_slots) == 2
+    assert sorted([slot.name for slot in enum_slots]) == ["employed", "past_employer"]
 
 
 def test_issue_998_schema_and_attribute_slots(view):

--- a/tests/test_utils/input/imports/README.md
+++ b/tests/test_utils/input/imports/README.md
@@ -1,0 +1,33 @@
+A tree of imports like:
+
+```
+main
+|- linkml:types
+|- s1
+|  |- s1_1
+|  |- s1_2
+|     |- s1_2_1
+|        |- s1_2_1_1
+|           |- s1_2_1_1_1
+|           |- s1_2_1_1_2
+|- s2
+|  |- s2_1
+|  |- s2_2
+|- s3
+   |- s3_1
+   |- s3_2
+```
+
+This is used to test SchemaView's logic for complex import hierarchies,
+eg.
+- overrides
+- imports closure completeness
+- (at some point) monotonicity
+- etc. 
+
+Currently, each schema...
+- Contains one `Main` class with a value whose default is overridden to indicate which module defined it, this is used to test overrides.
+- Contains a class like `S2` that carries the name of the module to ensure that unique classes are gotten from the whole tree
+- Each node in the tree outwards from `main` will carry the 'special classes' from the parents, overriding them as with `main` to
+  get a more detailed picture of override order: eg. `s1_2_1` will also define `S1_2` and override its `ifabsent` field, 
+  which `S1_2` should override since it's the importing schema.

--- a/tests/test_utils/input/imports/main.yaml
+++ b/tests/test_utils/input/imports/main.yaml
@@ -1,0 +1,15 @@
+id: main
+name: main
+title: main
+imports:
+  - linkml:types
+  - s1
+  - s2
+  - s3
+classes:
+  Main:
+    description: "The class we use to test overrides on imports!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "Main"

--- a/tests/test_utils/input/imports/s1.yaml
+++ b/tests/test_utils/input/imports/s1.yaml
@@ -1,0 +1,20 @@
+id: s1
+name: s1
+title: s1
+imports:
+  - linkml:types
+  - s1_1
+  - s1_2
+classes:
+  Main:
+    description: "The class we use to test overrides on imports!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S1"
+  S1:
+    description: "A class from one of the imported classes!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S1"

--- a/tests/test_utils/input/imports/s1_1.yaml
+++ b/tests/test_utils/input/imports/s1_1.yaml
@@ -1,0 +1,24 @@
+id: s1_1
+name: s1_1
+title: s1_1
+imports:
+  - linkml:types
+classes:
+  Main:
+    description: "The class we use to test overrides on imports!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S1_1"
+  S1:
+    description: "A class from one of the imported classes!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S1_1"
+  S1_1:
+    description: "A class from one of the imported classes!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S1_1"

--- a/tests/test_utils/input/imports/s1_2.yaml
+++ b/tests/test_utils/input/imports/s1_2.yaml
@@ -1,0 +1,25 @@
+id: s1_2
+name: s1_2
+title: s1_2
+imports:
+  - linkml:types
+  - s1_2_1
+classes:
+  Main:
+    description: "The class we use to test overrides on imports!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S1_2"
+  S1:
+    description: "A class from one of the imported classes!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S1_2"
+  S1_2:
+    description: "A class from one of the imported classes!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S1_2"

--- a/tests/test_utils/input/imports/s1_2_1.yaml
+++ b/tests/test_utils/input/imports/s1_2_1.yaml
@@ -1,0 +1,31 @@
+id: s1_2_1
+name: s1_2_1
+title: s1_2_1
+imports:
+  - linkml:types
+  - s1_2_1_1
+classes:
+  Main:
+    description: "The class we use to test overrides on imports!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S1_2_1"
+  S1:
+    description: "A class from one of the imported classes!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S1_2_1"
+  S1_2:
+    description: "A class from one of the imported classes!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S1_2_1"
+  S1_2_1:
+    description: "A class from one of the imported classes!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S1_2_1"

--- a/tests/test_utils/input/imports/s1_2_1_1.yaml
+++ b/tests/test_utils/input/imports/s1_2_1_1.yaml
@@ -1,0 +1,38 @@
+id: s1_2_1_1
+name: s1_2_1_1
+title: s1_2_1_1
+imports:
+  - linkml:types
+  - s1_2_1_1_1
+  - s1_2_1_1_2
+classes:
+  Main:
+    description: "The class we use to test overrides on imports!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S1_2_1_1"
+  S1:
+    description: "A class from one of the imported classes!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S1_2_1_1"
+  S1_2:
+    description: "A class from one of the imported classes!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S1_2_1_1"
+  S1_2_1:
+    description: "A class from one of the imported classes!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S1_2_1_1"
+  S1_2_1_1:
+    description: "A class from one of the imported classes!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S1_2_1_1"

--- a/tests/test_utils/input/imports/s1_2_1_1_1.yaml
+++ b/tests/test_utils/input/imports/s1_2_1_1_1.yaml
@@ -1,0 +1,42 @@
+id: s1_2_1_1_1
+name: s1_2_1_1_1
+title: s1_2_1_1_1
+imports:
+  - linkml:types
+classes:
+  Main:
+    description: "The class we use to test overrides on imports!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S1_2_1_1_1"
+  S1:
+    description: "A class from one of the imported classes!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S1_2_1_1_1"
+  S1_2:
+    description: "A class from one of the imported classes!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S1_2_1_1_1"
+  S1_2_1:
+    description: "A class from one of the imported classes!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S1_2_1_1_1"
+  S1_2_1_1:
+    description: "A class from one of the imported classes!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S1_2_1_1_1"
+  S1_2_1_1_1:
+    description: "A class from one of the imported classes!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S1_2_1_1_1"

--- a/tests/test_utils/input/imports/s1_2_1_1_2.yaml
+++ b/tests/test_utils/input/imports/s1_2_1_1_2.yaml
@@ -1,0 +1,42 @@
+id: s1_2_1_1_2
+name: s1_2_1_1_2
+title: s1_2_1_1_2
+imports:
+  - linkml:types
+classes:
+  Main:
+    description: "The class we use to test overrides on imports!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S1_2_1_1_2"
+  S1:
+    description: "A class from one of the imported classes!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S1_2_1_1_2"
+  S1_2:
+    description: "A class from one of the imported classes!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S1_2_1_1_2"
+  S1_2_1:
+    description: "A class from one of the imported classes!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S1_2_1_1_2"
+  S1_2_1_1:
+    description: "A class from one of the imported classes!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S1_2_1_1_2"
+  S1_2_1_1_2:
+    description: "A class from one of the imported classes!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S1_2_1_1_2"

--- a/tests/test_utils/input/imports/s2.yaml
+++ b/tests/test_utils/input/imports/s2.yaml
@@ -1,0 +1,20 @@
+id: s2
+name: s2
+title: s2
+imports:
+  - linkml:types
+  - s2_1
+  - s2_2
+classes:
+  Main:
+    description: "The class we use to test overrides on imports!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S2"
+  S2:
+    description: "A class from one of the imported classes!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S2"

--- a/tests/test_utils/input/imports/s2_1.yaml
+++ b/tests/test_utils/input/imports/s2_1.yaml
@@ -1,0 +1,24 @@
+id: s2_1
+name: s2_1
+title: s2_1
+imports:
+  - linkml:types
+classes:
+  Main:
+    description: "The class we use to test overrides on imports!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S2_1"
+  S2:
+    description: "A class from one of the imported classes!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S2_1"
+  S2_1:
+    description: "A class from one of the imported classes!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S2_1"

--- a/tests/test_utils/input/imports/s2_2.yaml
+++ b/tests/test_utils/input/imports/s2_2.yaml
@@ -1,0 +1,24 @@
+id: s2_2
+name: s2_2
+title: s2_2
+imports:
+  - linkml:types
+classes:
+  Main:
+    description: "The class we use to test overrides on imports!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S2_2"
+  S2:
+    description: "A class from one of the imported classes!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S2_2"
+  S2_2:
+    description: "A class from one of the imported classes!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S2_2"

--- a/tests/test_utils/input/imports/s3.yaml
+++ b/tests/test_utils/input/imports/s3.yaml
@@ -1,0 +1,20 @@
+id: s3
+name: s3
+title: s3
+imports:
+  - linkml:types
+  - s3_1
+  - s3_2
+classes:
+  Main:
+    description: "The class we use to test overrides on imports!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S3"
+  S3:
+    description: "A class from one of the imported classes!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S3"

--- a/tests/test_utils/input/imports/s3_1.yaml
+++ b/tests/test_utils/input/imports/s3_1.yaml
@@ -1,0 +1,24 @@
+id: s3_1
+name: s3_1
+title: s3_1
+imports:
+  - linkml:types
+classes:
+  Main:
+    description: "The class we use to test overrides on imports!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S3_1"
+  S3:
+    description: "A class from one of the imported classes!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S3_1"
+  S3_1:
+    description: "A class from one of the imported classes!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S3_1"

--- a/tests/test_utils/input/imports/s3_2.yaml
+++ b/tests/test_utils/input/imports/s3_2.yaml
@@ -1,0 +1,24 @@
+id: s3_2
+name: s3_2
+title: s3_2
+imports:
+  - linkml:types
+classes:
+  Main:
+    description: "The class we use to test overrides on imports!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S3_2"
+  S3:
+    description: "A class from one of the imported classes!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S3_2"
+  S3_2:
+    description: "A class from one of the imported classes!"
+    attributes:
+      value:
+        range: string
+        ifabsent: "S3_2"

--- a/tests/test_utils/test_schemaview.py
+++ b/tests/test_utils/test_schemaview.py
@@ -488,7 +488,7 @@ class SchemaViewTestCase(unittest.TestCase):
             - input/imports/README.md for explanation of the test schema
         """
         sv = SchemaView(SCHEMA_IMPORT_TREE)
-        closure = sv.imports_closure(imports=True, traverse=True)
+        closure = sv.imports_closure(imports=True)
         target = [
             'linkml:types',
             's1_1',

--- a/tests/test_utils/test_schemaview.py
+++ b/tests/test_utils/test_schemaview.py
@@ -18,6 +18,7 @@ from tests.test_utils import INPUT_DIR
 SCHEMA_NO_IMPORTS = Path(INPUT_DIR) / 'kitchen_sink_noimports.yaml'
 SCHEMA_WITH_IMPORTS = Path(INPUT_DIR) / 'kitchen_sink.yaml'
 SCHEMA_WITH_STRUCTURED_PATTERNS = Path(INPUT_DIR) / "pattern-example.yaml"
+SCHEMA_IMPORT_TREE = Path(INPUT_DIR) / 'imports' / 'main.yaml'
 
 yaml_loader = YAMLLoader()
 IS_CURRENT = 'is current'
@@ -477,6 +478,13 @@ class SchemaViewTestCase(unittest.TestCase):
         view2 = SchemaView(view.schema)
         self.assertCountEqual(view.all_classes(), view2.all_classes())
         self.assertCountEqual(view.all_classes(imports=False), view2.all_classes(imports=False))
+
+    def test_imports_order(self):
+        """
+        Imports should override in a python-like order.
+
+        See https://github.com/linkml/linkml/issues/1839
+        """
 
     def test_direct_remote_imports(self):
         """


### PR DESCRIPTION
Fix: https://github.com/linkml/linkml/issues/1839
Also:
- Fix: https://github.com/linkml/linkml/issues/1825
- Related to: https://github.com/linkml/linkml/issues/584

Previously on `this issue`....

the schemaview was doing an ordering that was almost perfectly backwards, not allowing one to redefine classes that had already been declared in an imported schema.

## Fix Ordering

Two substantive changes:
### 1) use a deque and `appendleft` 

(probably a perf wash vs. `reverse` but wanted to keep operation grouped): the `pop` and `append` operations make a FILO queue, and so we want earlier visited items (eg. the imported module) to be at the end of the imports closure. 

For intuition, in the sample import tree, the first layer of imports is 

```yaml
imports:
- linkml:types
- s1
- s2
- s3
```

so  the `todo` list will have `['linkml:types', 's1', 's2', 's3']`

on the next iteration we 
- pop (right) `s3`  from `todo`,
- add its imports to `todo`: `['linkml:types', 's1', 's2', 's3_1', 's3_2']`
- `leftappend` `s3` to `closure`: `['s3', 'main'`]`

and so on.

### 2) only check for uniqueness to avoid cycles

remove uniqueness checking in closure appends, and add to `visited` at the end of the loop rather than the start.

This is mostly to fix the case where a schema (like `linkml:types`) is imported multiple times in the tree. Currently, it would be inserted in the last place it appears (since the import resolution order effectively works backwards). In this change we add it everywhere that it is actually imported, but only follow its imports the first time it appears.  This is an imperfect fix that comes from needing to flatten a graph that can be completed once the schemaview class behaved recursively. 

We then filter duplicates, keeping the first appearance using a dictionary comprehension. 

## Also Changed

### `traverse` param:

I noticed that the `traverse` parameter behaved identically to the `imports` parameter, but i could only see the `imports` parameter being used. I switched that to being default `None` so it would only to a deprecation warning if you attempted to use it. I don't know how y'all handle deprecations so lmk how to handle that. 

### issue 998 tests

I'm not sure why I affected this here, but [this test](https://github.com/linkml/linkml-runtime/blob/c9adcaeb405804efcf19bd4fcfc950a8ddb173e1/tests/test_issues/test_linkml_issue_998.py#L84) was incorrectly specifying that there was only one slot that used `'EmploymentStatusEnum'` (which actually doesn't exist in the schema, it's named `'EmployedStatusEnum'`, so maybe schemaview needs some tests for whether a thing exists when referring to it?), but there are actually two slots that do:
- `past_employer`, a slot: https://github.com/linkml/linkml-runtime/blob/c9adcaeb405804efcf19bd4fcfc950a8ddb173e1/tests/test_issues/test_linkml_issue_998.py#L44
- `employed`, an attribute: https://github.com/linkml/linkml-runtime/blob/c9adcaeb405804efcf19bd4fcfc950a8ddb173e1/tests/test_issues/test_linkml_issue_998.py#L21

And since there are actually two `employed` attributes, there should really be 3 slots identified there, but since they are just indexed by slot name they are collapsed down to 2. 

idk i didn't want to change too much there, but that's sort of a warning sign that there might be something wrong elsewhere in schemaview, but i changed it so the tests correctly pass, not sure why they were passing before.
