### PR TITLE
BF: Fix bug and other improvement in `SchemaBuilder.add_class()`

### DIFF
--- a/linkml_runtime/utils/schema_builder.py
+++ b/linkml_runtime/utils/schema_builder.py
@@ -66,6 +66,7 @@ class SchemaBuilder:
 
         :param cls: name, dict object, or ClassDefinition object to add
         :param slots: slot of slot names or slot objects.
+            Note: If `use_attributes=True`, then this must be a list of SlotDefinitions
         :param slot_usage: slots keyed by slot name
         :param replace_if_present: if True, replace existing class if present
         :param kwargs: additional ClassDefinition properties
@@ -76,10 +77,14 @@ class SchemaBuilder:
             cls = ClassDefinition(cls, **kwargs)
         if isinstance(cls, dict):
             cls = ClassDefinition(**{**cls, **kwargs})
-        if cls.name is self.schema.classes and not replace_if_present:
+        if cls.name in self.schema.classes and not replace_if_present:
             raise ValueError(f"Class {cls.name} already exists")
         self.schema.classes[cls.name] = cls
         if use_attributes:
+            if not isinstance(slots, list):
+                raise ValueError(
+                    "If `use_attributes=True`, then `slots` must be a list."
+                )
             for s in slots:
                 if isinstance(s, SlotDefinition):
                     cls.attributes[s.name] = s
@@ -98,8 +103,6 @@ class SchemaBuilder:
             if slot_usage:
                 for k, v in slot_usage.items():
                     cls.slot_usage[k] = v
