### PR TITLE
Add action to test with upstream linkml

### DIFF
--- a/.github/workflows/test-upstream.yaml
+++ b/.github/workflows/test-upstream.yaml
@@ -1,0 +1,92 @@
+name: Test with upstream linkml
+on:
+  workflow_dispatch:
+
+jobs:
+  test_upstream:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, windows-latest ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11" ]
+        pydantic-version: [ "1", "2" ]
+        exclude:
+          - os: windows-latest
+            python-version: "3.8"
+          - os: windows-latest
+            pydantic-version: "1"
+          - python-version: "3.8"
+            pydantic-version: "1"
+          - python-version: "3.9"
+            pydantic-version: "1"
+          - python-version: "3.10"
+            pydantic-version: "1"
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: checkout upstream
+        uses: actions/checkout@v4
+        with:
+          repository: linkml/linkml
+          path: linkml
+          fetch-depth: 0
+
+      - name: checkout linkml-runtime
+        uses: actions/checkout@v4
+        with:
+          repository: linkml/linkml-runtime
+          path: linkml-runtime
+          fetch-depth: 0
+
+      - name: set up python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: install poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v3
+        with:
+          path: linkml/.venv
+          key: venv-${{ matrix.python-version }}-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
+
+      # make extra sure we're removing any old version of linkml-runtime that exists
+      - name: uninstall potentially cached linkml-runtime
+        working-directory: linkml
+        run: poetry run pip uninstall linkml-runtime
+
+      # we are not using linkml-runtime's lockfile, but simulating what will happen
+      # when we merge this and update linkml's lockfile
+      - name: add linkml-runtime to lockfile
+        working-directory: linkml
+        run: poetry add ../linkml-runtime
+
+      # use correct pydantic version
+      - name: install pydantic
+        working-directory: linkml
+        run: poetry add pydantic@^${{ matrix.pydantic-version }}
+
+      # note that we run the installation step always, even if we restore a venv,
+      # the cache will restore the old version of linkml-runtime, but the lockfile
+      # will only store the directory dependency (and thus will reinstall it)
+      # the cache will still speedup the rest of the installation
+      - name: install linkml
+        working-directory: linkml
+        run: poetry install --no-interaction -E tests
+
+      - name: print linkml-runtime version
+        working-directory: linkml
+        run: poetry run python -c 'import linkml_runtime; from importlib.metadata import version; print(linkml_runtime.__file__); print(version("linkml_runtime"))'
+
+      - name: run tests
+        working-directory: linkml
+        run: poetry run python -m pytest --with-slow
+
+
+

--- a/.github/workflows/test-upstream.yaml
+++ b/.github/workflows/test-upstream.yaml
@@ -1,11 +1,13 @@
 name: Test with upstream linkml
 on:
+  pull_request_review:
+    types: [ submitted ]
   workflow_dispatch:
 
 jobs:
   test_upstream:
+    if: github.event_name == 'workflow_dispatch' || github.event.review.state == 'APPROVED'
     strategy:
-      fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest ]
         python-version: [ "3.8", "3.9", "3.10", "3.11" ]
@@ -24,17 +26,20 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+
       - name: checkout upstream
         uses: actions/checkout@v4
         with:
           repository: linkml/linkml
           path: linkml
+          ref: main
           fetch-depth: 0
 
       - name: checkout linkml-runtime
         uses: actions/checkout@v4
         with:
-          repository: linkml/linkml-runtime
+          # don't specify repository like this or else we won't get pull request branches correctly
+          # repository: linkml/linkml-runtime
           path: linkml-runtime
           fetch-depth: 0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,11 @@ packages = [
     { include = "linkml_runtime" }
 ]
 
+[tool.poetry-dynamic-versioning]
+enable = true
+vcs = "git"
+style = "pep440"
+
 [tool.poetry.scripts]
 comparefiles = "linkml_runtime.utils.comparefiles:cli"
 linkml-normalize = "linkml_runtime.processing.referencevalidator:cli"
@@ -61,5 +66,5 @@ pydantic = ">=1.10.2, <3.0.0"
 coverage = "^6.2"
 
 [build-system]
-requires = ["poetry-core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
+build-backend = "poetry_dynamic_versioning.backend"


### PR DESCRIPTION
Fix: https://github.com/linkml/linkml/issues/1749

This PR adds an action to run the linkml tests against the current version of linkml-runtime.

This action runs after an approving review has been received, and can also be run manually. This is because this is a relatively expensive test, and should only be run after the content of a PR has been approved to check whether any modifications will need to be made upstream to accommodate it.

If this is accepted, in order for it to be protective we probably need to also add a branch protection rule that prevents pull requests from being merged until this action has passed. otherwise the temptation might be to approve a PR and then immediately merge it, since the action will run only then.

As with all github actions things, i am actually not sure it will do exactly what i think it will until i see it run, so this might require a little debugging, but anyway it should help out with the perennial need to manually run linkml tests against linkml-runtime and make it a bit easier for this repo to be developed safely

## differences from linkml `main.yaml`

I swapped out the default being pydantic 1 to pydantic 2, since 1 is soon to be deprecated, and also added testing for 3.11

## dynamic versioning

This PR ALSO adds dynamic versioning to this repo exactly as is done in `linkml` - i am not sure why that wasn't present before, but it seems like it should be? currently the version in the repo is literally `0.0.0` and that prevents us from checking that the correct `linkml-runtime` version is installed during this action