### PR TITLE
Fix `linkml_files`

### DIFF
--- a/linkml_runtime/linkml_model/linkml_files.py
+++ b/linkml_runtime/linkml_model/linkml_files.py
@@ -67,7 +67,7 @@ class _Path(Enum):
     RDF = "rdf"
     SHEXC = "shex"
     SHEXJ = "shex"
-    YAML = "model/schema"
+    YAML = os.path.join("model", "schema")
 
 
 class ReleaseTag(_AutoName):
@@ -80,7 +80,7 @@ class ReleaseTag(_AutoName):
 
 def _build_path(source: Source, fmt: Format) -> str:
     """ Create the relative path for source and fmt """
-    return f"{_Path[fmt.name].value}/{source.value}.{fmt.value}"
+    return os.path.join(_Path[fmt.name].value, f"{source.value}.{fmt.value}")
 
 
 def _build_loc(base: str, source: Source, fmt: Format) -> str:

--- a/tests/test_linkml_model/test_linkml_files.py
+++ b/tests/test_linkml_model/test_linkml_files.py
@@ -1,0 +1,125 @@
+import pdb
+
+import pytest
+import requests
+from pathlib import Path
+from itertools import product
+from urllib.parse import urlparse
+
+from linkml_runtime.linkml_model.linkml_files import (
+    Source,
+    Format,
+    _Path,
+    URL_FOR,
+    LOCAL_PATH_FOR,
+    LOCAL_BASE,
+    GITHUB_IO_PATH_FOR,
+    GITHUB_PATH_FOR,
+    META_ONLY,
+    ReleaseTag
+)
+
+EXPECTED_FORMATS = [
+    (source, fmt) for source, fmt in product(Source, Format)
+     if (fmt not in META_ONLY and source != Source.META)
+]
+
+@pytest.mark.parametrize(
+    'source,fmt',
+    EXPECTED_FORMATS
+)
+def test_local_paths(source, fmt):
+    a_path = Path(LOCAL_PATH_FOR(source, fmt))
+    assert a_path.exists()
+    assert a_path.is_absolute()
+
+@pytest.mark.parametrize(
+    'fmt',
+    Format.__iter__()
+)
+def test_format_paths(fmt):
+    """Every format should have an entry in _Path"""
+    assert fmt.name in _Path.items()
+
+def test_no_unmapped_dirs():
+    """
+    There should be no additional directories that don't have a mapping for Format.
+    """
+    EXCLUDES = ('__pycache__',)
+
+    expected = {LOCAL_BASE / _Path.get(fmt.name).path for fmt in Format}
+    expected.add(LOCAL_BASE / 'model')
+
+    actual = {a_dir for a_dir in LOCAL_BASE.iterdir() if a_dir.is_dir() and a_dir.name not in EXCLUDES}
+    # Special case the root directory
+    actual.add(LOCAL_BASE)
+    # Special case YAML which is in a subdirectory - we've checked for existence above
+    actual.add(LOCAL_BASE / _Path.get('YAML').path)
+    assert expected == actual
+
+
+# --------------------------------------------------
+# URLs
+# --------------------------------------------------
+
+@pytest.mark.skip('We need to cache this...')
+@pytest.mark.parametrize(
+    'release_type',
+    ReleaseTag.__iter__()
+)
+@pytest.mark.parametrize(
+    'source,fmt',
+    EXPECTED_FORMATS
+)
+def test_github_path_exists(source,fmt, release_type):
+    url = GITHUB_PATH_FOR(source, fmt, release_type)
+    res = requests.get(url)
+    assert res.status_code != 404
+
+
+@pytest.mark.parametrize(
+    'release_type',
+    ReleaseTag.__iter__()
+)
+@pytest.mark.parametrize(
+    'source,fmt',
+    EXPECTED_FORMATS
+)
+def test_github_path_format(source,fmt, release_type):
+    if release_type == ReleaseTag.CURRENT:
+        pytest.skip("Need to cache network requests for this")
+
+    url = GITHUB_PATH_FOR(source, fmt, release_type)
+    # ensure it parses
+    assert urlparse(url)
+    # for windows...
+    assert '\\' not in url
+
+
+@pytest.mark.skip("Need to cache this")
+@pytest.mark.parametrize(
+    'source,fmt',
+    EXPECTED_FORMATS
+)
+def test_github_io_path(source,fmt):
+    url = GITHUB_IO_PATH_FOR(source, fmt)
+    res = requests.get(url)
+    assert res.status_code != 404
+
+
+@pytest.mark.skip('Need to cache this')
+@pytest.mark.parametrize(
+    'source,fmt',
+    EXPECTED_FORMATS
+)
+def test_url_for_format(source,fmt):
+    url = URL_FOR(source, fmt)
+    res = requests.get(url)
+    assert res.status_code != 404
+
+
+
+
+
+
+

--- a/tests/test_linkml_model/test_linkml_files.py
+++ b/tests/test_linkml_model/test_linkml_files.py
@@ -1,5 +1,3 @@
-import pdb
-
 import pytest
 import requests
 from pathlib import Path
@@ -27,7 +25,7 @@ from linkml_runtime.linkml_model.linkml_files import (
 
 EXPECTED_FORMATS = [
     (source, fmt) for source, fmt in product(Source, Format)
-     if (fmt not in META_ONLY and source != Source.META)
+    if (fmt not in META_ONLY or source == Source.META)
 ]
 
 @pytest.mark.parametrize(

--- a/tests/test_linkml_model/test_linkml_files.py
+++ b/tests/test_linkml_model/test_linkml_files.py
@@ -6,6 +6,12 @@ from pathlib import Path
 from itertools import product
 from urllib.parse import urlparse
 
+try:
+    import requests_cache
+    HAVE_REQUESTS_CACHE = True
+except ImportError:
+    HAVE_REQUESTS_CACHE = False
+
 from linkml_runtime.linkml_model.linkml_files import (
     Source,
     Format,
@@ -62,7 +68,7 @@ def test_no_unmapped_dirs():
 # URLs
 # --------------------------------------------------
 
-@pytest.mark.skip('We need to cache this...')
+@pytest.mark.skipif(not HAVE_REQUESTS_CACHE, reason='We need to cache this...')
 @pytest.mark.parametrize(
     'release_type',
     ReleaseTag.__iter__()
@@ -96,7 +102,7 @@ def test_github_path_format(source,fmt, release_type):
     assert '\\' not in url
 
 
-@pytest.mark.skip("Need to cache this")
+@pytest.mark.skipif(not HAVE_REQUESTS_CACHE,reason= "Need to cache this")
 @pytest.mark.parametrize(
     'source,fmt',
     EXPECTED_FORMATS
@@ -107,7 +113,7 @@ def test_github_io_path(source,fmt):
     assert res.status_code != 404
 
 
-@pytest.mark.skip('Need to cache this')
+@pytest.mark.skipif(not HAVE_REQUESTS_CACHE,reason= 'Need to cache this')
 @pytest.mark.parametrize(
     'source,fmt',
     EXPECTED_FORMATS


### PR DESCRIPTION
on windows, the paths for local model files look [like this](https://github.com/linkml/linkml/actions/runs/8305222724/job/22731836059?pr=1976#step:11:330):

```
'D:\\a\\linkml\\linkml\\.venv\\lib\\site-packages\\linkml_runtime\\linkml_model\\model/schema/types.yaml'
```

which seems to work, but it probably shouldn't. 

change hardcoded `/` separators to use `os.path.join` to make paths correct on windows

Related to: https://github.com/linkml/linkml/pull/1976