### PR TITLE
pretty print models

### DIFF
--- a/linkml_runtime/linkml_model/meta.py
+++ b/linkml_runtime/linkml_model/meta.py
@@ -148,7 +148,7 @@ class TypeMappingFramework(extended_str):
 
 Anything = Any
 
-@dataclass
+@dataclass(repr=False)
 class CommonMetadata(YAMLRoot):
     """
     Generic metadata shared across definitions
@@ -311,7 +311,7 @@ class CommonMetadata(YAMLRoot):
         super().__post_init__(**kwargs)
 
 
-@dataclass
+@dataclass(repr=False)
 class Element(YAMLRoot):
     """
     A named element in the model
@@ -516,7 +516,7 @@ class Element(YAMLRoot):
         super().__post_init__(**kwargs)
 
 
-@dataclass
+@dataclass(repr=False)
 class SchemaDefinition(Element):
     """
     A collection of definitions that make up a schema or a data model.
@@ -628,7 +628,7 @@ class SchemaDefinition(Element):
         super().__post_init__(**kwargs)
 
 
-@dataclass
+@dataclass(repr=False)
 class AnonymousTypeExpression(YAMLRoot):
     """
     A type expression that is not a top-level named type definition. Used for nesting.
@@ -696,7 +696,7 @@ class AnonymousTypeExpression(YAMLRoot):
         super().__post_init__(**kwargs)
 
 
-@dataclass
+@dataclass(repr=False)
 class TypeDefinition(Element):
     """
     an element that whose instances are atomic scalar values that can be mapped to primitive types
@@ -791,7 +791,7 @@ class TypeDefinition(Element):
         super().__post_init__(**kwargs)
 
 
-@dataclass
+@dataclass(repr=False)
 class SubsetDefinition(Element):
     """
     an element that can be used to group other metamodel elements
@@ -814,7 +814,7 @@ class SubsetDefinition(Element):
         super().__post_init__(**kwargs)
 
 
-@dataclass
+@dataclass(repr=False)
 class Definition(Element):
     """
     abstract base class for core metaclasses
@@ -863,7 +863,7 @@ class Definition(Element):
         super().__post_init__(**kwargs)
 
 
-@dataclass
+@dataclass(repr=False)
 class AnonymousEnumExpression(YAMLRoot):
     """
     An enum_expression that is not named
@@ -927,7 +927,7 @@ class AnonymousEnumExpression(YAMLRoot):
         super().__post_init__(**kwargs)
 
 
-@dataclass
+@dataclass(repr=False)
 class EnumDefinition(Definition):
     """
     an element whose instances must be drawn from a specified set of permissible values
@@ -1001,7 +1001,7 @@ class EnumDefinition(Definition):
         super().__post_init__(**kwargs)
 
 
-@dataclass
+@dataclass(repr=False)
 class EnumBinding(YAMLRoot):
     """
     A binding of a slot or a class to a permissible value from an enumeration.
@@ -1186,7 +1186,7 @@ class EnumBinding(YAMLRoot):
         super().__post_init__(**kwargs)
 
 
-@dataclass
+@dataclass(repr=False)
 class MatchQuery(YAMLRoot):
     """
     A query that is used on an enum expression to dynamically obtain a set of permissivle values via a query that
@@ -1212,7 +1212,7 @@ class MatchQuery(YAMLRoot):
         super().__post_init__(**kwargs)
 
 
-@dataclass
+@dataclass(repr=False)
 class ReachabilityQuery(YAMLRoot):
     """
     A query that is used on an enum expression to dynamically obtain a set of permissible values via walking from a
@@ -1256,7 +1256,7 @@ class ReachabilityQuery(YAMLRoot):
         super().__post_init__(**kwargs)
 
 
-@dataclass
+@dataclass(repr=False)
 class StructuredAlias(YAMLRoot):
     """
     object that contains meta data about a synonym or alias including where it came from (source) and its scope
@@ -1453,7 +1453,7 @@ class Expression(YAMLRoot):
     class_model_uri: ClassVar[URIRef] = LINKML.Expression
 
 
-@dataclass
+@dataclass(repr=False)
 class TypeExpression(Expression):
     """
     An abstract class grouping named types and anonymous type expressions
@@ -1521,7 +1521,7 @@ class TypeExpression(Expression):
         super().__post_init__(**kwargs)
 
 
-@dataclass
+@dataclass(repr=False)
 class EnumExpression(Expression):
     """
     An expression that constrains the range of a slot
@@ -1585,7 +1585,7 @@ class EnumExpression(Expression):
         super().__post_init__(**kwargs)
 
 
-@dataclass
+@dataclass(repr=False)
 class AnonymousExpression(YAMLRoot):
     """
     An abstract parent class for any nested expression
