### PR TITLE
Update Cache To Support > 128 Entries

### DIFF
--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -155,7 +155,7 @@ class SchemaView(object):
     def __hash__(self):
         return hash(self.__key())
 
-    @lru_cache()
+    @lru_cache(None)
     def namespaces(self) -> Namespaces:
         namespaces = Namespaces()
         for s in self.schema_map.values():
@@ -207,7 +207,7 @@ class SchemaView(object):
         schema = load_schema_wrap(sname + '.yaml', base_dir=base_dir)
         return schema
 
-    @lru_cache()
+    @lru_cache(None)
     def imports_closure(self, imports: bool = True, traverse: Optional[bool] = None, inject_metadata=True) -> List[SchemaDefinitionName]:
         """
         Return all imports
@@ -287,7 +287,7 @@ class SchemaView(object):
                         a.from_schema = s.id
         return closure
 
-    @lru_cache()
+    @lru_cache(None)
     def all_schema(self, imports: bool = True) -> List[SchemaDefinition]:
         """
         :param imports: include imports closure
@@ -297,7 +297,7 @@ class SchemaView(object):
         return [m[sn] for sn in self.imports_closure(imports)]
 
     @deprecated("Use `all_classes` instead")
-    @lru_cache()
+    @lru_cache(None)
     def all_class(self, imports=True) -> Dict[ClassDefinitionName, ClassDefinition]:
         """
         :param imports: include imports closure
@@ -342,7 +342,7 @@ class SchemaView(object):
         rank_ordered_elements.update(unranked_map)
         return rank_ordered_elements
 
-    @lru_cache()
+    @lru_cache(None)
     def all_classes(self, ordered_by=OrderedBy.PRESERVE, imports=True) -> Dict[ClassDefinitionName, ClassDefinition]:
         """
         :param ordered_by: an enumerated parameter that returns all the slots in the order specified.
@@ -361,7 +361,7 @@ class SchemaView(object):
         return ordered_classes
 
     @deprecated("Use `all_slots` instead")
-    @lru_cache()
+    @lru_cache(None)
     def all_slot(self, **kwargs) -> Dict[SlotDefinitionName, SlotDefinition]:
         """
         :param imports: include imports closure
@@ -369,7 +369,7 @@ class SchemaView(object):
         """
         return self.all_slots(**kwargs)
 
-    @lru_cache()
+    @lru_cache(None)
     def all_slots(self, ordered_by=OrderedBy.PRESERVE, imports=True, attributes=True) -> Dict[
         SlotDefinitionName, SlotDefinition]:
         """
@@ -396,7 +396,7 @@ class SchemaView(object):
         return ordered_slots
 
     @deprecated("Use `all_enums` instead")
-    @lru_cache()
+    @lru_cache(None)
     def all_enum(self, imports=True) -> Dict[EnumDefinitionName, EnumDefinition]:
         """
         :param imports: include imports closure
@@ -404,7 +404,7 @@ class SchemaView(object):
         """
         return self._get_dict(ENUMS, imports)
 
-    @lru_cache()
+    @lru_cache(None)
     def all_enums(self, imports=True) -> Dict[EnumDefinitionName, EnumDefinition]:
         """
         :param imports: include imports closure
@@ -413,7 +413,7 @@ class SchemaView(object):
         return self._get_dict(ENUMS, imports)
 
     @deprecated("Use `all_types` instead")
-    @lru_cache()
+    @lru_cache(None)
     def all_type(self, imports=True) -> Dict[TypeDefinitionName, TypeDefinition]:
         """
         :param imports: include imports closure
@@ -421,7 +421,7 @@ class SchemaView(object):
         """
         return self._get_dict(TYPES, imports)
 
-    @lru_cache()
+    @lru_cache(None)
     def all_types(self, imports=True) -> Dict[TypeDefinitionName, TypeDefinition]:
         """
         :param imports: include imports closure
@@ -437,7 +437,7 @@ class SchemaView(object):
         """
         return self._get_dict(SUBSETS, imports)
 
-    @lru_cache()
+    @lru_cache(None)
     def all_subsets(self, imports=True) -> Dict[SubsetDefinitionName, SubsetDefinition]:
         """
         :param imports: include imports closure
@@ -446,7 +446,7 @@ class SchemaView(object):
         return self._get_dict(SUBSETS, imports)
 
     @deprecated("Use `all_elements` instead")
-    @lru_cache()
+    @lru_cache(None)
     def all_element(self, imports=True) -> Dict[ElementName, Element]:
         """
         :param imports: include imports closure
