### PR TITLE
Make tests fail, not print

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -24,7 +24,7 @@ test_settings = config['test.settings']
 # Action on mismatch.  One of 'Ignore', 'Report' or 'Fail'
 #  If 'Fail', the expected file will be saved in the appropriate temp directory
 #  NOTE: Before setting this back to Report or Ignore, you need to run cleartemp.sh in this directory
-DEFAULT_MISMATCH_ACTION = eval(test_settings.get('DEFAULT_MISMATCH_ACTION', 'MismatchAction.Report'))
+DEFAULT_MISMATCH_ACTION = eval(test_settings.get('DEFAULT_MISMATCH_ACTION', 'MismatchAction.Fail'))
 
 # Use local import map.  If True, tests/input/local_import_map.json is used to create the test files.  Note that this
 #  will result in local path names being recorded in jsonld files.  This should always be set to False before generating

--- a/tests/support/clicktestcase.py
+++ b/tests/support/clicktestcase.py
@@ -80,10 +80,13 @@ class ClickTestCase(TestEnvironmentTestCase):
                 nt = nt[window:]
                 ot = ot[window:]
             offset = max(offset-view, 0)
-            print("   - - EXPECTED - -")
-            print(ow[offset:offset+view+view])
-            print("\n   - - ACTUAL - -")
-            print(nw[offset:offset+view+view])
+            msg = '\n'.join([
+                "   - - EXPECTED - -",
+                str(ow[offset:offset+view+view]),
+                "   - - ACTUAL - -",
+                str(nw[offset:offset+view+view])
+            ])
+            raise ValueError(msg)
 
     def do_test(self,
                 args: Union[str, List[str]],

--- a/tests/support/test_environment.py
+++ b/tests/support/test_environment.py
@@ -65,7 +65,7 @@ class TestEnvironment:
     @staticmethod
     def _check_changed(test_file: str, runtime_file: str) -> None:
         if not filecmp.cmp(test_file, runtime_file):
-            print(
+            raise Exception(
                 f"WARNING: Test file {test_file} does not match {runtime_file}.  "
                 f"You may want to update the test version and rerun")
         from tests import USE_LOCAL_IMPORT_MAP
@@ -112,7 +112,7 @@ class TestEnvironment:
 
     @property
     def report_errors(self) -> bool:
-        return self.mismatch_action != MismatchAction.Ignore
+        return self.mismatch_action == MismatchAction.Report
 
     def __str__(self):
         """ Return the current state of the log file """
@@ -175,10 +175,12 @@ class TestEnvironment:
 
         diffs = are_dir_trees_equal(expected_output_directory, temp_output_directory)
         if diffs:
-            self.log(expected_output_directory, diffs)
             if not self.fail_on_error:
+                self.log(expected_output_directory, diffs)
                 shutil.rmtree(expected_output_directory)
                 os.rename(temp_output_directory, expected_output_directory)
+            else:
+                raise Exception(f'Diffs found in {expected_output_directory}:\n{diffs}')
         else:
             shutil.rmtree(temp_output_directory)
 
@@ -237,12 +239,13 @@ class TestEnvironment:
             cmsg = comparator(actual_text, actual_text)
             if cmsg:
                 msg = msg + '\n' + cmsg
-        if msg:
-            self.log(expected_file_path, msg)
+
         if msg and not self.fail_on_error:
             self.make_temp_dir(os.path.dirname(expected_file_path), clear=False)
             with open(expected_file_path, 'w', encoding='UTF-8') as outf:
                 outf.write(actual_text)
+        elif msg is not None:
+            raise Exception(msg)
         return not msg
 
 

--- a/tests/test_issues/test_issue_368_enums.py
+++ b/tests/test_issues/test_issue_368_enums.py
@@ -27,9 +27,6 @@ class Issue368TestCase(LoaderDumperTestCase):
         def dump_and_load(dumper: Callable, sfx: str) -> None:
             fname = env.actual_path(f'issue_368_1.{sfx}')
             dumper(example, fname)
-            with open(fname) as f:
-                print(f'\n----- {sfx} -----')
-                print(f.read())
 
         dump_and_load(json_dumper.dump, 'json')
         dump_and_load(yaml_dumper.dump, 'yaml')

--- a/tests/test_issues/test_linkml_issue_478.py
+++ b/tests/test_issues/test_linkml_issue_478.py
@@ -14,12 +14,8 @@ class Issue478TestCase(TestCase):
 
     def test_issue_478(self):
         view = SchemaView(env.input_path('linkml_issue_478.yaml'))
-        for c in view.all_classes():
-            print(f'c={c}')
         cnames = list(view.class_name_mappings().keys())
         snames = list(view.slot_name_mappings().keys())
-        print(cnames)
-        print(snames)
         cnames.remove("5'Sequencing")  ## TODO
         self.assertCountEqual(['FooBar', 'NamedThing', 'BiosampleProcessing', 'TooMuchWhitespace'], cnames)
         snames.remove("5'_sequence")  ## TODO

--- a/tests/test_issues/test_linkml_issue_576.py
+++ b/tests/test_issues/test_linkml_issue_576.py
@@ -23,8 +23,6 @@ class Issue576TestCase(TestCase):
         s = rdflib_dumper.dumps(inst, view, 'turtle', prefix_map={"@base": "http://example.org/default/"})
         self.assertIn("@base <http://example.org/default/> .", s)
         g = rdflib.Graph().parse(data=s, format='turtle')
-        for t in g.triples((None, None, None)):
-            print(t)
         cases = [
             (None,
              rdflib.term.URIRef('https://w3id.org/linkml/personinfo/source'),

--- a/tests/test_loaders_dumpers/test_enum.py
+++ b/tests/test_loaders_dumpers/test_enum.py
@@ -18,12 +18,6 @@ class EnumTestCase(unittest.TestCase):
         * https://github.com/linkml/linkml/issues/119
         """
         i = Organism(state='LIVING')
-        print(i)
-        print(i.state)
-        print(i.state.code)
-        print(i.state.code.text)
-        print(type(i.state))
-        print(StateEnum.LIVING)
         assert str(i.state) == 'LIVING'
         assert i.state.code == StateEnum.LIVING
         obj = json.loads(json_dumper.dumps(i))
@@ -31,7 +25,6 @@ class EnumTestCase(unittest.TestCase):
         obj = yaml.safe_load(yaml_dumper.dumps(i))
         assert obj['state'] == 'LIVING'
         reconstituted = json_loader.loads(json_dumper.dumps(i), target_class=Organism)
-        print(f'RECONSTITUTED = {reconstituted}')
         assert reconstituted.state.code == StateEnum.LIVING
 
 

--- a/tests/test_loaders_dumpers/test_rdflib_dumper.py
+++ b/tests/test_loaders_dumpers/test_rdflib_dumper.py
@@ -150,17 +150,13 @@ class RdfLibDumperTestCase(unittest.TestCase):
         assert not org1type1.meaning
         assert org1type2.meaning
         org1 = Organization('ROR:1', categories=[org1type1, org1type2])
-        print(org1.categories)
         g = rdflib_dumper.as_rdf_graph(org1, schemaview=view, prefix_map=self.prefix_map)
-        print(g)
         cats = list(g.objects(ROR['1'], INFO['categories']))
-        print(cats)
         self.assertCountEqual([Literal('non profit'), URIRef('https://example.org/bizcodes/001')], cats)
         orgs = rdflib_loader.from_rdf_graph(g, target_class=Organization, schemaview=view)
         assert len(orgs) == 1
         [org1x] = orgs
         catsx = org1x.categories
-        print(catsx)
         self.assertCountEqual([org1type1, org1type2], catsx)
 
     def test_undeclared_prefix(self):
@@ -245,7 +241,6 @@ class RdfLibDumperTestCase(unittest.TestCase):
                                              ignore_unmapped_predicates=True)
         self.assertEqual(address.city, 'foo city')
         ttl = rdflib_dumper.dumps(address, schemaview=view)
-        print(ttl)
         g = Graph()
         g.parse(data=ttl, format='ttl')
         INFO = Namespace('https://w3id.org/linkml/examples/personinfo/')

--- a/tests/test_processing/test_referencevalidator.py
+++ b/tests/test_processing/test_referencevalidator.py
@@ -148,7 +148,6 @@ class ReferenceValidatorTestCase(unittest.TestCase):
 
         Sets up a document object that each test will contribute to.
         """
-        print("Setting up class...")
         doc = MarkdownDocument()
         doc.h1("Validation Suite")
         doc.text("This document describes the validation suite for the LinkML model.")
@@ -1154,8 +1153,6 @@ class ReferenceValidatorTestCase(unittest.TestCase):
         """
         obj = yaml.load(s, DupCheckYamlLoader)
         report = validator.validate(obj)
-        for r in report.results_excluding_normalized():
-            print(yaml_dumper.dumps(r))
         self.assertEqual(1, len(report.results_excluding_normalized()))
         r = report.results_excluding_normalized()[0]
         self.assertEqual(3, r.source_line_number)
@@ -1188,8 +1185,6 @@ class ReferenceValidatorTestCase(unittest.TestCase):
         report = Report()
         schema_norm = validator.normalize(schema_dict, target=sdc.name, report=report)
         self.assertEqual(dict, type(schema_norm["prefixes"]))
-        for r in report.results_excluding_normalized():
-            print(yaml_dumper.dumps(r))
         self.assertEqual(len(report.errors()), 0)
         # for r in report.repaired():
         #    print(r)

--- a/tests/test_utils/test_dict_utils.py
+++ b/tests/test_utils/test_dict_utils.py
@@ -40,34 +40,26 @@ class DictUtilTestCase(TestEnvironmentTestCase):
         assert d['name'] == 'test class'
         assert d['id_prefixes'] == []
         assert d['description'] is None
-        for x in _signature(d):
-            if not _is_python_type(x):
-                print(f'   ****={x} {type(x)}')
         assert all(_is_basic_type(x) for x in _signature(d))
 
         d2 = yutils.as_dict(obj2)
-        print(d2)
         assert d2['slot_usage']['foo']['range'] == 'bar'
         assert all(_is_basic_type(x) for x in _signature(d2))
 
         # as_simple_dict removes nones and empty lists
         d = as_simple_dict(obj)
-        print(d)
         assert isinstance(d, dict)
         assert all(_is_python_type(x) for x in _signature(d))
         assert d == {'name': 'test class'}
 
         d2 = as_simple_dict(obj2)
-        print(d2)
         assert isinstance(d2, dict)
         assert d2 == {'name': 'test class', 'slot_usage': {'foo': {'name': 'foo', 'range': 'bar'}}}
 
         s = yutils.as_yaml(obj)
-        print(s)
         assert(s.strip() == 'name: test class')
 
         s2 = yutils.as_yaml(obj2)
-        print(s2)
         assert(s2.strip().startswith('name: test class'))
 
 

--- a/tests/test_utils/test_ruleutils.py
+++ b/tests/test_utils/test_ruleutils.py
@@ -26,9 +26,6 @@ class RuleUtilsTestCase(unittest.TestCase):
         disj = get_range_as_disjunction(analyte)
         #print(disj)
         self.assertCountEqual(disj, {'MissingValueEnum', 'AnalyteEnum'})
-        for s in view.all_slots().values():
-            disj = get_range_as_disjunction(s)
-            print(f'{s.name} DISJ: {disj}')
 
     def test_roll_up(self):
         # no import schema
@@ -36,9 +33,6 @@ class RuleUtilsTestCase(unittest.TestCase):
         c = view.get_class('ProteinCodingGene')
         rules = subclass_to_rules(view, 'ProteinCodingGene', 'SeqFeature')
         rule = rules[0]
-        print(f'IF: {rule.preconditions}')
-        print(f'THEN: {rule.postconditions}')
-        print(yaml_dumper.dumps(rule))
 
 
 


### PR DESCRIPTION
The output of the tests is pretty difficult to read, but there were lots of places that were saying "ERROR" without failing. 

Looking further, it appears as if the default behavior for the TestEnvironment is to print, not fail on error. 

There are also many print statements throughout the tests - raising an exception should be the print statement in tests.

This PR
- Changes the default test behavior to fail on errors
- Raises exceptions rather than logging when tests should fail
- Removes all print statements from tests.