### PR TITLE
Add action to test with upstream linkml v2

### DIFF
--- a/.github/workflows/test-upstream.yaml
+++ b/.github/workflows/test-upstream.yaml
@@ -71,7 +71,13 @@ jobs:
 
       - name: remove potentially cached linkml-runtime version
         working-directory: linkml
-        run: poetry run pip uninstall linkml-runtime
+        run: poetry run pip uninstall linkml-runtime -y
+
+      - name: get linkml-runtime short hash
+        working-directory: linkml-runtime
+        run: |
+          LINKML_RUNTIME_COMMIT=$(git rev-parse --short HEAD)
+          echo "LINKML_RUNTIME_COMMIT=$LINKML_RUNTIME_COMMIT" >> "$GITHUB_ENV"
 
       # install the local version of linkml-runtime:
       # we do this vs. pip --force-reinstall so that we keep linkml's locked deps
@@ -82,7 +88,7 @@ jobs:
       - name: add linkml-runtime to linkml's venv
         working-directory: linkml
         env:
-          POETRY_DYNAMIC_VERSIONING_OVERRIDE: "linkml-runtime = 1.99.0"
+          POETRY_DYNAMIC_VERSIONING_OVERRIDE: "linkml-runtime = 1.99.0+${{ env.LINKML_RUNTIME_COMMIT }}"
         run: poetry add ../linkml-runtime
 
       # note that we run the installation step always, even if we restore a venv,

--- a/.github/workflows/test-upstream.yaml
+++ b/.github/workflows/test-upstream.yaml
@@ -61,17 +61,6 @@ jobs:
           path: linkml/.venv
           key: venv-${{ matrix.python-version }}-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
 
-      # make extra sure we're removing any old version of linkml-runtime that exists
-      - name: uninstall potentially cached linkml-runtime
-        working-directory: linkml
-        run: poetry run pip uninstall linkml-runtime
-
-      # we are not using linkml-runtime's lockfile, but simulating what will happen
-      # when we merge this and update linkml's lockfile
-      - name: add linkml-runtime to lockfile
-        working-directory: linkml
-        run: poetry add ../linkml-runtime
-
       # use correct pydantic version
       - name: install pydantic
         working-directory: linkml
@@ -83,7 +72,15 @@ jobs:
       # the cache will still speedup the rest of the installation
       - name: install linkml
         working-directory: linkml
-        run: poetry install --no-interaction -E tests
+        run: poetry install --no-interaction --no-root -E tests
+
+      # force install the local version of linkml-runtime
+      # we don't use poetry's lockfile here because according to poetry-dynamic-versioning:
+      # "The dynamic version is not available during poetry run or poetry shell because of a Poetry design choice that prevents the plugin from cleaning up after itself."
+      # and since linkml depends on a specific version of linkml-runtime, this would always fail
+      - name: install linkml-runtime in linkml's venv
+        working-directory: linkml
+        run: poetry run pip install --force-reinstall ../linkml-runtime
 
       - name: print linkml-runtime version
         working-directory: linkml

--- a/.github/workflows/test-upstream.yaml
+++ b/.github/workflows/test-upstream.yaml
@@ -87,7 +87,9 @@ jobs:
       # and since linkml depends on a specific version of linkml-runtime, this would always fail
       - name: add linkml-runtime to linkml's venv
         working-directory: linkml
-        run: POETRY_DYNAMIC_VERSIONING_OVERRIDE="linkml-runtime = 1.99.0+${{ env.LINKML_RUNTIME_COMMIT }}" poetry add ../linkml-runtime
+        run: |
+          poetry self add "poetry-dynamic-versioning[plugin]"
+          POETRY_DYNAMIC_VERSIONING_OVERRIDE="linkml-runtime = 1.99.0+${{ env.LINKML_RUNTIME_COMMIT }}" poetry add ../linkml-runtime
 
       # note that we run the installation step always, even if we restore a venv,
       # the cache will restore the old version of linkml-runtime, but the lockfile

--- a/.github/workflows/test-upstream.yaml
+++ b/.github/workflows/test-upstream.yaml
@@ -1,3 +1,11 @@
+# This action is split up into two phases because
+# - We want to test linkml-runtime against linkml's lockfile - so we can't pip install --force-reinstall the local version
+# - We want to also take into account any deps changes linkml-runtime might have - so we can't pip install --no-deps
+# - We need to actually be able to install linkml-runtime, and since dynamic versioning doesn't work and can't be forced with
+#   env vars from another project...
+# We build a wheel with an artificially high version first, and then share that to the upstream tests
+# The linkml-runtime wheel should be the same across OS and python versions (and is actually an additional test of our packaging)
+
 name: Test with upstream linkml
 on:
   pull_request_review:
