### PR TITLE
Run tests once

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -46,12 +46,6 @@ jobs:
         run: poetry install --no-interaction
 
       #----------------------------------------------
-      #              run test suite   
-      #----------------------------------------------
-      - name: Run tests
-        run: poetry run python -m unittest discover
-
-      #----------------------------------------------
       #              coverage report   
       #----------------------------------------------
       - name: Generate coverage results


### PR DESCRIPTION
Currently the tests run twice per condition - both `poetry run python -m unittest discover` and `poetry run coverage run -m unittest discover` run the tests.

this PR makes it so the tests only run once