### PR TITLE
[perf] Use yamllib if available

### DIFF
--- a/linkml_runtime/utils/yamlutils.py
+++ b/linkml_runtime/utils/yamlutils.py
@@ -14,6 +14,11 @@ from linkml_runtime.utils.formatutils import is_empty
 
 YAMLObjTypes = Union[JsonObjTypes, "YAMLRoot"]
 
+try:
+    from yaml import CSafeLoader as SafeLoader
+except ImportError:
+    from yaml.loader import SafeLoader
+
 
 class YAMLMark(yaml.error.Mark):
     def __str__(self):
@@ -369,7 +374,7 @@ class extended_float(float, TypedNode):
     pass
 
 
-class DupCheckYamlLoader(yaml.loader.SafeLoader):
+class DupCheckYamlLoader(SafeLoader):
     """
     A YAML loader that throws an error when the same key appears twice
     """


### PR DESCRIPTION
Loading yaml is actually really slow in pure python! and we load a lot of yaml!

There's a free perf boost we can get by just using the compiled yamllib versions if they are available (they usually are). 

The only failure I noticed was that there was a single `\t` character at the start of a multiline string in the biolink model that cause s parsing error, but once that was fixed it was exactly the same just way faster.

For `YAMLLoader.load_as_dict` in main `linkml` tests, (cumulative time in seconds, `--with-slow`)

|                            | Total test time | `load_as_dict` | per call |
| ---------------- | -------------- | --------------- | ------- |
| Before PR | 1527s  | 451.3s | .1136s |
| This PR              | 1334s   | 243.9s | .062s |
| Change. | -193s | -207s | -.0516 |
Change:  | -12.6% | -46% | |

all ~ for free ~