### PR TITLE
Make induced_slot recursive

### DIFF
--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -1343,7 +1343,7 @@ class SchemaView(object):
                              "or as a slot definition in the schema")
 
         # copy the slot, as it will be modified
-        induced_slot = SlotDefinition(**remove_empty_items(slot))
+        induced_slot = SlotDefinition(**{k:v for k,v in slot.__dict__.items() if v})
 
         # propagate inheritable_slots from ancestors
         if not slot_comes_from_attribute:

--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -1343,7 +1343,7 @@ class SchemaView(object):
                              "or as a slot definition in the schema")
 
         # copy the slot, as it will be modified
-        induced_slot = deepcopy(slot)
+        induced_slot = SlotDefinition(**remove_empty_items(slot))
 
         # propagate inheritable_slots from ancestors
         if not slot_comes_from_attribute:

--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -1343,7 +1343,7 @@ class SchemaView(object):
                              "or as a slot definition in the schema")
 
         # copy the slot, as it will be modified
-        induced_slot = copy(slot)
+        induced_slot = deepcopy(slot)
 
         # propagate inheritable_slots from ancestors
         if not slot_comes_from_attribute:

--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -6,7 +6,7 @@ from functools import lru_cache
 from copy import copy, deepcopy
 from collections import defaultdict, deque
 from pathlib import Path
-from typing import Mapping, Tuple, TypeVar
+from typing import Mapping, Optional, Tuple, TypeVar
 import warnings
 
 from linkml_runtime.utils.namespaces import Namespaces
@@ -144,6 +144,11 @@ class SchemaView(object):
     modifications: int = 0
     uuid: str = None
 
+    ## private vars --------
+    # cached hash
+    _hash: Optional[int] = None
+
+
     def __init__(self, schema: Union[str, Path, SchemaDefinition],
                  importmap: Optional[Dict[str, str]] = None, merge_imports: bool = False, base_dir: str = None):
         if isinstance(schema, Path):
@@ -165,8 +170,10 @@ class SchemaView(object):
             return self.__key() == other.__key()
         return NotImplemented
 
-    def __hash__(self):
-        return hash(self.__key())
+    def __hash__(self) -> int:
+        if self._hash is None:
+            self._hash = hash(self.__key())
+        return self._hash
 
     @lru_cache(None)
     def namespaces(self) -> Namespaces:
@@ -1825,6 +1832,7 @@ class SchemaView(object):
         return s2
 
     def set_modified(self) -> None:
+        self._hash = None
         self.modifications += 1
 
     def materialize_patterns(self) -> None:


### PR DESCRIPTION
Related to: https://github.com/linkml/linkml/issues/2219
and all the other times i gone and talked about making schemaview recursive.

Two main things we're trying to do here:
- make it go faster
- make it be more predictable

THere are a lot of places where schemaview will iterate over the whole schema in some way, sometimes in nested ways. We get a lot of mileage out of caching, but it also places some functional barriers in front of us where nonlocal effects become hard to diagnose, things get very bound up together, and implementing stuff like structured imports where we have to be able to handle lots of layers of different schemas with long inheritance chains gets v hard to do.

`induced_slot` is like my white whale, it takes an outsized amount of time because of the amount of checking up and down inheritance trees needs to get done, and it's also a critical stepping stone that we are sure is rock solid in order to make it never be in doubt whether we're looking at "the right" model class/etc. It's currently in some exponential time complexity state because for each slot for each class one needs to check the entire inheritance tree. 

This is a start in the direction of a schemaview that only looks one step out at a time, recursively, so each step can be simpler. There are some bugs that i caused, and there are also some bugs that i think i am revealing (but have to figure out what they mean first), so it's not ready for review, but opening this as a draft. The general strategy is just that - to only look at the immediate parents of slots and classes so each slot/class combination is induced exactly once. in doing so, i am trying to keep each object as minimal as possible any only touch what is defined at each stage, but some of the methods of doing so are a bit costly, and i also am not sure about where to put the mutation guards yet so there are some missed/unnecessary copies done, but that's all tbd.

anyway here ya go, will return later. 

perf status

current state of `linkml` and `linkml-runtime` (run on all non-slow tests, so the different would probably be greater since in the slow tests is where it gets really expensive)

<img width="738" alt="Screenshot 2024-07-24 at 1 51 43 AM" src="https://github.com/user-attachments/assets/0687c6c2-2221-4ce0-825e-c3270f21d050">

this pr:

<img width="723" alt="Screenshot 2024-07-24 at 1 51 52 AM" src="https://github.com/user-attachments/assets/f4387871-b59e-4dc8-87b6-79f4c433106b">

sort of weird result to me that there is 3.1s total time spent in the body of the function but snakeviz is showing 40s all collected there, probably just a visualization bug tho



