### PR TITLE
Add inheritance ordering, unify element ordering

### DIFF
--- a/linkml_runtime/exceptions.py
+++ b/linkml_runtime/exceptions.py
@@ -1,0 +1,2 @@
+class OrderingError(RuntimeError):
+    """Exception raised when there is a problem with SchemaView ordering"""


### PR DESCRIPTION
Schemaview seems like the right place to keep sorting methods that will be used by all the generators. Lo and behold, it already is!

Added the inheritance ordering method used by pythongen and pydanticgen, put all ordering into a single method.

Must be merged before the adjoining linkml PR (will add link in a second) and linkml lockfile must be regenerated to reflect the release containing this PR