### PR TITLE
Handle attributes edge case in schema_as_dict

### DIFF
--- a/linkml_runtime/utils/schema_as_dict.py
+++ b/linkml_runtime/utils/schema_as_dict.py
@@ -42,7 +42,7 @@ def _remove_names(obj: Any, parent: Optional[str]) -> Any:
     :return:
     """
     if isinstance(obj, dict):
-        return {k: _remove_names(v, k) for k, v in obj.items() if k != 'name' or parent is None or parent in ['slots', 'slot_usage']}
+        return {k: _remove_names(v, k) for k, v in obj.items() if k != 'name' or parent is None or parent in ['slots', 'slot_usage', 'attributes']}
     elif isinstance(obj, list):
         return [_remove_names(x, parent) for x in obj]
     else:

--- a/tests/test_utils/test_schema_as_dict.py
+++ b/tests/test_utils/test_schema_as_dict.py
@@ -7,6 +7,7 @@ from linkml_runtime.linkml_model.meta import SchemaDefinition, ClassDefinition
 from linkml_runtime.loaders.yaml_loader import YAMLLoader
 from linkml_runtime.utils.schema_as_dict import schema_as_yaml_dump, schema_as_dict
 from linkml_runtime.utils.schemaview import SchemaView
+from linkml_runtime.utils.schema_builder import ClassDefinition, SchemaBuilder, SlotDefinition
 
 from tests.test_utils import INPUT_DIR, OUTPUT_DIR
 
@@ -44,6 +45,32 @@ class SchemaAsDictTestCase(unittest.TestCase):
                     for pv in e.get('permissible_values', {}).values():
                         assert 'text' not in pv
         self.assertIn('name', obj['slots'])
+
+
+    def test_as_dict_with_attributes(self):
+        """
+        tests schema_as_dict, see https://github.com/linkml/linkml/issues/100
+        """
+
+        # Create a class with an attribute named 'name'
+        cls = ClassDefinition(name="Patient")
+        slots = [
+            SlotDefinition(name="id", range="string"),
+            SlotDefinition(name="name", range="string"),
+        ]
+        builder = SchemaBuilder()
+        builder.add_class(cls=cls, slots=slots, use_attributes=True)
+
+        # Verify that the 'name' slot exists in the schema
+        view = SchemaView(builder.schema)
+        self.assertIn('name', view.all_slots())
+
+        # Convert the schema to a dict
+        obj = schema_as_dict(view.schema)
+
+        # Verify that the 'name' slot still exists, as an attribute
+        self.assertIn('name', obj['classes']['Patient']['attributes'])
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
When using SchemaBuilder, any slots defined with name="name", will be removed by the schema_as_dict function, if the slot was added to a class using the use_attributes=True flag.

See issue: https://github.com/linkml/linkml/issues/2247