@@ -1754,7 +1754,7 @@ class AnonymousExpression(YAMLRoot):
         super().__post_init__(**kwargs)
 
 
-@dataclass
+@dataclass(repr=False)
 class PathExpression(YAMLRoot):
     """
     An expression that describes an abstract path from an object to another through a sequence of slot lookups
@@ -1959,7 +1959,7 @@ class PathExpression(YAMLRoot):
         super().__post_init__(**kwargs)
 
 
-@dataclass
+@dataclass(repr=False)
 class SlotExpression(Expression):
     """
     an expression that constrains the range of values a slot can take
@@ -2092,7 +2092,7 @@ class SlotExpression(Expression):
         super().__post_init__(**kwargs)
 
 
-@dataclass
+@dataclass(repr=False)
 class AnonymousSlotExpression(AnonymousExpression):
     _inherited_slots: ClassVar[List[str]] = ["range", "required", "recommended", "multivalued", "inlined", "inlined_as_list", "minimum_value", "maximum_value", "pattern", "structured_pattern", "value_presence", "equals_string", "equals_string_in", "equals_number", "equals_expression", "exact_cardinality", "minimum_cardinality", "maximum_cardinality"]
 
@@ -2222,7 +2222,7 @@ class AnonymousSlotExpression(AnonymousExpression):
         super().__post_init__(**kwargs)
 
 
-@dataclass
+@dataclass(repr=False)
 class SlotDefinition(Definition):
     """
     an element that describes how instances are related to other instances
@@ -2531,7 +2531,7 @@ class SlotDefinition(Definition):
         super().__post_init__(**kwargs)
 
 
-@dataclass
+@dataclass(repr=False)
 class ClassExpression(YAMLRoot):
     """
     A boolean expression that can be used to dynamically determine membership of a class
@@ -2571,7 +2571,7 @@ class ClassExpression(YAMLRoot):
         super().__post_init__(**kwargs)
 
 
-@dataclass
+@dataclass(repr=False)
 class AnonymousClassExpression(AnonymousExpression):
     _inherited_slots: ClassVar[List[str]] = []
 
@@ -2612,7 +2612,7 @@ class AnonymousClassExpression(AnonymousExpression):
         super().__post_init__(**kwargs)
 
 
-@dataclass
+@dataclass(repr=False)
 class ClassDefinition(Definition):
     """
     an element whose instances are complex objects that may have slot-value assignments
@@ -2747,7 +2747,7 @@ class ClassLevelRule(YAMLRoot):
     class_model_uri: ClassVar[URIRef] = LINKML.ClassLevelRule
 
 
-@dataclass
+@dataclass(repr=False)
 class ClassRule(ClassLevelRule):
     """
     A rule that applies to instances of a class
@@ -2940,7 +2940,7 @@ class ClassRule(ClassLevelRule):
         super().__post_init__(**kwargs)
 
 
-@dataclass
+@dataclass(repr=False)
 class ArrayExpression(YAMLRoot):
     """
     defines the dimensions of an array
@@ -3123,7 +3123,7 @@ class ArrayExpression(YAMLRoot):
         super().__post_init__(**kwargs)
 
 
-@dataclass
+@dataclass(repr=False)
 class DimensionExpression(YAMLRoot):
     """
     defines one of the dimensions of an array
@@ -3308,7 +3308,7 @@ class DimensionExpression(YAMLRoot):
         super().__post_init__(**kwargs)
 
 
-@dataclass
+@dataclass(repr=False)
 class PatternExpression(YAMLRoot):
     """
     a regular expression pattern used to evaluate conformance of a string
@@ -3489,7 +3489,7 @@ class PatternExpression(YAMLRoot):
         super().__post_init__(**kwargs)
 
 
-@dataclass
+@dataclass(repr=False)
 class ImportExpression(YAMLRoot):
     """
     an expression describing an import
@@ -3671,7 +3671,7 @@ class ImportExpression(YAMLRoot):
         super().__post_init__(**kwargs)
 
 
-@dataclass
+@dataclass(repr=False)
 class Setting(YAMLRoot):
     """
     assignment of a key to a value
@@ -3700,7 +3700,7 @@ class Setting(YAMLRoot):
         super().__post_init__(**kwargs)
 
 
-@dataclass
+@dataclass(repr=False)
 class Prefix(YAMLRoot):
     """
     prefix URI tuple
@@ -3729,7 +3729,7 @@ class Prefix(YAMLRoot):
         super().__post_init__(**kwargs)
 
 
-@dataclass
+@dataclass(repr=False)
 class LocalName(YAMLRoot):
     """
     an attributed label
@@ -3758,7 +3758,7 @@ class LocalName(YAMLRoot):
         super().__post_init__(**kwargs)
 
 
-@dataclass
+@dataclass(repr=False)
 class Example(YAMLRoot):
     """
     usage example and description
