### PR TITLE
[schemaview][bug] Pass `imports` as kwarg to `all_slots`

### DIFF
--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -802,7 +802,7 @@ class SchemaView(object):
         :param is_a: include is_a parents (default is True)
         :return: all direct child slot names (is_a and mixins)
         """
-        elts = [self.get_slot(x) for x in self.all_slots(imports)]
+        elts = [self.get_slot(x) for x in self.all_slots(imports=imports)]
         return [x.name for x in elts if (x.is_a == slot_name and is_a) or (mixins and slot_name in x.mixins)]
 
     @lru_cache(None)


### PR DESCRIPTION
phew! +1 to the need for https://github.com/linkml/linkml-runtime/pull/316

https://github.com/linkml/linkml-runtime/pull/313 changed the if/else switch in selecting ordering to raise an exception for an unknown value rather than fall through because doing so exposes bugs like this one!

specifically, the `docgen` tests were all failing on a call to `slot_children` because they were passing imports as a positional argument rather than a kwarg. Looking for all usages between `linkml_runtime` and `linkml` for the two methods `all_slots` and `all_classes` that call `ordered`, and this looks like the only time that happens, everywhere else passes nothing or passes kargs

bonus! now we honor that `imports` param :)