### PR TITLE
Fix deprecation warning - use model_dump not dict

### DIFF
--- a/linkml_runtime/dumpers/yaml_dumper.py
+++ b/linkml_runtime/dumpers/yaml_dumper.py
@@ -13,7 +13,7 @@ class YAMLDumper(Dumper):
         # Internal note: remove_empty_items will also convert Decimals to int/float;
         # this is necessary until https://github.com/yaml/pyyaml/pull/372 is merged
 
-        dumper_safe_element = element.dict() if isinstance(element, BaseModel) else element
+        dumper_safe_element = element.model_dump() if isinstance(element, BaseModel) else element
         return yaml.dump(remove_empty_items(dumper_safe_element, hide_protected_keys=True),
                          Dumper=yaml.SafeDumper, sort_keys=False, 
                          allow_unicode=True,


### PR DESCRIPTION
minor tidying - now that we don't support pydantic 1 anymore, we can update to pydantic 2 stuff. Currently we get an annoying deprecation warning from using `dict()`, so this fixes that.