@@ -3784,7 +3784,7 @@ class Example(YAMLRoot):
         super().__post_init__(**kwargs)
 
 
-@dataclass
+@dataclass(repr=False)
 class AltDescription(YAMLRoot):
     """
     an attributed description
@@ -3813,7 +3813,7 @@ class AltDescription(YAMLRoot):
         super().__post_init__(**kwargs)
 
 
-@dataclass
+@dataclass(repr=False)
 class PermissibleValue(YAMLRoot):
     """
     a permissible value, accompanied by intended text and an optional mapping to a concept URI
@@ -4015,7 +4015,7 @@ class PermissibleValue(YAMLRoot):
         super().__post_init__(**kwargs)
 
 
-@dataclass
+@dataclass(repr=False)
 class UniqueKey(YAMLRoot):
     """
     a collection of slots whose values uniquely identify an instance of a class

--- a/linkml_runtime/utils/enumerations.py
+++ b/linkml_runtime/utils/enumerations.py
@@ -102,4 +102,4 @@ class EnumDefinitionImpl(YAMLRoot, metaclass=EnumDefinitionMeta):
 
     def __repr__(self) -> str:
         rlist = [(f.name, getattr(self._code, f.name)) for f in fields(self._code)]
-        return '(' + ', '.join([f"{f[0]}={repr(f[1])}" for f in rlist if f[1]]) + ')'
+        return self.__class__.__name__ + '(' + ', '.join([f"{f[0]}={repr(f[1])}" for f in rlist if f[1]]) + ')'

--- a/linkml_runtime/utils/yamlutils.py
+++ b/linkml_runtime/utils/yamlutils.py
@@ -11,8 +11,7 @@ from rdflib import Graph, URIRef
 from yaml.constructor import ConstructorError
 
 from linkml_runtime.utils.context_utils import CONTEXTS_PARAM_TYPE, merge_contexts
-from linkml_runtime.utils.formatutils import is_empty
-from linkml_runtime.utils.formatutils import remove_empty_items
+from linkml_runtime.utils.formatutils import is_empty, remove_empty_items
 
 YAMLObjTypes = Union[JsonObjTypes, "YAMLRoot"]
 

--- a/linkml_runtime/utils/yamlutils.py
+++ b/linkml_runtime/utils/yamlutils.py
@@ -1,9 +1,7 @@
-import pdb
 from copy import copy
 from json import JSONDecoder
 from typing import Union, Any, List, Optional, Type, Callable, Dict
 from pprint import pformat
-import textwrap
 
 import yaml
 from deprecated.classic import deprecated

--- a/linkml_runtime/utils/yamlutils.py
+++ b/linkml_runtime/utils/yamlutils.py
@@ -1,6 +1,7 @@
 from copy import copy
 from json import JSONDecoder
 from typing import Union, Any, List, Optional, Type, Callable, Dict
+from pprint import pformat
 
 import yaml
 from deprecated.classic import deprecated
@@ -11,6 +12,7 @@ from yaml.constructor import ConstructorError
 
 from linkml_runtime.utils.context_utils import CONTEXTS_PARAM_TYPE, merge_contexts
 from linkml_runtime.utils.formatutils import is_empty
+from linkml_runtime.utils.formatutils import remove_empty_items
 
 YAMLObjTypes = Union[JsonObjTypes, "YAMLRoot"]
 
@@ -276,6 +278,11 @@ class YAMLRoot(JsonObj):
     def MissingRequiredField(self, field_name: str) -> None:
         """ Generic loader error handler """
         raise ValueError(f"{field_name} must be supplied")
+
+    def __str__(self):
+        res = remove_empty_items(self)
+        return pformat(as_dict(res),indent=2,compact=True)
+
 
 
 def root_representer(dumper: yaml.Dumper, data: YAMLRoot):

--- a/linkml_runtime/utils/yamlutils.py
+++ b/linkml_runtime/utils/yamlutils.py
@@ -1,7 +1,9 @@
+import pdb
 from copy import copy
 from json import JSONDecoder
 from typing import Union, Any, List, Optional, Type, Callable, Dict
 from pprint import pformat
+import textwrap
 
 import yaml
 from deprecated.classic import deprecated
@@ -11,7 +13,7 @@ from rdflib import Graph, URIRef
 from yaml.constructor import ConstructorError
 
 from linkml_runtime.utils.context_utils import CONTEXTS_PARAM_TYPE, merge_contexts
-from linkml_runtime.utils.formatutils import is_empty, remove_empty_items
+from linkml_runtime.utils.formatutils import is_empty, remove_empty_items, is_list, is_dict, items
 
 YAMLObjTypes = Union[JsonObjTypes, "YAMLRoot"]
 
@@ -278,10 +280,20 @@ class YAMLRoot(JsonObj):
         """ Generic loader error handler """
         raise ValueError(f"{field_name} must be supplied")
 
-    def __str__(self):
-        res = remove_empty_items(self)
-        return pformat(as_dict(res),indent=2,compact=True)
+    def __repr__(self):
+        """Only reformat 1-layer deep to preserve __repr__ of child objects"""
+        res = {}
+        for key, val in items(self):
+            if val == [] or val == {} or val is None:
+                continue
+            res[key] = val
+        return self.__class__.__name__ + '(' + pformat(res, indent=2,
+                                                       compact=True) + ')'
 
+    def __str__(self):
+        """Dump everything into a dict, recursively, stringifying it all"""
+        res = remove_empty_items(self)
+        return self.__class__.__name__ + '(' + pformat(res, indent=2, compact=True) + ')'
 
 
 def root_representer(dumper: yaml.Dumper, data: YAMLRoot):

--- a/linkml_runtime/utils/yamlutils.py
+++ b/linkml_runtime/utils/yamlutils.py
@@ -286,7 +286,7 @@ class YAMLRoot(JsonObj):
                 continue
             res[key] = val
         return self.__class__.__name__ + '(' + pformat(res, indent=2,
-                                                       compact=True) + ')'
+                                                       compact=True, sort_dicts=False) + ')'
 
     def __str__(self):
         """Dump everything into a dict, recursively, stringifying it all"""

--- a/tests/test_utils/test_inlined_as_dict_forms.py
+++ b/tests/test_utils/test_inlined_as_dict_forms.py
@@ -9,25 +9,25 @@ class InlinedAsDictTestcase(unittest.TestCase):
     """ Test the various YAML forms for inlined_as_dict entries"""
     def test_list_variations(self):
         v = E()
-        self.assertEqual("E(ev={})", str(v), "No entries, period")
+        self.assertEqual(v.ev, {}, "No entries, period")
         v = E({})
-        self.assertEqual("E(ev={})", str(v), "Default is empty dictionary")
+        self.assertEqual(v.ev, {}, "Default is empty dictionary")
         v = E([])
-        self.assertEqual('E(ev={})', str(v), "Empty list becomes empty dictionary")
+        self.assertEqual(v.ev, {}, "Empty list becomes empty dictionary")
         v = E(JsonObj())
-        self.assertEqual('E(ev={})', str(v), "Empty JsonObj becomes empty dictionary")
+        self.assertEqual(v.ev, {}, "Empty JsonObj becomes empty dictionary")
         # Form 5 -- list of keys
         v1 = JsonObj(["k1", "k2"])
         v = E(v1)
-        self.assertEqual("E(ev={'k1': EInst(s1='k1', s2=None, s3=None), 'k2': EInst(s1='k2', s2=None, s3=None)})",
-                         str(v))
+        self.assertEqual(v.ev, {'k1': EInst(s1='k1'), 'k2': EInst(s1='k2')})
         # Form 4: -- list of key/object pairs
         v = E([{"k1": {"s1": "k1", "s2": "v21", "s3": "v23"}},
                {"k2": {"s2": "v22", "s3": "v23"}},
                {"k3": {}}])
-        self.assertEqual("E(ev={'k1': EInst(s1='k1', s2='v21', s3='v23'),"
-                         " 'k2': EInst(s1='k2', s2='v22', s3='v23'),"
-                         " 'k3': EInst(s1='k3', s2=None, s3=None)})", str(v),
+        self.assertEqual(v.ev,
+                         {'k1': EInst(s1='k1', s2='v21', s3='v23'),
+                         'k2': EInst(s1='k2', s2='v22', s3='v23'),
+                         'k3': EInst(s1='k3', s2=None, s3=None)},
                          "List of key value constructors")
 
         with self.assertRaises(ValueError) as e:
@@ -41,28 +41,34 @@ class InlinedAsDictTestcase(unittest.TestCase):
         v = E([{"k1": EInst(s1="k1", s2="v21", s3="v23")},
                {"k2": JsonObj({"s2": "v22", "s3": "v23"})},
                {"k3": None}])
-        self.assertEqual("E(ev={'k1': EInst(s1='k1', s2='v21', s3='v23'),"
-                         " 'k2': EInst(s1='k2', s2='v22', s3='v23'),"
-                         " 'k3': EInst(s1='k3', s2=None, s3=None)})", str(v))
+        self.assertEqual(v.ev,
+                         {
+                             'k1': EInst(s1='k1', s2='v21', s3='v23'),
+                             'k2': EInst(s1='k2', s2='v22', s3='v23'),
+                             'k3': EInst(s1='k3', s2=None, s3=None)
+                         })
 
         # More Form 5 variations
         v = E(["k1", "k2", {"k3": "v3"}, ["k4", "v4"], {"s1": "k5", "s2": "v52"}])
-        self.assertEqual("E(ev={'k1': EInst(s1='k1', s2=None, s3=None), "
-                         "'k2': EInst(s1='k2', s2=None, s3=None), "
-                         "'k3': EInst(s1='k3', s2='v3', s3=None), "
-                         "'k4': EInst(s1='k4', s2='v4', s3=None), "
-                         "'k5': EInst(s1='k5', s2='v52', s3=None)})", str(v), "Key value tuples")
+        self.assertEqual(v.ev,
+                         {'k1': EInst(s1='k1', s2=None, s3=None),
+                         'k2': EInst(s1='k2', s2=None, s3=None),
+                         'k3': EInst(s1='k3', s2='v3', s3=None),
+                         'k4': EInst(s1='k4', s2='v4', s3=None),
+                         'k5': EInst(s1='k5', s2='v52', s3=None)}, "Key value tuples")
 
         # Form 6 - list of positional object values
         v = E([["k1", "v12", "v13"], ["k2", "v22"], ["k3"]])
-        self.assertEqual("E(ev={'k1': EInst(s1='k1', s2='v12', s3='v13'), "
-                         "'k2': EInst(s1='k2', s2='v22', s3=None), "
-                         "'k3': EInst(s1='k3', s2=None, s3=None)})", str(v), "Positional objects")
+        self.assertEqual(v.ev,
+                         {'k1': EInst(s1='k1', s2='v12', s3='v13'),
+                         'k2': EInst(s1='k2', s2='v22', s3=None),
+                         'k3': EInst(s1='k3', s2=None, s3=None)}, "Positional objects")
 
         # Form 7 - list of kv dictionaries
         v = E([{"s1": "v11", "s2": "v12"}, {"s1": "v21", "s2": "v22", "s3": "v23"}])
-        self.assertEqual("E(ev={'v11': EInst(s1='v11', s2='v12', s3=None), "
-                         "'v21': EInst(s1='v21', s2='v22', s3='v23')})", str(v), "List of dictionaries")
+        self.assertEqual(v.ev,
+                         {'v11': EInst(s1='v11', s2='v12', s3=None),
+                         'v21': EInst(s1='v21', s2='v22', s3='v23')}, "List of dictionaries")
 
 
     def test_dict_variations(self):
@@ -72,23 +78,30 @@ class InlinedAsDictTestcase(unittest.TestCase):
                "k2": JsonObj({"s2": "v22", "s3": "v23"}),
                "k3": {"s2": "v32", "s3": "v33"},
                "k4": {"s1": "k4"}})
-        self.assertEqual(("E(ev={'k1': EInst(s1='k1', s2='v21', s3='v23'), "
-                          "'k2': EInst(s1='k2', s2='v22', s3='v23'), "
-                          "'k3': EInst(s1='k3', s2='v32', s3='v33'), "
-                          "'k4': EInst(s1='k4', s2=None, s3=None)})"), str(v), "Dictionary of key/object entries")
+        self.assertEqual(v.ev,
+                 {'k1': EInst(s1='k1', s2='v21', s3='v23'),
+                          'k2': EInst(s1='k2', s2='v22', s3='v23'),
+                          'k3': EInst(s1='k3', s2='v32', s3='v33'),
+                          'k4': EInst(s1='k4', s2=None, s3=None)},
+                    "Dictionary of key/object entries")
 
         # Form 2: key/value tuples (only works when at most two values are required
         v = E(ev={"k1": "v11", "k2": "v21", "k3": {}})
-        self.assertEqual("E(ev={'k1': EInst(s1='k1', s2='v11', s3=None),"
-                         " 'k2': EInst(s1='k2', s2='v21', s3=None), "
-                         "'k3': EInst(s1='k3', s2=None, s3=None)})", str(v), "Dictionary of two-key entries")
+        expected = ("E({ 'ev': { 'k1': {'s1': 'k1', 's2': 'v11'},\n"
+                    "          'k2': {'s1': 'k2', 's2': 'v21'},\n"
+                    "          'k3': {'s1': 'k3'}}})")
+        self.assertEqual(v.ev,
+                 {'k1': EInst(s1='k1', s2='v11', s3=None),
+                          'k2': EInst(s1='k2', s2='v21', s3=None),
+                          'k3': EInst(s1='k3', s2=None, s3=None)},
+                    "Dictionary of two-key entries")
 
         # Form 3: Basic single object (differentiated from form2 by the presence of the key name
         v = E({"s1": "k1"})
-        self.assertEqual("E(ev={'k1': EInst(s1='k1', s2=None, s3=None)})",
-                         str(v), "Single entry dictionary")
+        self.assertEqual(v.ev, {'k1': EInst(s1='k1', s2=None, s3=None)},
+                         "Single entry dictionary")
         v = E({"s1": "k1", "s2": "v12"})
-        self.assertEqual("E(ev={'k1': EInst(s1='k1', s2='v12', s3=None)})", str(v), "Single entry dictionary")
+        self.assertEqual(v.ev, {'k1': EInst(s1='k1', s2='v12', s3=None)}, "Single entry dictionary")
 
     def test_isempties(self):
         base = E()
@@ -106,3 +119,4 @@ class InlinedAsDictTestcase(unittest.TestCase):
 
 if __name__ == '__main__':
     unittest.main()
+

--- a/tests/test_utils/test_inlined_as_list_forms.py
+++ b/tests/test_utils/test_inlined_as_list_forms.py
@@ -9,25 +9,25 @@ class InlinedAsListTestcase(unittest.TestCase):
     """ Test the various YAML forms for inlined_as_list entries"""
     def test_list_variations(self):
         v = E()
-        self.assertEqual("E(ev=[])", str(v), "No entries, period")
+        self.assertEqual(v.ev, [], "No entries, period")
         v = E({})
-        self.assertEqual("E(ev=[])", str(v), "Default is empty dictionary")
+        self.assertEqual(v.ev, [], "Default is empty dictionary")
         v = E([])
-        self.assertEqual('E(ev=[])', str(v), "Empty list becomes empty dictionary")
+        self.assertEqual(v.ev, [], "Empty list becomes empty dictionary")
         v = E(JsonObj())
-        self.assertEqual('E(ev=[])', str(v), "Empty JsonObj becomes empty dictionary")
+        self.assertEqual(v.ev, [], "Empty JsonObj becomes empty dictionary")
         # Form 5 -- list of keys
         v1 = JsonObj(["k1", "k2"])
         v = E(v1)
-        self.assertEqual("E(ev=[EInst(s1='k1', s2=None, s3=None), EInst(s1='k2', s2=None, s3=None)])",
-                         str(v))
+        self.assertEqual(v.ev, [EInst(s1='k1', s2=None, s3=None), EInst(s1='k2', s2=None, s3=None)])
         # Form 4: -- list of key/object pairs
         v = E([{"k1": {"s1": "k1", "s2": "v21", "s3": "v23"}},
                {"k2": {"s2": "v22", "s3": "v23"}},
                {"k3": {}}])
-        self.assertEqual("E(ev=[EInst(s1='k1', s2='v21', s3='v23'),"
-                         " EInst(s1='k2', s2='v22', s3='v23'),"
-                         " EInst(s1='k3', s2=None, s3=None)])", str(v),
+        self.assertEqual(v.ev,
+                         [EInst(s1='k1', s2='v21', s3='v23'),
+                         EInst(s1='k2', s2='v22', s3='v23'),
+                         EInst(s1='k3', s2=None, s3=None)],
                          "List of key value constructors")
 
         with self.assertRaises(ValueError) as e:
@@ -41,28 +41,32 @@ class InlinedAsListTestcase(unittest.TestCase):
         v = E([{"k1": EInst(s1="k1", s2="v21", s3="v23")},
                {"k2": JsonObj({"s2": "v22", "s3": "v23"})},
                {"k3": None}])
-        self.assertEqual("E(ev=[EInst(s1='k1', s2='v21', s3='v23'),"
-                         " EInst(s1='k2', s2='v22', s3='v23'),"
-                         " EInst(s1='k3', s2=None, s3=None)])", str(v))
+        self.assertEqual(v.ev,
+                         [EInst(s1='k1', s2='v21', s3='v23'),
+                         EInst(s1='k2', s2='v22', s3='v23'),
+                         EInst(s1='k3', s2=None, s3=None)])
 
         # More Form 5 variations
         v = E(["k1", "k2", {"k3": "v3"}, ["k4", "v4"], {"s1": "k5", "s2": "v52"}])
-        self.assertEqual("E(ev=[EInst(s1='k1', s2=None, s3=None), "
-                          "EInst(s1='k2', s2=None, s3=None), "
-                          "EInst(s1='k3', s2='v3', s3=None), "
-                          "EInst(s1='k4', s2='v4', s3=None), "
-                          "EInst(s1='k5', s2='v52', s3=None)])", str(v), "Key value tuples")
+        self.assertEqual(v.ev,
+                         [EInst(s1='k1', s2=None, s3=None),
+                          EInst(s1='k2', s2=None, s3=None),
+                          EInst(s1='k3', s2='v3', s3=None),
+                          EInst(s1='k4', s2='v4', s3=None),
+                          EInst(s1='k5', s2='v52', s3=None)], "Key value tuples")
 
         # Form 6 - list of positional object values
         v = E([["k1", "v12", "v13"], ["k2", "v22"], ["k3"]])
-        self.assertEqual("E(ev=[EInst(s1='k1', s2='v12', s3='v13'), "
-                          "EInst(s1='k2', s2='v22', s3=None), "
-                          "EInst(s1='k3', s2=None, s3=None)])", str(v), "Positional objects")
+        self.assertEqual(v.ev,
+                         [EInst(s1='k1', s2='v12', s3='v13'),
+                          EInst(s1='k2', s2='v22', s3=None),
+                          EInst(s1='k3', s2=None, s3=None)], "Positional objects")
 
         # Form 7 - list of kv dictionaries
         v = E([{"s1": "v11", "s2": "v12"}, {"s1": "v21", "s2": "v22", "s3": "v23"}])
-        self.assertEqual("E(ev=[EInst(s1='v11', s2='v12', s3=None), "
-                         "EInst(s1='v21', s2='v22', s3='v23')])", str(v), "List of dictionaries")
+        self.assertEqual(v.ev,
+                         [EInst(s1='v11', s2='v12', s3=None),
+                         EInst(s1='v21', s2='v22', s3='v23')], "List of dictionaries")
 
 
     def test_dict_variations(self):
@@ -72,23 +76,25 @@ class InlinedAsListTestcase(unittest.TestCase):
                "k2": JsonObj({"s2": "v22", "s3": "v23"}),
                "k3": {"s2": "v32", "s3": "v33"},
                "k4": {"s1": "k4"}})
-        self.assertEqual(("E(ev=[EInst(s1='k1', s2='v21', s3='v23'), "
-                           "EInst(s1='k2', s2='v22', s3='v23'), "
-                           "EInst(s1='k3', s2='v32', s3='v33'), "
-                           "EInst(s1='k4', s2=None, s3=None)])"), str(v), "Dictionary of key/object entries")
+        self.assertEqual(v.ev,
+                         [EInst(s1='k1', s2='v21', s3='v23'),
+                           EInst(s1='k2', s2='v22', s3='v23'),
+                           EInst(s1='k3', s2='v32', s3='v33'),
+                           EInst(s1='k4', s2=None, s3=None)], "Dictionary of key/object entries")
 
         # Form 2: key/value tuples (only works when at most two values are required
         v = E(ev={"k1": "v11", "k2": "v21", "k3": {}})
-        self.assertEqual("E(ev=[EInst(s1='k1', s2='v11', s3=None),"
-                         " EInst(s1='k2', s2='v21', s3=None), "
-                          "EInst(s1='k3', s2=None, s3=None)])", str(v), "Dictionary of two-key entries")
+        self.assertEqual(v.ev,
+                 [EInst(s1='k1', s2='v11', s3=None),
+                          EInst(s1='k2', s2='v21', s3=None),
+                          EInst(s1='k3', s2=None, s3=None)], "Dictionary of two-key entries")
 
         # Form 3: Basic single object (differentiated from form2 by the presence of the key name
         v = E({"s1": "k1"})
-        self.assertEqual("E(ev=[EInst(s1='k1', s2=None, s3=None)])",
-                         str(v), "Single entry dictionary")
+        self.assertEqual(v.ev, [EInst(s1='k1', s2=None, s3=None)],
+                   "Single entry dictionary")
         v = E({"s1": "k1", "s2": "v12"})
-        self.assertEqual("E(ev=[EInst(s1='k1', s2='v12', s3=None)])", str(v), "Single entry dictionary")
+        self.assertEqual(v.ev, [EInst(s1='k1', s2='v12', s3=None)], "Single entry dictionary")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
hi i'm ​🇸​​🇹​​🇷​​🇮​​🇳​​🇬​ ​🇷​​🇪​​🇵​​🇷​​🇪​​🇸​​🇪​​🇳​​🇹​​🇦​​🇹​​🇮​​🇴​​🇳​ ​🇴​​🇫​ ​🇲​​🇴​​🇩​​🇪​​🇱​ ​🇩​​🇪​​🇫​​🇮​​🇳​​🇮​​🇹​​🇮​​🇴​​🇳​

you might remember me from other print statements such as

<code>
>>> sv = SchemaView('tests/test_loaders_dumpers/input/personinfo.yaml')
>>> cls = sv.get_class('Person')
>>> print(cls)
ClassDefinition(name='Person', id_prefixes=[], id_prefixes_are_closed=None, definition_uri=None, local_names={}, conforms_to=None, implements=[], instantiates=[], extensions={}, annotations={}, description='A person (alive, dead, undead, or fictional).', alt_descriptions={}, title=None, deprecated=None, todos=[], notes=[], comments=[], examples=[], in_subset=[], from_schema='https://w3id.org/linkml/examples/personinfo', imported_from=None, source=None, in_language=None, see_also=[], deprecated_element_has_exact_replacement=None, deprecated_element_has_possible_replacement=None, aliases=[], structured_aliases={}, mappings=[], exact_mappings=[], close_mappings=[], related_mappings=[], narrow_mappings=[], broad_mappings=[], created_by=None, contributors=[], created_on=None, last_updated_on=None, modified_by=None, status=None, rank=None, categories=[], keywords=[], is_a='NamedThing', abstract=None, mixin=None, mixins=['HasAliases'], apply_to=[], values_from=[], string_serialization=None, slots=['primary_email', 'birth_date', 'age_in_years', 'gender', 'current_address', 'has_employment_history', 'has_familial_relationships', 'has_interpersonal_relationships', 'has_medical_history'], slot_usage={'primary_email': SlotDefinition(name='primary_email', id_prefixes=[], id_prefixes_are_closed=None, definition_uri=None, local_names={}, conforms_to=None, implements=[], instantiates=[], extensions={}, annotations={}, description=None, alt_descriptions={}, title=None, deprecated=None, todos=[], notes=[], comments=[], examples=[], in_subset=[], from_schema=None, imported_from=None, source=None, in_language=None, see_also=[], deprecated_element_has_exact_replacement=None, deprecated_element_has_possible_replacement=None, aliases=[], structured_aliases={}, mappings=[], exact_mappings=[], close_mappings=[], related_mappings=[], narrow_mappings=[], broad_mappings=[], created_by=None, contributors=[], created_on=None, last_updated_on=None, modified_by=None, status=None, rank=None, categories=[], keywords=[], is_a=None, abstract=None, mixin=None, mixins=[], apply_to=[], values_from=[], string_serialization=None, singular_name=None, domain=None, slot_uri=None, multivalued=None, array=None, inherited=None, readonly=None, ifabsent=None, list_elements_unique=None, list_elements_ordered=None, shared=None, key=None, identifier=None, designates_type=None, alias=None, owner=None, domain_of=[], subproperty_of=None, symmetric=None, reflexive=None, locally_reflexive=None, irreflexive=None, asymmetric=None, transitive=None, inverse=None, is_class_field=None, transitive_form_of=None, reflexive_transitive_form_of=None, role=None, is_usage_slot=None, usage_slot_name=None, relational_role=None, slot_group=None, is_grouping_slot=None, path_rule=None, disjoint_with=[], children_are_mutually_disjoint=None, union_of=[], range=None, range_expression=None, enum_range=None, required=None, recommended=None, inlined=None, inlined_as_list=None, minimum_value=None, maximum_value=None, pattern='^\\S+@[\\S+\\.]+\\S+', structured_pattern=None, unit=None, implicit_prefix=None, value_presence=None, equals_string=None, equals_string_in=[], equals_number=None, equals_expression=None, exact_cardinality=None, minimum_cardinality=None, maximum_cardinality=None, has_member=None, all_members=None, none_of=[], exactly_one_of=[], any_of=[], all_of=[])}, attributes={}, class_uri='schema:Person', subclass_of=None, union_of=[], defining_slots=[], tree_root=None, unique_keys={}, rules=[], classification_rules=[], slot_names_unique=None, represents_relationship=None, disjoint_with=[], children_are_mutually_disjoint=None, any_of=[], exactly_one_of=[], none_of=[], all_of=[], slot_conditions={})
</code>

---

well today i'm here to talk to you about

edited, updated format:

```python
>>> sv = SchemaView('tests/test_loaders_dumpers/input/personinfo.yaml')
>>> cls = sv.get_class('Person')
>>> print(cls)
ClassDefinition({
  'name': 'Person',
  'description': 'A person (alive, dead, undead, or fictional).',
  'from_schema': 'https://w3id.org/linkml/examples/personinfo',
  'is_a': 'NamedThing',
  'mixins': ['HasAliases'],
  'slots': ['primary_email', 'birth_date', 'age_in_years', 'gender', 'current_address',
    'has_employment_history', 'has_familial_relationships',
    'has_interpersonal_relationships', 'has_medical_history'],
  'slot_usage': {'primary_email': SlotDefinition({'name': 'primary_email', 'pattern': '^\\S+@[\\S+\\.]+\\S+'})},
  'class_uri': 'schema:Person'
})

```