### PR TITLE
remove references to the now delete linkml_runtime.utils.ifabsent_functions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -63,4 +63,4 @@ jobs:
           name: codecov-results-${{ matrix.os }}-${{ matrix.python-version }}
           token: ${{ secrets.CODECOV_TOKEN }}
           file: coverage.xml
-          fail_ci_if_error: true
+          fail_ci_if_error: false

--- a/linkml_runtime/linkml_model/json/meta.json
+++ b/linkml_runtime/linkml_model/json/meta.json
@@ -2590,7 +2590,7 @@
     {
       "name": "ifabsent",
       "definition_uri": "https://w3id.org/linkml/ifabsent",
-      "description": "function that provides a default value for the slot.  Possible values for this slot are defined in\nlinkml_runtime.utils.ifabsent_functions.default_library:\n  * [Tt]rue -- boolean True\n  * [Ff]alse -- boolean False\n  * int(value) -- integer value\n  * str(value) -- string value\n  * default_range -- schema default range\n  * bnode -- blank node identifier\n  * slot_uri -- URI for the slot\n  * class_curie -- CURIE for the containing class\n  * class_uri -- URI for the containing class",
+      "description": "function that provides a default value for the slot.\n  * [Tt]rue -- boolean True\n  * [Ff]alse -- boolean False\n  * int(value) -- integer value\n  * str(value) -- string value\n  * default_range -- schema default range\n  * bnode -- blank node identifier\n  * slot_uri -- URI for the slot\n  * class_curie -- CURIE for the containing class\n  * class_uri -- URI for the containing class",
       "from_schema": "https://w3id.org/linkml/meta",
       "close_mappings": [
         "https://w3id.org/shacl/defaultValue"

--- a/linkml_runtime/linkml_model/owl/meta.owl.ttl
+++ b/linkml_runtime/linkml_model/owl/meta.owl.ttl
@@ -1421,6 +1421,14 @@ linkml:ifabsent a owl:ObjectProperty,
   * EnumName(PermissibleValue) -- enum value""" ;
     skos:inScheme linkml:meta .
 
+linkml:implements a owl:ObjectProperty,
+        linkml:SlotDefinition ;
+    rdfs:label "implements" ;
+    rdfs:domain linkml:Element ;
+    rdfs:range linkml:Uriorcurie ;
+    skos:definition "An element in another schema which this element conforms to. The referenced element is not imported into the schema for the implementing element. However, the referenced schema may be used to check conformance of the implementing element." ;
+    skos:inScheme linkml:meta .
+
 linkml:import_as a owl:ObjectProperty,
         linkml:SlotDefinition ;
     rdfs:label "import_as" ;

--- a/linkml_runtime/linkml_model/rdf/meta.model.ttl
+++ b/linkml_runtime/linkml_model/rdf/meta.model.ttl
@@ -1228,8 +1228,7 @@ linkml:iec61360code a linkml:SlotDefinition ;
 
 linkml:ifabsent a linkml:SlotDefinition ;
     skos:closeMatch sh1:defaultValue ;
-    skos:definition """function that provides a default value for the slot.  Possible values for this slot are defined in
-linkml_runtime.utils.ifabsent_functions.default_library:
+    skos:definition """function that provides a default value for the slot.
   * [Tt]rue -- boolean True
   * [Ff]alse -- boolean False
   * int(value) -- integer value

--- a/linkml_runtime/linkml_model/rdf/meta.ttl
+++ b/linkml_runtime/linkml_model/rdf/meta.ttl
@@ -1228,8 +1228,7 @@ linkml:iec61360code a linkml:SlotDefinition ;
 
 linkml:ifabsent a linkml:SlotDefinition ;
     skos:closeMatch sh1:defaultValue ;
-    skos:definition """function that provides a default value for the slot.  Possible values for this slot are defined in
-linkml_runtime.utils.ifabsent_functions.default_library:
+    skos:definition """function that provides a default value for the slot.
   * [Tt]rue -- boolean True
   * [Ff]alse -- boolean False
   * int(value) -- integer value

--- a/linkml_runtime/linkml_model/sqlddl/meta.sql
+++ b/linkml_runtime/linkml_model/sqlddl/meta.sql
@@ -313,7 +313,7 @@
 --     * Slot: multivalued Description: true means that slot can have more than one value
 --     * Slot: inherited Description: true means that the *value* of a slot is inherited by subclasses
 --     * Slot: readonly Description: If present, slot is read only.  Text explains why
---     * Slot: ifabsent Description: function that provides a default value for the slot.  Possible values for this slot are defined inlinkml_runtime.utils.ifabsent_functions.default_library:  * [Tt]rue -- boolean True  * [Ff]alse -- boolean False  * int(value) -- integer value  * str(value) -- string value  * default_range -- schema default range  * bnode -- blank node identifier  * slot_uri -- URI for the slot  * class_curie -- CURIE for the containing class  * class_uri -- URI for the containing class
+--     * Slot: ifabsent Description: function that provides a default value for the slot. * [Tt]rue -- boolean True  * [Ff]alse -- boolean False  * int(value) -- integer value  * str(value) -- string value  * default_range -- schema default range  * bnode -- blank node identifier  * slot_uri -- URI for the slot  * class_curie -- CURIE for the containing class  * class_uri -- URI for the containing class
 --     * Slot: list_elements_unique Description: If True, then there must be no duplicates in the elements of a multivalued slot
 --     * Slot: list_elements_ordered Description: If True, then the order of elements of a multivalued slot is guaranteed to be preserved. If False, the order may still be preserved but this is not guaranteed
 --     * Slot: shared Description: If True, then the relationship between the slot domain and range is many to one or many to many

--- a/notebooks/SchemaView_BioLink.ipynb
+++ b/notebooks/SchemaView_BioLink.ipynb
@@ -4,551 +4,191 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
-   "outputs": [],
    "source": [
     "from linkml_runtime.utils.schemaview import SchemaView"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {},
-   "outputs": [],
    "source": [
     "view = SchemaView(\"../tests/test_utils/input/biolink-model.yaml\")"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": 4,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Loading schema https://w3id.org/linkml/types from ../tests/test_utils/input/biolink-model.yaml\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "['Biolink-Model', 'linkml:types']"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
     "view.imports_closure()"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": 5,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(257, 421, 4)"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
     "len(view.all_classes()), len(view.all_slots()), len(view.all_subsets())"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": 6,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['gene',\n",
-       " 'gene or gene product',\n",
-       " 'genomic entity',\n",
-       " 'chemical entity or gene or gene product',\n",
-       " 'physical essence',\n",
-       " 'ontology class',\n",
-       " 'biological entity',\n",
-       " 'named thing',\n",
-       " 'entity',\n",
-       " 'physical essence or occurrent',\n",
-       " 'thing with taxon',\n",
-       " 'macromolecular machine mixin']"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
     "view.class_ancestors('gene')"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['biolink:Gene',\n",
-       " 'biolink:GeneOrGeneProduct',\n",
-       " 'biolink:GenomicEntity',\n",
-       " 'biolink:ChemicalEntityOrGeneOrGeneProduct',\n",
-       " 'biolink:PhysicalEssence',\n",
-       " 'biolink:OntologyClass',\n",
-       " 'biolink:BiologicalEntity',\n",
-       " 'biolink:NamedThing',\n",
-       " 'biolink:Entity',\n",
-       " 'biolink:PhysicalEssenceOrOccurrent',\n",
-       " 'biolink:ThingWithTaxon',\n",
-       " 'biolink:MacromolecularMachineMixin']"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
     "[view.get_uri(c) for c in view.class_ancestors('gene')]"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": 8,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['https://w3id.org/biolink/vocab/Gene',\n",
-       " 'https://w3id.org/biolink/vocab/GeneOrGeneProduct',\n",
-       " 'https://w3id.org/biolink/vocab/GenomicEntity',\n",
-       " 'https://w3id.org/biolink/vocab/ChemicalEntityOrGeneOrGeneProduct',\n",
-       " 'https://w3id.org/biolink/vocab/PhysicalEssence',\n",
-       " 'https://w3id.org/biolink/vocab/OntologyClass',\n",
-       " 'https://w3id.org/biolink/vocab/BiologicalEntity',\n",
-       " 'https://w3id.org/biolink/vocab/NamedThing',\n",
-       " 'https://w3id.org/biolink/vocab/Entity',\n",
-       " 'https://w3id.org/biolink/vocab/PhysicalEssenceOrOccurrent',\n",
-       " 'https://w3id.org/biolink/vocab/ThingWithTaxon',\n",
-       " 'https://w3id.org/biolink/vocab/MacromolecularMachineMixin']"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
     "[view.get_uri(c, expand=True) for c in view.class_ancestors('gene')]"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": 9,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['gene', 'biological entity', 'named thing', 'entity']"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
     "view.class_ancestors('gene', mixins=False)"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": 10,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['affects', 'related to']"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
     "view.slot_ancestors('affects')"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": 11,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['affects abundance of',\n",
-       " 'abundance affected by',\n",
-       " 'affects activity of',\n",
-       " 'activity affected by',\n",
-       " 'activity affects',\n",
-       " 'affects expression of',\n",
-       " 'expression affected by',\n",
-       " 'affects folding of',\n",
-       " 'folding affected by',\n",
-       " 'affects localization of',\n",
-       " 'localization affected by',\n",
-       " 'affects metabolic processing of',\n",
-       " 'metabolic processing affected by',\n",
-       " 'affects molecular modification of',\n",
-       " 'molecular modification affected by',\n",
-       " 'affects synthesis of',\n",
-       " 'sythesis affected by',\n",
-       " 'affects degradation of',\n",
-       " 'degradation affected by',\n",
-       " 'affects mutation rate of',\n",
-       " 'mutation rate affected by',\n",
-       " 'affects response to',\n",
-       " 'response affected by',\n",
-       " 'affects splicing of',\n",
-       " 'splicing affected by',\n",
-       " 'affects stability of',\n",
-       " 'stability affected by',\n",
-       " 'affects transport of',\n",
-       " 'transport affected by',\n",
-       " 'affects secretion of',\n",
-       " 'secretion affected by',\n",
-       " 'affects uptake of',\n",
-       " 'uptake affected by',\n",
-       " 'process regulates process',\n",
-       " 'entity regulates entity',\n",
-       " 'disrupts',\n",
-       " 'ameliorates',\n",
-       " 'exacerbates',\n",
-       " 'affects expression in']"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
     "view.slot_children('affects')"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": 12,
    "metadata": {},
-   "outputs": [],
    "source": [
     "affects = view.get_slot('affects')"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": 13,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['SEMMEDDB:AFFECTS', 'SEMMEDDB:affects', 'DGIdb:affects', 'RTXKG1:affects']"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
     "affects.exact_mappings"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": 14,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'self': ['biolink:affects'],\n",
-       " 'native': ['biolink:affects'],\n",
-       " 'exact': ['SEMMEDDB:AFFECTS',\n",
-       "  'SEMMEDDB:affects',\n",
-       "  'DGIdb:affects',\n",
-       "  'RTXKG1:affects'],\n",
-       " 'narrow': ['SEMMEDDB:administered_to',\n",
-       "  'CTD:prediction_hypothesis',\n",
-       "  'GOREL:0001006',\n",
-       "  'CTD:inferred',\n",
-       "  'UPHENO:0000001',\n",
-       "  'RO:0002263',\n",
-       "  'RO:0002264',\n",
-       "  'NCIT:R158',\n",
-       "  'NCIT:R160',\n",
-       "  'NCIT:R30',\n",
-       "  'NCIT:R150',\n",
-       "  'NCIT:R72',\n",
-       "  'NCIT:R146',\n",
-       "  'NCIT:R124',\n",
-       "  'NCIT:R173',\n",
-       "  'NCIT:R100',\n",
-       "  'NCIT:R102',\n",
-       "  'NCIT:R101',\n",
-       "  'NCIT:R113',\n",
-       "  'NCIT:R23',\n",
-       "  'NCIT:R25',\n",
-       "  'NCIT:gene_mapped_to_disease',\n",
-       "  'NCIT:R133',\n",
-       "  'RO:0002343',\n",
-       "  'RO:0002355',\n",
-       "  'RO:0002591',\n",
-       "  'RO:0002592',\n",
-       "  'RO:0012003',\n",
-       "  'SNOMED:has_pathological_process'],\n",
-       " 'broad': [],\n",
-       " 'related': ['DRUGBANK:pathway'],\n",
-       " 'close': [],\n",
-       " 'undefined': []}"
-      ]
-     },
-     "execution_count": 14,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
     "view.get_mappings(affects.name)"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": 15,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'self': ['https://w3id.org/biolink/vocab/affects'],\n",
-       " 'native': ['https://w3id.org/biolink/vocab/affects'],\n",
-       " 'exact': ['https://skr3.nlm.nih.gov/SemMedDBAFFECTS',\n",
-       "  'https://skr3.nlm.nih.gov/SemMedDBaffects',\n",
-       "  'https://www.dgidb.org/interaction_typesaffects',\n",
-       "  'http://kg1endpoint.rtx.ai/affects'],\n",
-       " 'narrow': ['https://skr3.nlm.nih.gov/SemMedDBadministered_to',\n",
-       "  'http://translator.ncats.nih.gov/CTD_prediction_hypothesis',\n",
-       "  'http://purl.obolibrary.org/obo/GOREL_0001006',\n",
-       "  'http://translator.ncats.nih.gov/CTD_inferred',\n",
-       "  'http://purl.obolibrary.org/obo/UPHENO_0000001',\n",
-       "  'http://purl.obolibrary.org/obo/RO_0002263',\n",
-       "  'http://purl.obolibrary.org/obo/RO_0002264',\n",
-       "  'http://purl.obolibrary.org/obo/NCIT_R158',\n",
-       "  'http://purl.obolibrary.org/obo/NCIT_R160',\n",
-       "  'http://purl.obolibrary.org/obo/NCIT_R30',\n",
-       "  'http://purl.obolibrary.org/obo/NCIT_R150',\n",
-       "  'http://purl.obolibrary.org/obo/NCIT_R72',\n",
-       "  'http://purl.obolibrary.org/obo/NCIT_R146',\n",
-       "  'http://purl.obolibrary.org/obo/NCIT_R124',\n",
-       "  'http://purl.obolibrary.org/obo/NCIT_R173',\n",
-       "  'http://purl.obolibrary.org/obo/NCIT_R100',\n",
-       "  'http://purl.obolibrary.org/obo/NCIT_R102',\n",
-       "  'http://purl.obolibrary.org/obo/NCIT_R101',\n",
-       "  'http://purl.obolibrary.org/obo/NCIT_R113',\n",
-       "  'http://purl.obolibrary.org/obo/NCIT_R23',\n",
-       "  'http://purl.obolibrary.org/obo/NCIT_R25',\n",
-       "  'http://purl.obolibrary.org/obo/NCIT_gene_mapped_to_disease',\n",
-       "  'http://purl.obolibrary.org/obo/NCIT_R133',\n",
-       "  'http://purl.obolibrary.org/obo/RO_0002343',\n",
-       "  'http://purl.obolibrary.org/obo/RO_0002355',\n",
-       "  'http://purl.obolibrary.org/obo/RO_0002591',\n",
-       "  'http://purl.obolibrary.org/obo/RO_0002592',\n",
-       "  'http://purl.obolibrary.org/obo/RO_0012003',\n",
-       "  'http://purl.obolibrary.org/obo/SNOMED_has_pathological_process'],\n",
-       " 'broad': [],\n",
-       " 'related': ['http://identifiers.org/drugbank/pathway'],\n",
-       " 'close': [],\n",
-       " 'undefined': []}"
-      ]
-     },
-     "execution_count": 15,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
     "view.get_mappings(affects.name, expand=True)"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": 16,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['association',\n",
-       " 'contributor association',\n",
-       " 'genotype to genotype part association',\n",
-       " 'genotype to gene association',\n",
-       " 'genotype to variant association',\n",
-       " 'gene to gene association',\n",
-       " 'gene to gene homology association',\n",
-       " 'gene to gene coexpression association',\n",
-       " 'pairwise gene to gene interaction',\n",
-       " 'pairwise molecular interaction',\n",
-       " 'cell line to disease or phenotypic feature association',\n",
-       " 'chemical to chemical association',\n",
-       " 'reaction to participant association',\n",
-       " 'reaction to catalyst association',\n",
-       " 'chemical to chemical derivation association',\n",
-       " 'chemical to disease or phenotypic feature association',\n",
-       " 'chemical to pathway association',\n",
-       " 'chemical to gene association',\n",
-       " 'drug to gene association',\n",
-       " 'material sample derivation association']"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
     "[c for c in view.all_classes().keys() if view.is_relationship(c)][0:20]"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": 17,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{}"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
     "view.annotation_dict(affects.name)"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": 18,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'biolink:canonical_predicate': Annotation(tag='biolink:canonical_predicate', value='True', extensions={}, annotations={})}"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
     "affects.annotations"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": 20,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "False"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
     "from linkml_runtime.linkml_model.annotations import Annotation, Annotatable\n",
     "\n",
     "isinstance(affects, Annotatable)"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": 21,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "SlotDefinition(name='affects', id_prefixes=[], definition_uri=None, aliases=[], local_names={}, mappings=[], exact_mappings=['SEMMEDDB:AFFECTS', 'SEMMEDDB:affects', 'DGIdb:affects', 'RTXKG1:affects'], close_mappings=[], related_mappings=['DRUGBANK:pathway'], narrow_mappings=['SEMMEDDB:administered_to', 'CTD:prediction_hypothesis', 'GOREL:0001006', 'CTD:inferred', 'UPHENO:0000001', 'RO:0002263', 'RO:0002264', 'NCIT:R158', 'NCIT:R160', 'NCIT:R30', 'NCIT:R150', 'NCIT:R72', 'NCIT:R146', 'NCIT:R124', 'NCIT:R173', 'NCIT:R100', 'NCIT:R102', 'NCIT:R101', 'NCIT:R113', 'NCIT:R23', 'NCIT:R25', 'NCIT:gene_mapped_to_disease', 'NCIT:R133', 'RO:0002343', 'RO:0002355', 'RO:0002591', 'RO:0002592', 'RO:0012003', 'SNOMED:has_pathological_process'], broad_mappings=[], extensions={}, annotations={'biolink:canonical_predicate': Annotation(tag='biolink:canonical_predicate', value='True', extensions={}, annotations={})}, description=\"describes an entity that has a direct affect on the state or quality of another existing entity. Use of the 'affects' predicate implies that the affected entity already exists, unlike predicates such as 'affects risk for' and 'prevents, where the outcome is something that may or may not come to be.\", alt_descriptions={}, deprecated=None, todos=[], notes=[], comments=[], examples=[], in_subset=['translator_minimal'], from_schema=None, imported_from=None, see_also=[], deprecated_element_has_exact_replacement=None, deprecated_element_has_possible_replacement=None, is_a='related to', abstract=None, mixin=None, mixins=[], apply_to=[], values_from=[], created_by=None, created_on=None, last_updated_on=None, modified_by=None, status=None, string_serialization=None, singular_name=None, domain=None, range=None, slot_uri=None, multivalued=None, inherited=None, readonly=None, ifabsent=None, required=None, recommended=None, inlined=None, inlined_as_list=None, key=None, identifier=None, alias=None, owner=None, domain_of=[], subproperty_of=None, symmetric=None, inverse=None, is_class_field=None, role=None, is_usage_slot=None, usage_slot_name=None, minimum_value=None, maximum_value=None, pattern=None)"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
     "affects"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": 22,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "SlotDefinition(name='affects', id_prefixes=[], definition_uri=None, aliases=[], local_names={}, mappings=[], exact_mappings=['SEMMEDDB:AFFECTS', 'SEMMEDDB:affects', 'DGIdb:affects', 'RTXKG1:affects'], close_mappings=[], related_mappings=['DRUGBANK:pathway'], narrow_mappings=['SEMMEDDB:administered_to', 'CTD:prediction_hypothesis', 'GOREL:0001006', 'CTD:inferred', 'UPHENO:0000001', 'RO:0002263', 'RO:0002264', 'NCIT:R158', 'NCIT:R160', 'NCIT:R30', 'NCIT:R150', 'NCIT:R72', 'NCIT:R146', 'NCIT:R124', 'NCIT:R173', 'NCIT:R100', 'NCIT:R102', 'NCIT:R101', 'NCIT:R113', 'NCIT:R23', 'NCIT:R25', 'NCIT:gene_mapped_to_disease', 'NCIT:R133', 'RO:0002343', 'RO:0002355', 'RO:0002591', 'RO:0002592', 'RO:0012003', 'SNOMED:has_pathological_process'], broad_mappings=[], extensions={}, annotations={'biolink:canonical_predicate': Annotation(tag='biolink:canonical_predicate', value='True', extensions={}, annotations={})}, description=\"describes an entity that has a direct affect on the state or quality of another existing entity. Use of the 'affects' predicate implies that the affected entity already exists, unlike predicates such as 'affects risk for' and 'prevents, where the outcome is something that may or may not come to be.\", alt_descriptions={}, deprecated=None, todos=[], notes=[], comments=[], examples=[], in_subset=['translator_minimal'], from_schema=None, imported_from=None, see_also=[], deprecated_element_has_exact_replacement=None, deprecated_element_has_possible_replacement=None, is_a='related to', abstract=None, mixin=None, mixins=[], apply_to=[], values_from=[], created_by=None, created_on=None, last_updated_on=None, modified_by=None, status=None, string_serialization=None, singular_name=None, domain=None, range=None, slot_uri=None, multivalued=None, inherited=None, readonly=None, ifabsent=None, required=None, recommended=None, inlined=None, inlined_as_list=None, key=None, identifier=None, alias=None, owner=None, domain_of=[], subproperty_of=None, symmetric=None, inverse=None, is_class_field=None, role=None, is_usage_slot=None, usage_slot_name=None, minimum_value=None, maximum_value=None, pattern=None)"
-      ]
-     },
-     "execution_count": 22,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
     "e = view.get_element('affects')\n",
     "e"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [],
+   "outputs": []
   }
  ],
  "metadata": {

--- a/notebooks/SchemaView_MIxS.ipynb
+++ b/notebooks/SchemaView_MIxS.ipynb
@@ -5,292 +5,128 @@
    "execution_count": 1,
    "id": "d82643aa",
    "metadata": {},
-   "outputs": [],
    "source": [
     "from linkml_runtime.utils.schemaview import SchemaView"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": 2,
    "id": "850e4b34",
    "metadata": {},
-   "outputs": [],
    "source": [
     "view = SchemaView(\"../tests/test_utils/input/mixs/mixs.yaml\")"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": 4,
    "id": "c0e9ccd4",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Loading schema water from ../tests/test_utils/input/mixs/mixs.yaml\n",
-      "Loading schema terms from ../tests/test_utils/input/mixs/mixs.yaml\n",
-      "Loading schema ranges from ../tests/test_utils/input/mixs/mixs.yaml\n",
-      "Loading schema https://w3id.org/linkml/types from ../tests/test_utils/input/mixs/mixs.yaml\n",
-      "Loading schema wastewater_sludge from ../tests/test_utils/input/mixs/mixs.yaml\n",
-      "Loading schema soil from ../tests/test_utils/input/mixs/mixs.yaml\n",
-      "Loading schema sediment from ../tests/test_utils/input/mixs/mixs.yaml\n",
-      "Loading schema plant_associated from ../tests/test_utils/input/mixs/mixs.yaml\n",
-      "Loading schema miscellaneous_natural_or_artificial_environment from ../tests/test_utils/input/mixs/mixs.yaml\n",
-      "Loading schema microbial_mat_biofilm from ../tests/test_utils/input/mixs/mixs.yaml\n",
-      "Loading schema hydrocarbon_resources_fluids_swabs from ../tests/test_utils/input/mixs/mixs.yaml\n",
-      "Loading schema hydrocarbon_resources_cores from ../tests/test_utils/input/mixs/mixs.yaml\n",
-      "Loading schema human_vaginal from ../tests/test_utils/input/mixs/mixs.yaml\n",
-      "Loading schema human_skin from ../tests/test_utils/input/mixs/mixs.yaml\n",
-      "Loading schema human_oral from ../tests/test_utils/input/mixs/mixs.yaml\n",
-      "Loading schema human_gut from ../tests/test_utils/input/mixs/mixs.yaml\n",
-      "Loading schema human_associated from ../tests/test_utils/input/mixs/mixs.yaml\n",
-      "Loading schema host_associated from ../tests/test_utils/input/mixs/mixs.yaml\n",
-      "Loading schema built_environment from ../tests/test_utils/input/mixs/mixs.yaml\n",
-      "Loading schema air from ../tests/test_utils/input/mixs/mixs.yaml\n",
-      "Loading schema core from ../tests/test_utils/input/mixs/mixs.yaml\n",
-      "Loading schema checklists from ../tests/test_utils/input/mixs/mixs.yaml\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "609"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
     "len(view.all_slots())"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": 10,
    "id": "98f7305b",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['water',\n",
-       " 'quantity value',\n",
-       " 'wastewater_sludge',\n",
-       " 'soil',\n",
-       " 'sediment',\n",
-       " 'plant-associated',\n",
-       " 'miscellaneous natural or artificial environment',\n",
-       " 'microbial mat_biofilm',\n",
-       " 'hydrocarbon resources-fluids_swabs',\n",
-       " 'hydrocarbon resources-cores']"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
     "list(view.all_classes().keys())[0:10]"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": 19,
    "id": "84e6ff27",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "False"
-      ]
-     },
-     "execution_count": 19,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
     "view.get_slot('elev').required is True"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": 20,
    "id": "cf892380",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 20,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
     "view.induced_slot('elev', 'soil').required is True"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": 21,
    "id": "735859e1",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "False"
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
     "view.induced_slot('elev', 'human-gut').required is True"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": 23,
    "id": "ff33091c",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'Minimum Information About an Uncultivated Virus Genome'"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
     "view.get_class('MIUVIG').description"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": 25,
    "id": "11a0226e",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "['MIUVIG',\n",
-       " 'air MIUVIG',\n",
-       " 'built environment MIUVIG',\n",
-       " 'host-associated MIUVIG',\n",
-       " 'human-associated MIUVIG',\n",
-       " 'human-gut MIUVIG',\n",
-       " 'human-oral MIUVIG',\n",
-       " 'human-skin MIUVIG',\n",
-       " 'human-vaginal MIUVIG',\n",
-       " 'hydrocarbon resources-cores MIUVIG',\n",
-       " 'hydrocarbon resources-fluids_swabs MIUVIG',\n",
-       " 'microbial mat_biofilm MIUVIG',\n",
-       " 'miscellaneous natural or artificial environment MIUVIG',\n",
-       " 'plant-associated MIUVIG',\n",
-       " 'sediment MIUVIG',\n",
-       " 'soil MIUVIG',\n",
-       " 'wastewater_sludge MIUVIG',\n",
-       " 'water MIUVIG']"
-      ]
-     },
-     "execution_count": 25,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
     "view.class_descendants('MIUVIG')"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": 26,
    "id": "4656e62b",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 26,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
     "view.induced_slot('vir_ident_software', 'MIUVIG').required is True"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": 27,
    "id": "2e103d35",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 27,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
     "view.induced_slot('vir_ident_software', 'soil MIUVIG').required is True"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": 28,
    "id": "1b9d4bd2",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "False"
-      ]
-     },
-     "execution_count": 28,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
     "view.induced_slot('vir_ident_software', 'soil').required is True"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "1b8dcfa2",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [],
+   "outputs": []
   }
  ],
  "metadata": {

--- a/notebooks/SchemaView_Monarch.ipynb
+++ b/notebooks/SchemaView_Monarch.ipynb
@@ -5,41 +5,31 @@
    "execution_count": 1,
    "id": "3e37f9e6",
    "metadata": {},
-   "outputs": [],
    "source": [
     "# what biolink:category does my identifier represent\n",
     "# how to find the predicates used for gene to disease mappings\n"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": 14,
    "id": "169c9e40",
    "metadata": {},
-   "outputs": [],
    "source": [
     "from linkml_runtime.utils.schemaview import SchemaView\n",
     "import requests \n",
     "from pprint import pprint\n",
     "# note you can also use a path on a local filesystem\n",
     "view = SchemaView(\"https://raw.githubusercontent.com/biolink/biolink-model/master/biolink-model.yaml\")"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": 15,
    "id": "54424ac5",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "<class 'linkml_runtime.linkml_model.meta.ClassDefinition'>\n",
-      "phenotype of\n"
-     ]
-    }
-   ],
    "source": [
     "# what biolink:category does my identifier represent?\n",
     "# id_prefixes\n",
@@ -50,92 +40,50 @@
     "\n",
     "element = view.get_element('phenotype of')\n",
     "print(element.name)\n"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": 16,
    "id": "61eeb009",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "inverse is: has phenotype\n"
-     ]
-    }
-   ],
    "source": [
     "# find inverses of a predicate\n",
     "print(\"inverse is: \" + view.inverse(element.name))"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": 17,
    "id": "91212ad9",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['disease']\n"
-     ]
-    }
-   ],
    "source": [
     "# id_prefixes\n",
     "prefixed_categories = view.get_elements_applicable_by_identifier(\"DOID:4\")\n",
     "print(prefixed_categories)"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": 18,
    "id": "49d364e9",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "['is missense variant of']\n"
-     ]
-    }
-   ],
    "source": [
     "# mappings \n",
     "\n",
     "mapped_categories = view.get_category_by_mapping('SO:0001583')\n",
     "print(mapped_categories)\n"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": 21,
    "id": "a7a0fa3f",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "GENO:0000002\n",
-      "description: An allele that varies in its sequence from what is considered the reference allele at that locus.\n",
-      "\n",
-      "OLS description: An allele that varies in it sequence from what is considered the reference or canonical sequence at that location.\n",
-      "WIKIDATA:Q15304597: can't find any matching terms in OLS that don't return 404 errors\n",
-      "SIO:010277: can't find any matching terms in OLS that don't return 404 errors\n",
-      "VMC:Allele: can't find any matching terms in OLS that don't return 404 errors\n",
-      "SO:0001059\n",
-      "description: An allele that varies in its sequence from what is considered the reference allele at that locus.\n",
-      "\n",
-      "OLS description: A sequence_alteration is a sequence_feature whose extent is the deviation from another sequence.\n"
-     ]
-    }
-   ],
    "source": [
     "# object = 'gene'\n",
     "# object = 'disease'\n",
@@ -164,90 +112,41 @@
     "    else:\n",
     "        print(exact_mapping + \": can't find any matching terms in OLS that don't return 404 errors\")\n",
     "     "
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": 10,
    "id": "5fbbc1c1",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "True"
-      ]
-     },
-     "execution_count": 10,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
     "# is my element a mixin?\n",
     "\n",
     "e = view.get_element('gene or gene product')\n",
     "view.is_mixin(e.name)"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": 22,
    "id": "5ab2f5c3",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "gene\n",
-      "gene or gene product\n",
-      "genomic entity\n",
-      "chemical entity or gene or gene product\n",
-      "physical essence\n",
-      "ontology class\n",
-      "biological entity\n",
-      "named thing\n",
-      "entity\n",
-      "physical essence or occurrent\n",
-      "thing with taxon\n",
-      "macromolecular machine mixin\n"
-     ]
-    }
-   ],
    "source": [
     "# view poly hierarchy - a gene is a chemical and biological entity\n",
     "\n",
     "ancestors = view.class_ancestors('gene')\n",
     "for a in ancestors:\n",
     "    print(a)\n"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": 23,
    "id": "2f9e0c55",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "72\n",
-      "gene to gene association\n",
-      "gene to gene homology association\n",
-      "gene to gene coexpression association\n",
-      "gene to phenotypic feature association\n",
-      "gene to disease association\n",
-      "gene as a model of disease association\n",
-      "gene has variant that contributes to disease association\n",
-      "gene to expression site association\n",
-      "gene to go term association\n",
-      "gene to gene product relationship\n",
-      "gene regulatory relationship\n"
-     ]
-    }
-   ],
    "source": [
     "# how to find the predicates used for gene to disease mappings\n",
     "# association:   \n",
@@ -262,27 +161,14 @@
     "for a in associations:\n",
     "    if a.startswith('gene'):\n",
     "        print(a)\n"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": 26,
    "id": "2779d0d9",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "gene to disease association\n",
-      "SlotDefinition(name='subject', id_prefixes=[], definition_uri=None, aliases=[], local_names={'ga4gh': LocalName(local_name_source='ga4gh', local_name_value='annotation subject'), 'neo4j': LocalName(local_name_source='neo4j', local_name_value='node with outgoing relationship')}, conforms_to=None, mappings=[], exact_mappings=['owl:annotatedSource', 'OBAN:association_has_subject'], close_mappings=[], related_mappings=[], narrow_mappings=[], broad_mappings=[], extensions={}, annotations={}, description='gene in which variation is correlated with the disease, may be protective or causative or associative, or as a model', alt_descriptions={}, title=None, deprecated=None, todos=[], notes=[], comments=[], examples=[], in_subset=[], from_schema='https://w3id.org/biolink/biolink-model', imported_from=None, see_also=[], deprecated_element_has_exact_replacement=None, deprecated_element_has_possible_replacement=None, is_a='association slot', abstract=None, mixin=None, mixins=[], apply_to=[], values_from=[], created_by=None, created_on=None, last_updated_on=None, modified_by=None, status=None, string_serialization=None, singular_name=None, domain=None, slot_uri='rdf:subject', multivalued=None, inherited=None, readonly=None, ifabsent=None, inlined=None, inlined_as_list=None, key=None, identifier=None, designates_type=None, alias=None, owner='gene to disease association', domain_of=[], subproperty_of=None, symmetric=None, inverse=None, is_class_field=None, role=None, is_usage_slot=None, usage_slot_name=None, range='gene or gene product', range_expression=None, required=True, recommended=None, minimum_value=None, maximum_value=None, pattern=None, equals_string=None, equals_string_in=[], equals_number=None, equals_expression=None, minimum_cardinality=None, maximum_cardinality=None, has_member=None, all_members={}, none_of=[], exactly_one_of=[], any_of=[], all_of=[])\n",
-      "gene as a model of disease association\n",
-      "SlotDefinition(name='subject', id_prefixes=[], definition_uri=None, aliases=[], local_names={'ga4gh': LocalName(local_name_source='ga4gh', local_name_value='annotation subject'), 'neo4j': LocalName(local_name_source='neo4j', local_name_value='node with outgoing relationship')}, conforms_to=None, mappings=[], exact_mappings=['owl:annotatedSource', 'OBAN:association_has_subject'], close_mappings=[], related_mappings=[], narrow_mappings=[], broad_mappings=[], extensions={}, annotations={}, description='A gene that has a role in modeling the disease. This may be a model organism ortholog of a known disease gene, or it may be a gene whose mutants recapitulate core features of the disease.', alt_descriptions={}, title=None, deprecated=None, todos=[], notes=[], comments=[], examples=[], in_subset=[], from_schema='https://w3id.org/biolink/biolink-model', imported_from=None, see_also=[], deprecated_element_has_exact_replacement=None, deprecated_element_has_possible_replacement=None, is_a='association slot', abstract=None, mixin=None, mixins=[], apply_to=[], values_from=[], created_by=None, created_on=None, last_updated_on=None, modified_by=None, status=None, string_serialization=None, singular_name=None, domain=None, slot_uri='rdf:subject', multivalued=None, inherited=None, readonly=None, ifabsent=None, inlined=None, inlined_as_list=None, key=None, identifier=None, designates_type=None, alias=None, owner='gene as a model of disease association', domain_of=[], subproperty_of=None, symmetric=None, inverse=None, is_class_field=None, role=None, is_usage_slot=None, usage_slot_name=None, range='gene or gene product', range_expression=None, required=True, recommended=None, minimum_value=None, maximum_value=None, pattern=None, equals_string=None, equals_string_in=[], equals_number=None, equals_expression=None, minimum_cardinality=None, maximum_cardinality=None, has_member=None, all_members={}, none_of=[], exactly_one_of=[], any_of=[], all_of=[])\n",
-      "gene has variant that contributes to disease association\n",
-      "SlotDefinition(name='subject', id_prefixes=[], definition_uri=None, aliases=[], local_names={'ga4gh': LocalName(local_name_source='ga4gh', local_name_value='annotation subject'), 'neo4j': LocalName(local_name_source='neo4j', local_name_value='node with outgoing relationship')}, conforms_to=None, mappings=[], exact_mappings=['owl:annotatedSource', 'OBAN:association_has_subject'], close_mappings=[], related_mappings=[], narrow_mappings=[], broad_mappings=[], extensions={}, annotations={}, description='A gene that has a role in modeling the disease. This may be a model organism ortholog of a known disease gene, or it may be a gene whose mutants recapitulate core features of the disease.', alt_descriptions={}, title=None, deprecated=None, todos=[], notes=[], comments=[], examples=[], in_subset=[], from_schema='https://w3id.org/biolink/biolink-model', imported_from=None, see_also=[], deprecated_element_has_exact_replacement=None, deprecated_element_has_possible_replacement=None, is_a='association slot', abstract=None, mixin=None, mixins=[], apply_to=[], values_from=[], created_by=None, created_on=None, last_updated_on=None, modified_by=None, status=None, string_serialization=None, singular_name=None, domain=None, slot_uri='rdf:subject', multivalued=None, inherited=None, readonly=None, ifabsent=None, inlined=None, inlined_as_list=None, key=None, identifier=None, designates_type=None, alias=None, owner='gene has variant that contributes to disease association', domain_of=[], subproperty_of=None, symmetric=None, inverse=None, is_class_field=None, role=None, is_usage_slot=None, usage_slot_name=None, range='gene or gene product', range_expression=None, required=True, recommended=None, minimum_value=None, maximum_value=None, pattern=None, equals_string=None, equals_string_in=[], equals_number=None, equals_expression=None, minimum_cardinality=None, maximum_cardinality=None, has_member=None, all_members={}, none_of=[], exactly_one_of=[], any_of=[], all_of=[])\n"
-     ]
-    }
-   ],
    "source": [
     "for association in associations:\n",
     "    domain_element = view.get_element(view.induced_slot('subject', association).range)\n",
@@ -294,28 +180,29 @@
     "    if 'gene or gene product' in view.class_ancestors(domain_element.name) and 'disease' in view.class_ancestors(range_element.name):\n",
     "        print(association)\n",
     "        print(view.induced_slot('subject', association))\n"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "04093dc5",
    "metadata": {},
-   "outputs": [],
    "source": [
     "# find predicates for those associations\n",
     "# at this point, navigating the online doc might be easiest if you just want answers. \n",
     "# programatically, we can get the predicates that have equivalent domain and range constraints to find which \n",
     "# coudl be used for associations above.\n"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "6c8ade22",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [],
+   "outputs": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
This pull-request is necessary for https://github.com/linkml/linkml/pull/2175 as the documentation and metadata has been modified by the fact the `linkml_runtime.utils.ifabsent_functions` have been deleted.

The new enum default value support has also been documented in this pull-request.