@@ -5,7 +13,46 @@ on:
   workflow_dispatch:
 
 jobs:
+  build_wheel:
+    if: github.event_name == 'workflow_dispatch' || github.event.review.state == 'APPROVED'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+    outputs:
+      linkml-runtime-wheel: ${{ steps.wheel-upload.outputs.artifact-id }}
+
+    steps:
+      - name: checkout linkml-runtime
+        uses: actions/checkout@v4
+      - name: set up python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: install poetry
+        uses: snok/install-poetry@v1
+        with:
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+      - name: get linkml-runtime short hash
+        run: |
+          LINKML_RUNTIME_COMMIT=$(git rev-parse --short HEAD)
+          echo "LINKML_RUNTIME_COMMIT=$LINKML_RUNTIME_COMMIT" >> "$GITHUB_ENV"
+      - name: build linkml-runtime wheel
+        run: |
+          POETRY_DYNAMIC_VERSIONING_BYPASS="1.99.0+${{ env.LINKML_RUNTIME_COMMIT }}" poetry build
+      - name: upload dist directory
+        uses: actions/upload-artifact@v4
+        id: wheel-upload
+        with:
+          name: linkml-runtime-wheel
+          path: dist/
+          if-no-files-found: error
+          overwrite: true
+          retention-days: 5
+
   test_upstream:
+    needs: build_wheel
     if: github.event_name == 'workflow_dispatch' || github.event.review.state == 'APPROVED'
     strategy:
       matrix:
@@ -38,14 +85,6 @@ jobs:
           ref: main
           fetch-depth: 0
 
-      - name: checkout linkml-runtime
-        uses: actions/checkout@v4
-        with:
-          # don't specify repository like this or else we won't get pull request branches correctly
-          # repository: linkml/linkml-runtime
-          path: linkml-runtime
-          fetch-depth: 0
-
       - name: set up python
         uses: actions/setup-python@v5
         with:
@@ -73,26 +112,18 @@ jobs:
         working-directory: linkml
         run: poetry run pip uninstall linkml-runtime -y
 
-      - name: get linkml-runtime short hash
-        working-directory: linkml-runtime
-        run: |
-          LINKML_RUNTIME_COMMIT=$(git rev-parse --short HEAD)
-          echo "LINKML_RUNTIME_COMMIT=$LINKML_RUNTIME_COMMIT" >> "$GITHUB_ENV"
+      # this should unpack into dist/
+      - name: Download the built wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.build_wheel.outputs.linkml-runtime-wheel }}
 
-      # install the local version of linkml-runtime:
-      # we do this vs. pip --force-reinstall so that we keep linkml's locked deps
-      # and simulate what the lockfile will be after merging and relocking.
-      # we override the linkml-runtime version here according to poetry-dynamic-versioning:
-      # "The dynamic version is not available during poetry run or poetry shell because of a Poetry design choice that prevents the plugin from cleaning up after itself."
-      # and since linkml depends on a specific version of linkml-runtime, this would always fail
-      - name: add linkml-runtime to linkml's venv
+      # amazingly, poetry does find the wheel correctly
+      - name: add linkml-runtime wheel to linkml's venv
         working-directory: linkml
