### PR TITLE
Fix namespaces CURIE prefix & suffix extraction

### DIFF
--- a/linkml_runtime/utils/namespaces.py
+++ b/linkml_runtime/utils/namespaces.py
@@ -137,7 +137,9 @@ class Namespaces(CaseInsensitiveDict):
     def curie_for(self, uri: Any, default_ok: bool = True, pythonform: bool = False) -> Optional[str]:
         """
         Return the most appropriate CURIE for URI.  The first longest matching prefix used, if any.  If no CURIE is
-        present, None is returned
+        present, None is returned.
+
+        Please see https://www.w3.org/TR/curie/ for more details about CURIEs.
 
         @param uri: URI to create the CURIE for
         @param default_ok: True means the default prefix is ok. Otherwise, we have to have a real prefix
@@ -191,7 +193,7 @@ class Namespaces(CaseInsensitiveDict):
 
     def prefix_suffix(self, uri_or_curie: Any, case_shift: bool = True) -> Tuple[Optional[str], Optional[str]]:
         uri_or_curie = str(uri_or_curie)
-        if ':/' in uri_or_curie:
+        if '://' in uri_or_curie:
             uri_or_curie = self.curie_for(uri_or_curie)
             if not uri_or_curie:
                 return None, None

--- a/tests/test_utils/test_namespaces.py
+++ b/tests/test_utils/test_namespaces.py
@@ -14,7 +14,7 @@ class NamespacesTestCase(unittest.TestCase):
         self.assertEqual(str(ns.skos), str(SKOS))
         self.assertEqual(ns.skos.note, SKOS.note)
         ns.OIO = URIRef("http://www.geneontology.org/formats/oboInOwl")
-        ns['dc'] = "http://example.org/dc/"         # Overrides 'dc' in semweb_context
+        ns['dc'] = "http://example.org/dc/"  # Overrides 'dc' in semweb_context
         ns['l1'] = "http://example.org/subset/"
         ns['l2'] = "http://example.org/subset/test/"
         ns['l3'] = "http://example.org/subset/t"
@@ -63,8 +63,8 @@ class NamespacesTestCase(unittest.TestCase):
         self.assertEqual('u1:foo', ns.curie_for("urn:example:foo"))
         with self.assertRaises(ValueError):
             ns.curie_for("1abc\junk")
-        #no comment in skos?
-        #self.assertEqual(SKOS.comment, ns.uri_for("skos:comment"))
+        # no comment in skos?
+        # self.assertEqual(SKOS.comment, ns.uri_for("skos:comment"))
         self.assertEqual(URIRef('http://example.org/dc/table'), ns.uri_for("dc:table"))
         self.assertEqual(ns.uri_for("http://something.org"), URIRef("http://something.org"))
         self.assertEqual('https://w3id.org/biolink/metamodel/Schema', str(ns.uri_for(":Schema")))
@@ -99,6 +99,22 @@ class NamespacesTestCase(unittest.TestCase):
         test_NCIT_uri = URIRef('http://purl.obolibrary.org/obo/NCIT_C25300')
         self.assertEqual(prefixmap_merged.curie_for(test_NCIT_uri), test_NCIT_curie)
         self.assertEqual(prefixmap_merged.uri_for(test_NCIT_curie), test_NCIT_uri)
+
+    def test_prefix_suffix(self):
+        ns = Namespaces()
+        ns['farm'] = 'https://example.org/farm'
+        ns['farm_slash'] = 'https://slash.org/farm/'
+
+        self.assertEqual(('farm', 'cow'), ns.prefix_suffix('farm:cow'))
+        self.assertEqual(('farm', '/cow'), ns.prefix_suffix('https://example.org/farm/cow'))
+        self.assertEqual(('farm_slash', 'cow'), ns.prefix_suffix('https://slash.org/farm/cow'))
+        self.assertEqual(('farm_slash', 'cow/horns'), ns.prefix_suffix('farm_slash:cow/horns'))
+        self.assertEqual(('farm', '/cow/horns'), ns.prefix_suffix('farm:/cow/horns'))
+        self.assertEqual(('farm', '#cow/horns'), ns.prefix_suffix('farm:#cow/horns'))
+        self.assertEqual(('farm', ''), ns.prefix_suffix('farm:'))
+        self.assertEqual(('', 'cow'), ns.prefix_suffix(':cow'))
+        self.assertEqual((None, None), ns.prefix_suffix('https://missing-prefix.org/farm/cow'))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Motivation Behind This

While working on the LinkML JSON-LD Context generator, I chose to use the [namespaces.py `prefix_suffix(..)` method](https://github.com/linkml/linkml-runtime/blob/main/linkml_runtime/utils/namespaces.py#L192) to build `@id` attributes.

Then, I started having issues with the [test_curie_prefix_matching.py](https://github.com/linkml/linkml/blob/main/tests/test_issues/test_curie_prefix_matching.py) test class (BTW thanks to the developer of this class 👍 ) which has very specific CURIEs like `p1:/c/c1` for example.

## Solution

I went through the [CURIE specification](https://www.w3.org/TR/curie/) to find which types of CURIEs should be supported and I added them to the `test_namespaces.py` test class to make sure specific cases were managed.

The solution I propose is straightforward but as this method is used in many places, the impacts can be big. I have a pull request coming up to update the LinkML project with my JSON-LD Context generator developments and test updates.