### PR TITLE
fix upstream test action

### DIFF
--- a/.github/workflows/test-upstream.yaml
+++ b/.github/workflows/test-upstream.yaml
@@ -11,18 +11,9 @@ jobs:
       matrix:
         os: [ ubuntu-latest, windows-latest ]
         python-version: [ "3.8", "3.9", "3.10", "3.11" ]
-        pydantic-version: [ "1", "2" ]
         exclude:
           - os: windows-latest
             python-version: "3.8"
-          - os: windows-latest
-            pydantic-version: "1"
-          - python-version: "3.8"
-            pydantic-version: "1"
-          - python-version: "3.9"
-            pydantic-version: "1"
-          - python-version: "3.10"
-            pydantic-version: "1"
     runs-on: ${{ matrix.os }}
     env:
       POETRY_VIRTUALENVS_IN_PROJECT: true
@@ -80,11 +71,6 @@ jobs:
       - name: add linkml-runtime to lockfile
         working-directory: linkml
         run: poetry add ../linkml-runtime
-
-      # use correct pydantic version
-      - name: install pydantic
-        working-directory: linkml
-        run: poetry add pydantic@^${{ matrix.pydantic-version }}
 
       # note that we run the installation step always, even if we restore a venv,
       # the cache will restore the old version of linkml-runtime, but the lockfile

--- a/.github/workflows/test-upstream.yaml
+++ b/.github/workflows/test-upstream.yaml
@@ -61,9 +61,6 @@ jobs:
           virtualenvs-create: true
           virtualenvs-in-project: true
 
-      - name: Install dynamic versioning plugin
-        run: poetry self add "poetry-dynamic-versioning[plugin]"
-
       - name: Load cached venv
         id: cached-poetry-dependencies
         uses: actions/cache@v3

--- a/.github/workflows/test-upstream.yaml
+++ b/.github/workflows/test-upstream.yaml
@@ -13,7 +13,11 @@ jobs:
         python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
         exclude:
           - os: windows-latest
-            python-version: "3.8"
+            python-version: "3.9"
+          - os: windows-latest
+            python-version: "3.10"
+          - os: windows-latest
+            python-version: "3.11"
     runs-on: ${{ matrix.os }}
     env:
       POETRY_VIRTUALENVS_IN_PROJECT: true

--- a/.github/workflows/test-upstream.yaml
+++ b/.github/workflows/test-upstream.yaml
@@ -24,6 +24,8 @@ jobs:
           - python-version: "3.10"
             pydantic-version: "1"
     runs-on: ${{ matrix.os }}
+    env:
+      POETRY_VIRTUALENVS_IN_PROJECT: true
 
     steps:
 
@@ -55,11 +57,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: install poetry
-        uses: snok/install-poetry@v1
-        with:
-          virtualenvs-create: true
-          virtualenvs-in-project: true
+      - name: Install poetry
+        run: pipx install poetry
+
+      - name: Install dynamic versioning plugin
+        run: poetry self add "poetry-dynamic-versioning[plugin]"
 
       - name: Load cached venv
         id: cached-poetry-dependencies

--- a/.github/workflows/test-upstream.yaml
+++ b/.github/workflows/test-upstream.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest ]
-        python-version: [ "3.8", "3.9", "3.10", "3.11" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]
         exclude:
           - os: windows-latest
             python-version: "3.8"

--- a/.github/workflows/test-upstream.yaml
+++ b/.github/workflows/test-upstream.yaml
@@ -43,6 +43,13 @@ jobs:
           path: linkml-runtime
           fetch-depth: 0
 
+      - name: Ensure tags if not run from main repo
+        if: github.repository != 'linkml/linkml-runtime'
+        working-directory: linkml-runtime
+        run: |
+          git remote add upstream https://github.com/linkml/linkml-runtime
+          git fetch upstream --tags
+
       - name: set up python
         uses: actions/setup-python@v5
         with:
@@ -53,6 +60,9 @@ jobs:
         with:
           virtualenvs-create: true
           virtualenvs-in-project: true
+
+      - name: Install dynamic versioning plugin
+        run: poetry self add "poetry-dynamic-versioning[plugin]"
 
       - name: Load cached venv
         id: cached-poetry-dependencies


### PR DESCRIPTION
for the love of god.

this seems to work now: https://github.com/sneakers-the-rat/linkml-runtime/actions/runs/10106060261

basically the same thing as upstream `linkml` - pull requests come from different repositories, and forking doesn't necessarily bring the tags along with it. also the dynamic versioning plugin doesn't do a good job of installing itself when requested in `pyproject.toml`

also:
- made python versions and exclusions match upstream `linkml` main tests
- remove pydantic 1 tests