@@ -460,7 +460,7 @@ class SchemaView(object):
         # {**a,**b} syntax merges dictionary a and b into a single dictionary, removing duplicates.
         return {**all_classes, **all_slots, **all_enums, **all_types, **all_subsets}
 
-    @lru_cache()
+    @lru_cache(None)
     def all_elements(self, imports=True) -> Dict[ElementName, Element]:
         """
         :param imports: include imports closure
@@ -487,7 +487,7 @@ class SchemaView(object):
 
         return d
 
-    @lru_cache()
+    @lru_cache(None)
     def slot_name_mappings(self) -> Dict[str, SlotDefinition]:
         """
         Mapping between processed safe slot names (following naming conventions)  and slots.
@@ -501,7 +501,7 @@ class SchemaView(object):
             m[underscore(s.name)] = s
         return m
 
-    @lru_cache()
+    @lru_cache(None)
     def class_name_mappings(self) -> Dict[str, ClassDefinition]:
         """
         Mapping between processed safe class names (following naming conventions) and classes.
@@ -515,7 +515,7 @@ class SchemaView(object):
             m[camelcase(s.name)] = s
         return m
 
-    @lru_cache()
+    @lru_cache(None)
     def in_schema(self, element_name: ElementName) -> SchemaDefinitionName:
         """
         :param element_name:
@@ -526,7 +526,7 @@ class SchemaView(object):
             raise ValueError(f'Element {element_name} not in any schema')
         return ix[element_name]
 
-    @lru_cache()
+    @lru_cache(None)
     def element_by_schema_map(self) -> Dict[ElementName, SchemaDefinitionName]:
         ix = {}
         schemas = self.all_schema(True)
@@ -539,7 +539,7 @@ class SchemaView(object):
                     ix[aname] = schema.name
         return ix
 
-    @lru_cache()
+    @lru_cache(None)
     def get_class(self, class_name: CLASS_NAME, imports=True, strict=False) -> ClassDefinition:
         """
         :param class_name: name of the class to be retrieved
@@ -552,7 +552,7 @@ class SchemaView(object):
         else:
             return c
 
-    @lru_cache()
+    @lru_cache(None)
     def get_slot(self, slot_name: SLOT_NAME, imports=True, attributes=True, strict=False) -> SlotDefinition:
         """
         :param slot_name: name of the slot to be retrieved
@@ -575,7 +575,7 @@ class SchemaView(object):
             raise ValueError(f'No such slot as "{slot_name}"')
         return slot
 
-    @lru_cache()
+    @lru_cache(None)
     def get_subset(self, subset_name: SUBSET_NAME, imports=True, strict=False) -> SubsetDefinition:
         """
         :param subset_name: name of the subsey to be retrieved
@@ -588,7 +588,7 @@ class SchemaView(object):
         else:
             return s
 
-    @lru_cache()
+    @lru_cache(None)
     def get_enum(self, enum_name: ENUM_NAME, imports=True, strict=False) -> EnumDefinition:
         """
         :param enum_name: name of the enum to be retrieved
@@ -601,7 +601,7 @@ class SchemaView(object):
         else:
             return e
 
-    @lru_cache()
+    @lru_cache(None)
     def get_type(self, type_name: TYPE_NAME, imports=True, strict=False) -> TypeDefinition:
         """
         :param type_name: name of the type to be retrieved
@@ -623,7 +623,7 @@ class SchemaView(object):
             parents.append(e.is_a)
         return parents
 
-    @lru_cache()
+    @lru_cache(None)
     def class_parents(self, class_name: CLASS_NAME, imports=True, mixins=True, is_a=True) -> List[ClassDefinitionName]:
         """
         :param class_name: child class name
@@ -634,7 +634,7 @@ class SchemaView(object):
         cls = self.get_class(class_name, imports, strict=True)
         return self._parents(cls, imports, mixins, is_a)
 
-    @lru_cache()
+    @lru_cache(None)
     def enum_parents(self, enum_name: ENUM_NAME, imports=False, mixins=False, is_a=True) -> List[EnumDefinitionName]:
         """
         :param enum_name: child enum name
@@ -645,7 +645,7 @@ class SchemaView(object):
         e = self.get_enum(enum_name, strict=True)
         return self._parents(e, imports, mixins, is_a=is_a)
 
-    @lru_cache()
+    @lru_cache(None)
     def permissible_value_parent(self, permissible_value: str, enum_name: ENUM_NAME) -> Union[
         str, PermissibleValueText, None, ValueError]:
         """
@@ -662,7 +662,7 @@ class SchemaView(object):
         else:
             return []
 