-        for k, v in kwargs.items():
-            setattr(cls, k, v)
         return self
 
     def add_slot(

--- a/linkml_runtime/utils/schema_builder.py
+++ b/linkml_runtime/utils/schema_builder.py
@@ -70,7 +70,8 @@ class SchemaBuilder:
         :param replace_if_present: if True, replace existing class if present
         :param use_attributes: Whether to specify the given slots as an inline
             definition of slots, attributes, in the class definition
-        :param kwargs: additional ClassDefinition properties
+        :param kwargs: additional ClassDefinition properties (ignored if `cls` is a
+            `ClassDefinition`)
         :return: builder
         :raises ValueError: if class already exists and replace_if_present=False
         """

--- a/linkml_runtime/utils/schema_builder.py
+++ b/linkml_runtime/utils/schema_builder.py
@@ -80,13 +80,14 @@ class SchemaBuilder:
             raise ValueError(f"Class {cls.name} already exists")
         self.schema.classes[cls.name] = cls
         if use_attributes:
-            for s in slots:
-                if isinstance(s, SlotDefinition):
-                    cls.attributes[s.name] = s
-                else:
-                    raise ValueError(
-                        f"If use_attributes=True then slots must be SlotDefinitions"
-                    )
+            if slots is not None:
+                for s in slots:
+                    if isinstance(s, SlotDefinition):
+                        cls.attributes[s.name] = s
+                    else:
+                        raise ValueError(
+                            f"If use_attributes=True then slots must be SlotDefinitions"
+                        )
         else:
             if slots is not None:
                 for s in slots:

--- a/linkml_runtime/utils/schema_builder.py
+++ b/linkml_runtime/utils/schema_builder.py
@@ -16,7 +16,7 @@ class SchemaBuilder:
 
     Example:
 
-        >>> from linkml.utils.schema_builder import SchemaBuilder
+        >>> from linkml_runtime.utils.schema_builder import SchemaBuilder
         >>> sb = SchemaBuilder('test-schema')
         >>> sb.add_class('Person', slots=['name', 'age'])
         >>> sb.add_class('Organization', slots=['name', 'employees'])

--- a/linkml_runtime/utils/schema_builder.py
+++ b/linkml_runtime/utils/schema_builder.py
@@ -65,7 +65,8 @@ class SchemaBuilder:
         Adds a class to the schema.
 
         :param cls: name, dict object, or ClassDefinition object to add
-        :param slots: slot of slot names or slot objects.
+        :param slots: list of slot names or slot objects. This must be a list of
+            `SlotDefinition` objects if `use_attributes=True`
         :param slot_usage: slots keyed by slot name (ignored if `use_attributes=True`)
         :param replace_if_present: if True, replace existing class if present
         :param use_attributes: Whether to specify the given slots as an inline

--- a/linkml_runtime/utils/schema_builder.py
+++ b/linkml_runtime/utils/schema_builder.py
@@ -80,8 +80,6 @@ class SchemaBuilder:
             raise ValueError(f"Class {cls.name} already exists")
         self.schema.classes[cls.name] = cls
         if use_attributes:
-            if not isinstance(slots, list):
-                slots = [slots]
             for s in slots:
                 if isinstance(s, SlotDefinition):
                     cls.attributes[s.name] = s

--- a/linkml_runtime/utils/schema_builder.py
+++ b/linkml_runtime/utils/schema_builder.py
@@ -66,8 +66,10 @@ class SchemaBuilder:
 
         :param cls: name, dict object, or ClassDefinition object to add
         :param slots: slot of slot names or slot objects.
-        :param slot_usage: slots keyed by slot name
+        :param slot_usage: slots keyed by slot name (ignored if `use_attributes=True`)
         :param replace_if_present: if True, replace existing class if present
+        :param use_attributes: Whether to specify the given slots as an inline definition of
+            slots, attributes, in the class definition
         :param kwargs: additional ClassDefinition properties
         :return: builder
         :raises ValueError: if class already exists and replace_if_present=False

--- a/linkml_runtime/utils/schema_builder.py
+++ b/linkml_runtime/utils/schema_builder.py
@@ -66,7 +66,6 @@ class SchemaBuilder:
 
         :param cls: name, dict object, or ClassDefinition object to add
         :param slots: slot of slot names or slot objects.
-            Note: If `use_attributes=True`, then this must be a list of SlotDefinitions
         :param slot_usage: slots keyed by slot name
         :param replace_if_present: if True, replace existing class if present
         :param kwargs: additional ClassDefinition properties
@@ -82,9 +81,7 @@ class SchemaBuilder:
         self.schema.classes[cls.name] = cls
         if use_attributes:
             if not isinstance(slots, list):
-                raise ValueError(
-                    "If `use_attributes=True`, then `slots` must be a list."
-                )
+                slots = [slots]
             for s in slots:
                 if isinstance(s, SlotDefinition):
                     cls.attributes[s.name] = s

--- a/linkml_runtime/utils/schema_builder.py
+++ b/linkml_runtime/utils/schema_builder.py
@@ -76,6 +76,11 @@ class SchemaBuilder:
         :return: builder
         :raises ValueError: if class already exists and replace_if_present=False
         """
+        if slots is None:
+            slots = []
+        if slot_usage is None:
+            slot_usage = {}
+
         if isinstance(cls, str):
             cls = ClassDefinition(cls, **kwargs)
         if isinstance(cls, dict):
@@ -84,25 +89,22 @@ class SchemaBuilder:
             raise ValueError(f"Class {cls.name} already exists")
         self.schema.classes[cls.name] = cls
         if use_attributes:
-            if slots is not None:
-                for s in slots:
-                    if isinstance(s, SlotDefinition):
-                        cls.attributes[s.name] = s
-                    else:
-                        raise ValueError(
-                            f"If use_attributes=True then slots must be SlotDefinitions"
-                        )
+            for s in slots:
+                if isinstance(s, SlotDefinition):
+                    cls.attributes[s.name] = s
+                else:
+                    raise ValueError(
+                        f"If use_attributes=True then slots must be SlotDefinitions"
+                    )
         else:
-            if slots is not None:
-                for s in slots:
-                    cls.slots.append(s.name if isinstance(s, SlotDefinition) else s)
-                    if isinstance(s, str) and s in self.schema.slots:
-                        # top-level slot already exists
-                        continue
-                    self.add_slot(s, replace_if_present=replace_if_present)
-            if slot_usage:
-                for k, v in slot_usage.items():
-                    cls.slot_usage[k] = v
+            for s in slots:
+                cls.slots.append(s.name if isinstance(s, SlotDefinition) else s)
+                if isinstance(s, str) and s in self.schema.slots:
+                    # top-level slot already exists
+                    continue
+                self.add_slot(s, replace_if_present=replace_if_present)
+            for k, v in slot_usage.items():
+                cls.slot_usage[k] = v
         return self
 
     def add_slot(

--- a/linkml_runtime/utils/schema_builder.py
+++ b/linkml_runtime/utils/schema_builder.py
@@ -57,8 +57,8 @@ class SchemaBuilder:
         cls: Union[ClassDefinition, Dict, str],
         slots: List[Union[str, SlotDefinition]] = None,
         slot_usage: Dict[str, SlotDefinition] = None,
-        replace_if_present=False,
-        use_attributes=False,
+        replace_if_present: bool = False,
+        use_attributes: bool = False,
         **kwargs,
     ) -> "SchemaBuilder":
         """

--- a/linkml_runtime/utils/schema_builder.py
+++ b/linkml_runtime/utils/schema_builder.py
@@ -68,8 +68,8 @@ class SchemaBuilder:
         :param slots: slot of slot names or slot objects.
         :param slot_usage: slots keyed by slot name (ignored if `use_attributes=True`)
         :param replace_if_present: if True, replace existing class if present
-        :param use_attributes: Whether to specify the given slots as an inline definition of
-            slots, attributes, in the class definition
+        :param use_attributes: Whether to specify the given slots as an inline
+            definition of slots, attributes, in the class definition
         :param kwargs: additional ClassDefinition properties
         :return: builder
         :raises ValueError: if class already exists and replace_if_present=False

--- a/tests/test_utils/test_schema_builder.py
+++ b/tests/test_utils/test_schema_builder.py
@@ -1,0 +1,30 @@
+import pytest
+
+from linkml_runtime.utils.schema_builder import SchemaBuilder
+from linkml_runtime.linkml_model import ClassDefinition
+
+
+@pytest.mark.parametrize("replace_if_present", [True, False])
+def test_add_existing_class(replace_if_present):
+    """
+    Test the case of adding a class with a name that is the same as a class that already
+    exists in the schema
+    """
+    builder = SchemaBuilder()
+
+    cls_name = "Person"
+
+    # Add a class to the schema
+    cls = ClassDefinition(name=cls_name, slots=["name"])
+    builder.add_class(cls)
+
+    # Add another class with the same name to the schema
+    cls_repeat = ClassDefinition(name=cls_name, slots=["age"])
+
+    if replace_if_present:
+        builder.add_class(cls_repeat, replace_if_present=True)
+        assert builder.schema.classes[cls_name].slots == ["age"]
+    else:
+        with pytest.raises(ValueError, match=f"Class {cls_name} already exists"):
+            builder.add_class(cls_repeat)
+        assert builder.schema.classes[cls_name].slots == ["name"]

--- a/tests/test_utils/test_schema_builder.py
+++ b/tests/test_utils/test_schema_builder.py
@@ -1,7 +1,9 @@
+from typing import Optional, List, Union
+
 import pytest
 
 from linkml_runtime.utils.schema_builder import SchemaBuilder
-from linkml_runtime.linkml_model import ClassDefinition
+from linkml_runtime.linkml_model import ClassDefinition, SlotDefinition
 
 
 @pytest.mark.parametrize("replace_if_present", [True, False])
@@ -28,3 +30,51 @@ def test_add_existing_class(replace_if_present):
         with pytest.raises(ValueError, match=f"Class {cls_name} already exists"):
             builder.add_class(cls_repeat)
         assert builder.schema.classes[cls_name].slots == ["name"]
+
+
+@pytest.mark.parametrize(
+    "slots",
+    [
+        None,
+        ["name", "age"],
+        ["name", SlotDefinition(name="age")],
+        [SlotDefinition(name="name"), SlotDefinition(name="age")],
+    ],
+)
+@pytest.mark.parametrize("use_attributes", [True, False])
+def test_add_class_with_slot_additions(
+    slots: Optional[List[Union[str, SlotDefinition]]], use_attributes: bool
+):
+    """
+    Test adding a class with separate additional slots specification
+    """
+    # If `slots` is None, it should be treated as if it were an empty list
+    if slots is None:
+        slots = []
+
+    slot_names = {s if isinstance(s, str) else s.name for s in slots}
+
+    builder = SchemaBuilder()
+
+    cls_name = "Person"
+
+    # Add a class to the schema
+    cls = ClassDefinition(name=cls_name)
+
+    if use_attributes:
+        # === The case where the slots specified should be added to the `attributes`
+        # meta slot of the class ===
+        if any(not isinstance(s, SlotDefinition) for s in slots):
+            with pytest.raises(
+                ValueError,
+                match="If use_attributes=True then slots must be SlotDefinitions",
+            ):
+                builder.add_class(cls, slots=slots, use_attributes=use_attributes)
+        else:
+            builder.add_class(cls, slots=slots, use_attributes=use_attributes)
+            assert builder.schema.classes[cls_name].attributes.keys() == slot_names
+    else:
+        # === The case where the slots specified should be added to the `slots`
+        # meta slot of the schema ===
+        builder.add_class(cls, slots=slots, use_attributes=use_attributes)
+        assert builder.schema.slots.keys() == slot_names


### PR DESCRIPTION
This PR does the following.

1. Prevent the use of `kwargs` in setting the class to be added with an unacceptable attribute if `cls` is given as a `ClassDefinition` object (test provided)
2. Correct detection of duplicating classes. (test provided)
3. Handle the case `slots` is `None` while `use_attributes` is `True` (test provided)
4. Update the example in the doc string of `SchemaBuilder` to have the correct import statement (no test needed)
5. Provide documentation of the `use_attributes` param in the docstring (no test needed)
6. Give more informative documentation for the `slot_usage` param according to the behavior of existing code. (no test needed)
7. Provide type annotation to the `replace_if_present` and `use_attributes` params (no test needed)


Point 1 is included in this PR because the following lines are unneeded for the cases in which `cls` is given as a `dict` or `str` and are inconsistent with the behavior of `SchemaBuilder.add_slot()` and `SchemaBuilder.add_enum()`. In both `SchemaBuilder.add_slot()` and `SchemaBuilder.add_enum()`, if the first argument is of the target type, `SlotDefinition` and `EnumDefinition` respectively, `kwargs` is ignored.

https://github.com/linkml/linkml-runtime/blob/9fd5a3e374a1d1820da07a0e3d165b8f667033f4/linkml_runtime/utils/schema_builder.py#L101-L102