### PR TITLE
Display `any_of`, `exactly_one_of`, `none_of`, `all_of` range assertions in Usages section of class documentation page

### DIFF
--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -1657,7 +1657,7 @@ class SchemaView(object):
 
         :return: dictionary of SchemaUsages keyed by used elements
         """
-        ROLES = ['domain', 'range']
+        ROLES = ['domain', 'range', 'any_of', 'exactly_one_of', 'none_of', 'all_of']
         ix = defaultdict(list)
         for cn, c in self.all_classes().items():
             direct_slots = c.slots
@@ -1671,6 +1671,9 @@ class SchemaView(object):
                         vl = [v]
                     for x in vl:
                         if x is not None:
+                            if isinstance(x, AnonymousSlotExpression):
+                                x = x.range
+                                k = f"{k}[range]"
                             u = SchemaUsage(used_by=cn, slot=sn, metaslot=k, used=x)
                             u.inferred = sn in direct_slots
                             ix[x].append(u)

--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -1674,6 +1674,7 @@ class SchemaView(object):
                             if isinstance(x, AnonymousSlotExpression):
                                 x = x.range
                                 k = f"{k}[range]"
+                            k = k.split("[")[0] + "[range]" if "[range]" in k else k
                             u = SchemaUsage(used_by=cn, slot=sn, metaslot=k, used=x)
                             u.inferred = sn in direct_slots
                             ix[x].append(u)

--- a/tests/test_utils/input/kitchen_sink_noimports.yaml
+++ b/tests/test_utils/input/kitchen_sink_noimports.yaml
@@ -87,9 +87,15 @@ classes:
       - age in years
       - addresses
       - has birth event
+      - reason_for_happiness
     slot_usage:
       name:
         pattern: "^\\S+ \\S+"  ## do not do this in a real schema, people have all kinds of names
+      reason_for_happiness:
+        any_of:
+          - range: BirthEvent
+          - range: EmploymentEvent
+          - range: MarriageEvent
 
   Adult:
     is_a: Person
@@ -352,6 +358,10 @@ slots:
   postal code:
     alias: zip
     range: string
+
+  reason_for_happiness:
+    range: string
+    required: false
 
 
 enums:

--- a/tests/test_utils/test_schemaview.py
+++ b/tests/test_utils/test_schemaview.py
@@ -186,7 +186,7 @@ class SchemaViewTestCase(unittest.TestCase):
 
         self.assertCountEqual(['id', 'name',  ## From Thing
                                'has employment history', 'has familial relationships', 'has medical history',
-                               AGE_IN_YEARS, 'addresses', 'has birth event', ## From Person
+                               AGE_IN_YEARS, 'addresses', 'has birth event', 'reason_for_happiness', ## From Person
                                'aliases'  ## From HasAliases
                                 ],
                               view.class_slots('Person'))
@@ -256,6 +256,42 @@ class SchemaViewTestCase(unittest.TestCase):
             logging.debug(f' {k} = {v}')
         self.assertIn(SchemaUsage(used_by='FamilialRelationship', slot=RELATED_TO,
                            metaslot='range', used='Person', inferred=False), u['Person'])
+        self.assertListEqual(
+            [SchemaUsage(used_by='Person', 
+                        slot='reason_for_happiness', 
+                        metaslot='any_of[range]', 
+                        used='MarriageEvent', 
+                        inferred=True
+                        ), 
+            SchemaUsage(used_by='Adult',
+                        slot='reason_for_happiness', 
+                        metaslot='any_of[range]', 
+                        used='MarriageEvent', 
+                        inferred=False
+                        )], 
+            u['MarriageEvent'])
+        self.assertListEqual(
+            [SchemaUsage(used_by='Person', 
+                        slot='has employment history', 
+                        metaslot='range', 
+                        used='EmploymentEvent', 
+                        inferred=True), 
+            SchemaUsage(used_by='Person', 
+                        slot='reason_for_happiness', 
+                        metaslot='any_of[range]', 
+                        used='EmploymentEvent', 
+                        inferred=True), 
+            SchemaUsage(used_by='Adult', 
+                        slot='has employment history', 
+                        metaslot='range', 
+                        used='EmploymentEvent', 
+                        inferred=False), 
+            SchemaUsage(used_by='Adult', 
+                        slot='reason_for_happiness', 
+                        metaslot='any_of[range]', 
+                        used='EmploymentEvent', 
+                        inferred=False)],
+            u['EmploymentEvent'])
 
         # test methods also work for attributes
         leaves = view.class_leaves()


### PR DESCRIPTION
Fixes https://github.com/linkml/linkml/issues/2033

If a slot has a union range asserted/constrained using any of the following linkml constructs -- `any_of`, `exactly_one_of`, `none_of`, `all_of` then, the class which it asserts in it's range will have a reference to the slot mentioned in the Usages section of that class documentation page.