-    @lru_cache()
+    @lru_cache(None)
     def permissible_value_children(self, permissible_value: str, enum_name: ENUM_NAME) -> Union[
         str, PermissibleValueText, None, ValueError]:
         """
@@ -696,7 +696,7 @@ class SchemaView(object):
         else:
             raise ValueError(f'No such enum as "{enum_name}"')
 
-    @lru_cache()
+    @lru_cache(None)
     def slot_parents(self, slot_name: SLOT_NAME, imports=True, mixins=True, is_a=True) -> List[SlotDefinitionName]:
         """
         :param slot_name: child slot name
@@ -710,7 +710,7 @@ class SchemaView(object):
         else:
             return []
 
-    @lru_cache()
+    @lru_cache(None)
     def type_parents(self, type_name: TYPE_NAME, imports=True) -> List[TypeDefinitionName]:
         """
         :param type_name: child type name
@@ -723,7 +723,7 @@ class SchemaView(object):
         else:
             return []
 
-    @lru_cache()
+    @lru_cache(None)
     def get_children(self, name: str, mixin: bool = True) -> List[str]:
         """
         get the children of an element (any class, slot, enum, type)
@@ -740,7 +740,7 @@ class SchemaView(object):
                     children.append(el.name)
         return children
 
-    @lru_cache()
+    @lru_cache(None)
     def class_children(self, class_name: CLASS_NAME, imports=True, mixins=True, is_a=True) -> List[ClassDefinitionName]:
         """
         :param class_name: parent class name
@@ -752,7 +752,7 @@ class SchemaView(object):
         elts = [self.get_class(x) for x in self.all_classes(imports=imports)]
         return [x.name for x in elts if (x.is_a == class_name and is_a) or (mixins and class_name in x.mixins)]
 
-    @lru_cache()
+    @lru_cache(None)
     def slot_children(self, slot_name: SLOT_NAME, imports=True, mixins=True, is_a=True) -> List[SlotDefinitionName]:
         """
         :param slot_name: parent slot name
@@ -764,7 +764,7 @@ class SchemaView(object):
         elts = [self.get_slot(x) for x in self.all_slots(imports)]
         return [x.name for x in elts if (x.is_a == slot_name and is_a) or (mixins and slot_name in x.mixins)]
 
-    @lru_cache()
+    @lru_cache(None)
     def class_ancestors(self, class_name: CLASS_NAME, imports=True, mixins=True, reflexive=True, is_a=True,
                         depth_first=True) -> List[ClassDefinitionName]:
         """
@@ -782,7 +782,7 @@ class SchemaView(object):
                         class_name,
                         reflexive=reflexive, depth_first=depth_first)
 
-    @lru_cache()
+    @lru_cache(None)
     def permissible_value_ancestors(self, permissible_value_text: str,
                                     enum_name: ENUM_NAME,
                                     reflexive=True,
@@ -797,7 +797,7 @@ class SchemaView(object):
                         reflexive=reflexive,
                         depth_first=depth_first)
 
-    @lru_cache()
+    @lru_cache(None)
     def permissible_value_descendants(self, permissible_value_text: str,
                                     enum_name: ENUM_NAME,
                                     reflexive=True,
@@ -813,7 +813,7 @@ class SchemaView(object):
                         reflexive=reflexive,
                         depth_first=depth_first)
 
-    @lru_cache()
+    @lru_cache(None)
     def enum_ancestors(self, enum_name: ENUM_NAME, imports=True, mixins=True, reflexive=True, is_a=True,
                        depth_first=True) -> List[EnumDefinitionName]:
         """
@@ -831,7 +831,7 @@ class SchemaView(object):
                         enum_name,
                         reflexive=reflexive, depth_first=depth_first)
 
-    @lru_cache()
+    @lru_cache(None)
     def type_ancestors(self, type_name: TYPES, imports=True, reflexive=True, depth_first=True) -> List[
         TypeDefinitionName]:
         """
@@ -847,7 +847,7 @@ class SchemaView(object):
                         type_name,
                         reflexive=reflexive, depth_first=depth_first)
 
-    @lru_cache()
+    @lru_cache(None)
     def slot_ancestors(self, slot_name: SLOT_NAME, imports=True, mixins=True, reflexive=True, is_a=True) -> List[
         SlotDefinitionName]:
         """
@@ -864,7 +864,7 @@ class SchemaView(object):
                         slot_name,
                         reflexive=reflexive)
 