-        run: POETRY_DYNAMIC_VERSIONING_OVERRIDE="linkml-runtime = 1.99.0+${{ env.LINKML_RUNTIME_COMMIT }}" poetry add ../linkml-runtime
+        run: poetry add ./dist/*
 
-      # note that we run the installation step always, even if we restore a venv,
-      # the cache will restore the old version of linkml-runtime, but the lockfile
-      # will only store the directory dependency (and thus will reinstall it)
-      # the cache will still speedup the rest of the installation
+      # with the modifications to the lockfile, we can install the rest of the deps
       - name: install linkml
         working-directory: linkml
         run: poetry install --no-interaction --no-root -E tests

--- a/.github/workflows/test-upstream.yaml
+++ b/.github/workflows/test-upstream.yaml
@@ -24,6 +24,9 @@ jobs:
           - python-version: "3.10"
             pydantic-version: "1"
     runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
 
     steps:
 

--- a/.github/workflows/test-upstream.yaml
+++ b/.github/workflows/test-upstream.yaml
@@ -40,7 +40,6 @@ jobs:
           echo "LINKML_RUNTIME_COMMIT=$LINKML_RUNTIME_COMMIT" >> "$GITHUB_ENV"
       - name: build linkml-runtime wheel
         run: |
-          poetry self add "poetry-dynamic-versioning[plugin]"
           POETRY_DYNAMIC_VERSIONING_BYPASS="1.99.0+${{ env.LINKML_RUNTIME_COMMIT }}" poetry build
       - name: upload dist directory
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test-upstream.yaml
+++ b/.github/workflows/test-upstream.yaml
@@ -1,11 +1,3 @@
-# This action is split up into two phases because
-# - We want to test linkml-runtime against linkml's lockfile - so we can't pip install --force-reinstall the local version
-# - We want to also take into account any deps changes linkml-runtime might have - so we can't pip install --no-deps
-# - We need to actually be able to install linkml-runtime, and since dynamic versioning doesn't work and can't be forced with
-#   env vars from another project...
-# We build a wheel with an artificially high version first, and then share that to the upstream tests
-# The linkml-runtime wheel should be the same across OS and python versions (and is actually an additional test of our packaging)
-
 name: Test with upstream linkml
 on:
   pull_request_review:
@@ -13,46 +5,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build_wheel:
-    if: github.event_name == 'workflow_dispatch' || github.event.review.state == 'APPROVED'
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash
-    outputs:
-      linkml-runtime-wheel: ${{ steps.wheel-upload.outputs.artifact-id }}
-
-    steps:
-      - name: checkout linkml-runtime
-        uses: actions/checkout@v4
-      - name: set up python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - name: install poetry
-        uses: snok/install-poetry@v1
-        with:
-          virtualenvs-create: true
-          virtualenvs-in-project: true
-      - name: get linkml-runtime short hash
-        run: |
-          LINKML_RUNTIME_COMMIT=$(git rev-parse --short HEAD)
-          echo "LINKML_RUNTIME_COMMIT=$LINKML_RUNTIME_COMMIT" >> "$GITHUB_ENV"
-      - name: build linkml-runtime wheel
-        run: |
-          POETRY_DYNAMIC_VERSIONING_BYPASS="1.99.0+${{ env.LINKML_RUNTIME_COMMIT }}" poetry build
-      - name: upload dist directory
-        uses: actions/upload-artifact@v4
-        id: wheel-upload
-        with:
-          name: linkml-runtime-wheel
-          path: dist/
-          if-no-files-found: error
-          overwrite: true
-          retention-days: 5
-
   test_upstream:
-    needs: build_wheel
     if: github.event_name == 'workflow_dispatch' || github.event.review.state == 'APPROVED'
     strategy:
       matrix:
@@ -85,6 +38,14 @@ jobs:
           ref: main
           fetch-depth: 0
 
+      - name: checkout linkml-runtime
+        uses: actions/checkout@v4
+        with:
+          # don't specify repository like this or else we won't get pull request branches correctly
+          # repository: linkml/linkml-runtime
+          path: linkml-runtime
+          fetch-depth: 0
+
       - name: set up python
         uses: actions/setup-python@v5
         with:
@@ -112,18 +73,26 @@ jobs:
         working-directory: linkml
         run: poetry run pip uninstall linkml-runtime -y
 
-      # this should unpack into dist/
-      - name: Download the built wheel
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ needs.build_wheel.outputs.linkml-runtime-wheel }}
+      - name: get linkml-runtime short hash
+        working-directory: linkml-runtime
+        run: |
+          LINKML_RUNTIME_COMMIT=$(git rev-parse --short HEAD)
+          echo "LINKML_RUNTIME_COMMIT=$LINKML_RUNTIME_COMMIT" >> "$GITHUB_ENV"
 
-      # amazingly, poetry does find the wheel correctly
-      - name: add linkml-runtime wheel to linkml's venv
+      # install the local version of linkml-runtime:
+      # we do this vs. pip --force-reinstall so that we keep linkml's locked deps
+      # and simulate what the lockfile will be after merging and relocking.
+      # we override the linkml-runtime version here according to poetry-dynamic-versioning:
+      # "The dynamic version is not available during poetry run or poetry shell because of a Poetry design choice that prevents the plugin from cleaning up after itself."
+      # and since linkml depends on a specific version of linkml-runtime, this would always fail
+      - name: add linkml-runtime to linkml's venv
         working-directory: linkml
-        run: poetry add ./dist/*
+        run: POETRY_DYNAMIC_VERSIONING_OVERRIDE="linkml-runtime = 1.99.0+${{ env.LINKML_RUNTIME_COMMIT }}" poetry add ../linkml-runtime
 
-      # with the modifications to the lockfile, we can install the rest of the deps
+      # note that we run the installation step always, even if we restore a venv,
+      # the cache will restore the old version of linkml-runtime, but the lockfile
+      # will only store the directory dependency (and thus will reinstall it)
+      # the cache will still speedup the rest of the installation
       - name: install linkml
         working-directory: linkml
         run: poetry install --no-interaction --no-root -E tests

--- a/.github/workflows/test-upstream.yaml
+++ b/.github/workflows/test-upstream.yaml
@@ -87,9 +87,7 @@ jobs:
       # and since linkml depends on a specific version of linkml-runtime, this would always fail
       - name: add linkml-runtime to linkml's venv
         working-directory: linkml
-        env:
-          POETRY_DYNAMIC_VERSIONING_OVERRIDE: "linkml-runtime = 1.99.0+${{ env.LINKML_RUNTIME_COMMIT }}"
-        run: poetry add ../linkml-runtime
+        run: POETRY_DYNAMIC_VERSIONING_OVERRIDE="linkml-runtime = 1.99.0+${{ env.LINKML_RUNTIME_COMMIT }}" poetry add ../linkml-runtime
 
       # note that we run the installation step always, even if we restore a venv,
       # the cache will restore the old version of linkml-runtime, but the lockfile

--- a/.github/workflows/test-upstream.yaml
+++ b/.github/workflows/test-upstream.yaml
@@ -40,6 +40,7 @@ jobs:
           echo "LINKML_RUNTIME_COMMIT=$LINKML_RUNTIME_COMMIT" >> "$GITHUB_ENV"
       - name: build linkml-runtime wheel
         run: |
+          poetry self add "poetry-dynamic-versioning[plugin]"
           POETRY_DYNAMIC_VERSIONING_BYPASS="1.99.0+${{ env.LINKML_RUNTIME_COMMIT }}" poetry build
       - name: upload dist directory
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test-upstream.yaml
+++ b/.github/workflows/test-upstream.yaml
@@ -69,6 +69,22 @@ jobs:
         working-directory: linkml
         run: poetry add pydantic@^${{ matrix.pydantic-version }}
 
+      - name: remove potentially cached linkml-runtime version
+        working-directory: linkml
+        run: poetry run pip uninstall linkml-runtime
+
+      # install the local version of linkml-runtime:
+      # we do this vs. pip --force-reinstall so that we keep linkml's locked deps
+      # and simulate what the lockfile will be after merging and relocking.
+      # we override the linkml-runtime version here according to poetry-dynamic-versioning:
+      # "The dynamic version is not available during poetry run or poetry shell because of a Poetry design choice that prevents the plugin from cleaning up after itself."
+      # and since linkml depends on a specific version of linkml-runtime, this would always fail
+      - name: add linkml-runtime to linkml's venv
+        working-directory: linkml
+        env:
+          POETRY_DYNAMIC_VERSIONING_OVERRIDE: "linkml-runtime = 1.99.0"
+        run: poetry add ../linkml-runtime
+
       # note that we run the installation step always, even if we restore a venv,
       # the cache will restore the old version of linkml-runtime, but the lockfile
       # will only store the directory dependency (and thus will reinstall it)
@@ -76,14 +92,6 @@ jobs:
       - name: install linkml
         working-directory: linkml
         run: poetry install --no-interaction --no-root -E tests
-
-      # force install the local version of linkml-runtime
-      # we don't use poetry's lockfile here because according to poetry-dynamic-versioning:
-      # "The dynamic version is not available during poetry run or poetry shell because of a Poetry design choice that prevents the plugin from cleaning up after itself."
-      # and since linkml depends on a specific version of linkml-runtime, this would always fail
-      - name: install linkml-runtime in linkml's venv
-        working-directory: linkml
-        run: poetry run pip install --force-reinstall ../linkml-runtime
 
       - name: print linkml-runtime version
         working-directory: linkml


### PR DESCRIPTION
Continues: https://github.com/linkml/linkml-runtime/pull/316

Sorry to keep doing this with CI actions - as far as I know I can't test them on the fork until they are in main?

The previous action wouldn't run because the dynamic versioning plugin can't detect version when run within a poetry shell - https://github.com/mtkennerly/poetry-dynamic-versioning?tab=readme-ov-file#caveats

you also apparently need to explicitly install the plugin.

so i modified it so that we create an arbitrarily high version with the commit hash appended to it so we can be sure that the current version is being installed rather than a cached version.

You can see that the action is running *but correctly failing due to https://github.com/linkml/linkml/issues/2047 * here - https://github.com/sneakers-the-rat/linkml-runtime/actions/runs/8531972641/job/23372442173

this should get squash merged, but wanted to preserve commit history in PR so it's possible to see the various options i tried. blah. one day this will all be done and our CI will be spic and span