-    @lru_cache()
+    @lru_cache(None)
     def class_descendants(self, class_name: CLASS_NAME, imports=True, mixins=True, reflexive=True, is_a=True) -> List[
         ClassDefinitionName]:
         """
@@ -880,7 +880,7 @@ class SchemaView(object):
         return _closure(lambda x: self.class_children(x, imports=imports, mixins=mixins, is_a=is_a), class_name,
                         reflexive=reflexive)
 
-    @lru_cache()
+    @lru_cache(None)
     def slot_descendants(self, slot_name: SLOT_NAME, imports=True, mixins=True, reflexive=True, is_a=True) -> List[
         SlotDefinitionName]:
         """
@@ -896,7 +896,7 @@ class SchemaView(object):
         return _closure(lambda x: self.slot_children(x, imports=imports, mixins=mixins, is_a=is_a), slot_name,
                         reflexive=reflexive)
 
-    @lru_cache()
+    @lru_cache(None)
     def class_roots(self, imports=True, mixins=True, is_a=True) -> List[ClassDefinitionName]:
         """
         All classes that have no parents
@@ -909,7 +909,7 @@ class SchemaView(object):
                 for c in self.all_classes(imports=imports)
                 if self.class_parents(c, mixins=mixins, is_a=is_a, imports=imports) == []]
 
-    @lru_cache()
+    @lru_cache(None)
     def class_leaves(self, imports=True, mixins=True, is_a=True) -> List[ClassDefinitionName]:
         """
         All classes that have no children
@@ -922,7 +922,7 @@ class SchemaView(object):
                 for c in self.all_classes(imports=imports)
                 if self.class_children(c, mixins=mixins, is_a=is_a, imports=imports) == []]
 
-    @lru_cache()
+    @lru_cache(None)
     def slot_roots(self, imports=True, mixins=True) -> List[SlotDefinitionName]:
         """
         All slotes that have no parents
@@ -934,7 +934,7 @@ class SchemaView(object):
                 for c in self.all_slots(imports=imports)
                 if self.slot_parents(c, mixins=mixins, imports=imports) == []]
 
-    @lru_cache()
+    @lru_cache(None)
     def slot_leaves(self, imports=True, mixins=True) -> List[SlotDefinitionName]:
         """
         All slotes that have no children
@@ -946,7 +946,7 @@ class SchemaView(object):
                 for c in self.all_slots(imports=imports)
                 if self.slot_children(c, mixins=mixins, imports=imports) == []]
 
-    @lru_cache()
+    @lru_cache(None)
     def is_multivalued(self, slot_name: SlotDefinition) -> bool:
         """
         returns True if slot is multivalued, else returns False
@@ -956,7 +956,7 @@ class SchemaView(object):
         induced_slot = self.induced_slot(slot_name)
         return True if induced_slot.multivalued else False
 
-    @lru_cache()
+    @lru_cache(None)
     def slot_is_true_for_metadata_property(self, slot_name: SlotDefinition, metadata_property: str) -> bool:
         """
         Returns true if the value of the provided "metadata_property" is True.  For example,
@@ -1082,7 +1082,7 @@ class SchemaView(object):
 
         return applicable_elements
 
-    @lru_cache()
+    @lru_cache(None)
     def all_aliases(self) -> List[str]:
         """
         Get the aliases
@@ -1103,7 +1103,7 @@ class SchemaView(object):
 
         return element_aliases
 
-    @lru_cache()
+    @lru_cache(None)
     def get_mappings(self, element_name: ElementName = None, imports=True, expand=False) -> Dict[
         MAPPING_TYPE, List[URIorCURIE]]:
         """
@@ -1134,7 +1134,7 @@ class SchemaView(object):
 
         return m_dict
 
-    @lru_cache()
+    @lru_cache(None)
     def is_mixin(self, element_name: Union[ElementName, Element]):
         """
         Determines whether the given name is the name of a mixin
@@ -1148,7 +1148,7 @@ class SchemaView(object):
         is_mixin = element.mixin if isinstance(element, Definition) else False
         return is_mixin
 
-    @lru_cache()
+    @lru_cache(None)
     def inverse(self, slot_name: SlotDefinition):
         """
         Determines whether the given name is a relationship, and if that relationship has an inverse, returns
@@ -1192,7 +1192,7 @@ class SchemaView(object):
                     ix[v].append((mapping_type, self.get_element(en, imports=imports)))
         return ix
 
-    @lru_cache()
+    @lru_cache(None)
     def is_relationship(self, class_name: CLASS_NAME = None, imports=True) -> bool:
         """
         Tests if a class represents a relationship or reified statement
@@ -1211,7 +1211,7 @@ class SchemaView(object):
                     return True
         return False
 
-    @lru_cache()
+    @lru_cache(None)
     def annotation_dict(self, element_name: ElementName, imports=True) -> Dict[URIorCURIE, Any]:
         """
         Return a dictionary where keys are annotation tags and values are annotation values for any given element.
@@ -1227,7 +1227,7 @@ class SchemaView(object):
         e = self.get_element(element_name, imports=imports)
         return {k: v.value for k, v in e.annotations.items()}
 
-    @lru_cache()
+    @lru_cache(None)
     def class_slots(self, class_name: CLASS_NAME, imports=True, direct=False, attributes=True) -> List[
         SlotDefinitionName]:
         """
@@ -1253,7 +1253,7 @@ class SchemaView(object):
                 slots_nr.append(s)
         return slots_nr
 
-    @lru_cache()
+    @lru_cache(None)
     def induced_slot(self, slot_name: SLOT_NAME, class_name: CLASS_NAME = None, imports=True,
                      mangle_name=False) -> SlotDefinition:
         """
@@ -1351,12 +1351,12 @@ class SchemaView(object):
                     induced_slot.domain_of.append(c.name)
         return induced_slot
 
-    @lru_cache()
+    @lru_cache(None)
     def _metaslots_for_slot(self):
         fake_slot = SlotDefinition('__FAKE')
         return vars(fake_slot).keys()
 
-    @lru_cache()
+    @lru_cache(None)
     def class_induced_slots(self, class_name: CLASS_NAME = None, imports=True) -> List[SlotDefinition]:
         """
         All slots that are asserted or inferred for a class, with their inferred semantics
@@ -1367,7 +1367,7 @@ class SchemaView(object):
         """
         return [self.induced_slot(sn, class_name, imports=imports) for sn in self.class_slots(class_name)]
 
-    @lru_cache()
+    @lru_cache(None)
     def induced_class(self, class_name: CLASS_NAME = None) -> ClassDefinition:
         """
         Generate an induced class
@@ -1387,7 +1387,7 @@ class SchemaView(object):
         c.slots = []
         return c
 
-    @lru_cache()
+    @lru_cache(None)
     def induced_type(self, type_name: TYPE_NAME = None) -> TypeDefinition:
         """
 
@@ -1405,7 +1405,7 @@ class SchemaView(object):
                 t.repr = parent.repr
         return t
 
-    @lru_cache()
+    @lru_cache(None)
     def induced_enum(self, enum_name: ENUM_NAME = None) -> EnumDefinition:
         """
 
@@ -1415,7 +1415,7 @@ class SchemaView(object):
         e = deepcopy(self.get_enum(enum_name))
         return e
 
-    @lru_cache()
+    @lru_cache(None)
     def get_identifier_slot(self, cn: CLASS_NAME, use_key=False, imports=True) -> Optional[SlotDefinition]:
         """
         Find the slot that is the identifier for the given class
@@ -1433,7 +1433,7 @@ class SchemaView(object):
         else:
             return None
 
-    @lru_cache()
+    @lru_cache(None)
     def get_key_slot(self, cn: CLASS_NAME, imports=True) -> Optional[SlotDefinition]:
         """
         Find the slot that is the key for the given class
@@ -1448,7 +1448,7 @@ class SchemaView(object):
                 return s
         return None
 
-    @lru_cache()
+    @lru_cache(None)
     def get_type_designator_slot(self, cn: CLASS_NAME, imports=True) -> Optional[SlotDefinition]:
         """
         :param cn: class name
@@ -1558,7 +1558,7 @@ class SchemaView(object):
 
         return list(classes_set)
 
-    @lru_cache()
+    @lru_cache(None)
     def get_slots_by_enum(self, enum_name: ENUM_NAME = None) -> List[SlotDefinition]:
         """Get all slots that use a given enum: schema defined, attribute, or slot_usage.
 
@@ -1609,7 +1609,7 @@ class SchemaView(object):
                 anns = self.get_type(t).annotations
                 return "percent_encoded" in anns
 
-    @lru_cache()
+    @lru_cache(None)
     def usage_index(self) -> Dict[ElementName, List[SchemaUsage]]:
         """
         Fetch an index that shows the ways in which each element is used


### PR DESCRIPTION
Fixes https://github.com/linkml/linkml/issues/1973.

I'm starting with a really naive fix of just removing the entry limit for the `lru_cache`, but I'm open to pivoting to other solutions. 

With this change, running `gen-doc` on the following yaml file goes down from 3+ minutes to 7s.

[test.yaml.txt](https://github.com/linkml/linkml-runtime/files/14619348/test.yaml.txt)
