### PR TITLE
BF: Bug fixes and other improvement in `SchemaBuilder.add_enum()`

### DIFF
--- a/linkml_runtime/utils/schema_builder.py
+++ b/linkml_runtime/utils/schema_builder.py
@@ -66,6 +66,7 @@ class SchemaBuilder:
 
         :param cls: name, dict object, or ClassDefinition object to add
         :param slots: slot of slot names or slot objects.
+            Note: If `use_attributes=True`, then this must be a list of SlotDefinitions
         :param slot_usage: slots keyed by slot name
         :param replace_if_present: if True, replace existing class if present
         :param kwargs: additional ClassDefinition properties
@@ -76,10 +77,14 @@ class SchemaBuilder:
             cls = ClassDefinition(cls, **kwargs)
         if isinstance(cls, dict):
             cls = ClassDefinition(**{**cls, **kwargs})
-        if cls.name is self.schema.classes and not replace_if_present:
+        if cls.name in self.schema.classes and not replace_if_present:
             raise ValueError(f"Class {cls.name} already exists")
         self.schema.classes[cls.name] = cls
         if use_attributes:
+            if not isinstance(slots, list):
+                raise ValueError(
+                    "If `use_attributes=True`, then `slots` must be a list."
+                )
             for s in slots:
                 if isinstance(s, SlotDefinition):
                     cls.attributes[s.name] = s
@@ -98,8 +103,6 @@ class SchemaBuilder:
             if slot_usage:
                 for k, v in slot_usage.items():
                     cls.slot_usage[k] = v
-        for k, v in kwargs.items():
-            setattr(cls, k, v)
         return self
 
     def add_slot(

--- a/linkml_runtime/utils/schema_builder.py
+++ b/linkml_runtime/utils/schema_builder.py
@@ -70,7 +70,8 @@ class SchemaBuilder:
         :param replace_if_present: if True, replace existing class if present
         :param use_attributes: Whether to specify the given slots as an inline
             definition of slots, attributes, in the class definition
-        :param kwargs: additional ClassDefinition properties
+        :param kwargs: additional ClassDefinition properties (ignored if `cls` is a
+            `ClassDefinition`)
         :return: builder
         :raises ValueError: if class already exists and replace_if_present=False
         """

--- a/linkml_runtime/utils/schema_builder.py
+++ b/linkml_runtime/utils/schema_builder.py
@@ -80,13 +80,14 @@ class SchemaBuilder:
             raise ValueError(f"Class {cls.name} already exists")
         self.schema.classes[cls.name] = cls
         if use_attributes:
-            for s in slots:
-                if isinstance(s, SlotDefinition):
-                    cls.attributes[s.name] = s
-                else:
-                    raise ValueError(
-                        f"If use_attributes=True then slots must be SlotDefinitions"
-                    )
+            if slots is not None:
+                for s in slots:
+                    if isinstance(s, SlotDefinition):
+                        cls.attributes[s.name] = s
+                    else:
+                        raise ValueError(
+                            f"If use_attributes=True then slots must be SlotDefinitions"
+                        )
         else:
             if slots is not None:
                 for s in slots:

--- a/linkml_runtime/utils/schema_builder.py
+++ b/linkml_runtime/utils/schema_builder.py
@@ -16,7 +16,7 @@ class SchemaBuilder:
 
     Example:
 
-        >>> from linkml.utils.schema_builder import SchemaBuilder
+        >>> from linkml_runtime.utils.schema_builder import SchemaBuilder
         >>> sb = SchemaBuilder('test-schema')
         >>> sb.add_class('Person', slots=['name', 'age'])
         >>> sb.add_class('Organization', slots=['name', 'employees'])

--- a/linkml_runtime/utils/schema_builder.py
+++ b/linkml_runtime/utils/schema_builder.py
@@ -189,7 +189,14 @@ class SchemaBuilder:
         for pv in permissible_values:
             if isinstance(pv, str):
                 pv = PermissibleValue(text=pv)
-                enum_def.permissible_values[pv.text] = pv
+            elif not isinstance(pv, PermissibleValue):
+                msg = (
+                    f"A permissible value must be a `str` or "
+                    f"a `PermissibleValue` object, not {type(pv)}"
+                )
+                raise TypeError(msg)
+
+            enum_def.permissible_values[pv.text] = pv
 
         return self
 

--- a/linkml_runtime/utils/schema_builder.py
+++ b/linkml_runtime/utils/schema_builder.py
@@ -65,7 +65,8 @@ class SchemaBuilder:
         Adds a class to the schema.
 
         :param cls: name, dict object, or ClassDefinition object to add
-        :param slots: slot of slot names or slot objects.
+        :param slots: list of slot names or slot objects. This must be a list of
+            `SlotDefinition` objects if `use_attributes=True`
         :param slot_usage: slots keyed by slot name (ignored if `use_attributes=True`)
         :param replace_if_present: if True, replace existing class if present
         :param use_attributes: Whether to specify the given slots as an inline

--- a/linkml_runtime/utils/schema_builder.py
+++ b/linkml_runtime/utils/schema_builder.py
@@ -184,6 +184,8 @@ class SchemaBuilder:
             enum_def = EnumDefinition(**{**enum_def, **kwargs})
         if enum_def.name in self.schema.enums and not replace_if_present:
             raise ValueError(f"Enum {enum_def.name} already exists")
+
+        # Attach the enum definition to the schema
         self.schema.enums[enum_def.name] = enum_def
 
         for pv in permissible_values:

--- a/linkml_runtime/utils/schema_builder.py
+++ b/linkml_runtime/utils/schema_builder.py
@@ -80,8 +80,6 @@ class SchemaBuilder:
             raise ValueError(f"Class {cls.name} already exists")
         self.schema.classes[cls.name] = cls
         if use_attributes:
-            if not isinstance(slots, list):
-                slots = [slots]
             for s in slots:
                 if isinstance(s, SlotDefinition):
                     cls.attributes[s.name] = s

--- a/linkml_runtime/utils/schema_builder.py
+++ b/linkml_runtime/utils/schema_builder.py
@@ -66,8 +66,10 @@ class SchemaBuilder:
 
         :param cls: name, dict object, or ClassDefinition object to add
         :param slots: slot of slot names or slot objects.
-        :param slot_usage: slots keyed by slot name
+        :param slot_usage: slots keyed by slot name (ignored if `use_attributes=True`)
         :param replace_if_present: if True, replace existing class if present
+        :param use_attributes: Whether to specify the given slots as an inline definition of
+            slots, attributes, in the class definition
         :param kwargs: additional ClassDefinition properties
         :return: builder
         :raises ValueError: if class already exists and replace_if_present=False

--- a/linkml_runtime/utils/schema_builder.py
+++ b/linkml_runtime/utils/schema_builder.py
@@ -178,10 +178,19 @@ class SchemaBuilder:
         if permissible_values is None:
             permissible_values = []
 
-        if not isinstance(enum_def, EnumDefinition):
+        if isinstance(enum_def, str):
             enum_def = EnumDefinition(enum_def, **kwargs)
-        if isinstance(enum_def, dict):
+        elif isinstance(enum_def, dict):
             enum_def = EnumDefinition(**{**enum_def, **kwargs})
+        else:
+            # Ensure that `enum_def` is a `EnumDefinition` object
+            if not isinstance(enum_def, EnumDefinition):
+                msg = (
+                    f"enum_def must be a `str`, `dict`, or `EnumDefinition`, "
+                    f"not {type(enum_def)!r}"
+                )
+                raise TypeError(msg)
+
         if enum_def.name in self.schema.enums and not replace_if_present:
             raise ValueError(f"Enum {enum_def.name} already exists")
 

--- a/linkml_runtime/utils/schema_builder.py
+++ b/linkml_runtime/utils/schema_builder.py
@@ -175,6 +175,9 @@ class SchemaBuilder:
         :return: builder
         :raises ValueError: if enum already exists and replace_if_present=False
         """
+        if permissible_values is None:
+            permissible_values = []
+
         if not isinstance(enum_def, EnumDefinition):
             enum_def = EnumDefinition(enum_def, **kwargs)
         if isinstance(enum_def, dict):
@@ -182,11 +185,12 @@ class SchemaBuilder:
         if enum_def.name in self.schema.enums and not replace_if_present:
             raise ValueError(f"Enum {enum_def.name} already exists")
         self.schema.enums[enum_def.name] = enum_def
-        if permissible_values is not None:
-            for pv in permissible_values:
-                if isinstance(pv, str):
-                    pv = PermissibleValue(text=pv)
-                    enum_def.permissible_values[pv.text] = pv
+
+        for pv in permissible_values:
+            if isinstance(pv, str):
+                pv = PermissibleValue(text=pv)
+                enum_def.permissible_values[pv.text] = pv
+
         return self
 
     def add_prefix(self, prefix: str, url: str, replace_if_present = False) -> "SchemaBuilder":

--- a/linkml_runtime/utils/schema_builder.py
+++ b/linkml_runtime/utils/schema_builder.py
@@ -166,8 +166,9 @@ class SchemaBuilder:
         """
         Adds an enum to the schema
 
-        :param enum_def: The enum to be added
-        :param permissible_values: The permissible values of the enum
+        :param enum_def: The base specification of the enum to be added
+        :param permissible_values: Additional, or overriding, permissible values
+            of the enum to be added
         :param replace_if_present: Whether to replace the enum if it already exists in
             the schema by name
         :param kwargs: Additional `EnumDefinition` properties to be set as part of the

--- a/linkml_runtime/utils/schema_builder.py
+++ b/linkml_runtime/utils/schema_builder.py
@@ -166,10 +166,12 @@ class SchemaBuilder:
         """
         Adds an enum to the schema
 
-        :param enum_def:
-        :param permissible_values:
-        :param replace_if_present:
-        :param kwargs:
+        :param enum_def: The enum to be added
+        :param permissible_values: The permissible values of the enum
+        :param replace_if_present: Whether to replace the enum if it already exists in
+            the schema by name
+        :param kwargs: Additional `EnumDefinition` properties to be set as part of the
+            enum to be added
         :return: builder
         :raises ValueError: if enum already exists and replace_if_present=False
         """

--- a/linkml_runtime/utils/schema_builder.py
+++ b/linkml_runtime/utils/schema_builder.py
@@ -66,7 +66,6 @@ class SchemaBuilder:
 
         :param cls: name, dict object, or ClassDefinition object to add
         :param slots: slot of slot names or slot objects.
-            Note: If `use_attributes=True`, then this must be a list of SlotDefinitions
         :param slot_usage: slots keyed by slot name
         :param replace_if_present: if True, replace existing class if present
         :param kwargs: additional ClassDefinition properties
@@ -82,9 +81,7 @@ class SchemaBuilder:
         self.schema.classes[cls.name] = cls
         if use_attributes:
             if not isinstance(slots, list):
-                raise ValueError(
-                    "If `use_attributes=True`, then `slots` must be a list."
-                )
+                slots = [slots]
             for s in slots:
                 if isinstance(s, SlotDefinition):
                     cls.attributes[s.name] = s

--- a/linkml_runtime/utils/schema_builder.py
+++ b/linkml_runtime/utils/schema_builder.py
@@ -76,6 +76,11 @@ class SchemaBuilder:
         :return: builder
         :raises ValueError: if class already exists and replace_if_present=False
         """
+        if slots is None:
+            slots = []
+        if slot_usage is None:
+            slot_usage = {}
+
         if isinstance(cls, str):
             cls = ClassDefinition(cls, **kwargs)
         if isinstance(cls, dict):
@@ -84,25 +89,22 @@ class SchemaBuilder:
             raise ValueError(f"Class {cls.name} already exists")
         self.schema.classes[cls.name] = cls
         if use_attributes:
-            if slots is not None:
-                for s in slots:
-                    if isinstance(s, SlotDefinition):
-                        cls.attributes[s.name] = s
-                    else:
-                        raise ValueError(
-                            f"If use_attributes=True then slots must be SlotDefinitions"
-                        )
+            for s in slots:
+                if isinstance(s, SlotDefinition):
+                    cls.attributes[s.name] = s
+                else:
+                    raise ValueError(
+                        f"If use_attributes=True then slots must be SlotDefinitions"
+                    )
         else:
-            if slots is not None:
-                for s in slots:
-                    cls.slots.append(s.name if isinstance(s, SlotDefinition) else s)
-                    if isinstance(s, str) and s in self.schema.slots:
-                        # top-level slot already exists
-                        continue
-                    self.add_slot(s, replace_if_present=replace_if_present)
-            if slot_usage:
-                for k, v in slot_usage.items():
-                    cls.slot_usage[k] = v
+            for s in slots:
+                cls.slots.append(s.name if isinstance(s, SlotDefinition) else s)
+                if isinstance(s, str) and s in self.schema.slots:
+                    # top-level slot already exists
+                    continue
+                self.add_slot(s, replace_if_present=replace_if_present)
+            for k, v in slot_usage.items():
+                cls.slot_usage[k] = v
         return self
 
     def add_slot(

--- a/linkml_runtime/utils/schema_builder.py
+++ b/linkml_runtime/utils/schema_builder.py
@@ -57,8 +57,8 @@ class SchemaBuilder:
         cls: Union[ClassDefinition, Dict, str],
         slots: List[Union[str, SlotDefinition]] = None,
         slot_usage: Dict[str, SlotDefinition] = None,
-        replace_if_present=False,
-        use_attributes=False,
+        replace_if_present: bool = False,
+        use_attributes: bool = False,
         **kwargs,
     ) -> "SchemaBuilder":
         """

--- a/linkml_runtime/utils/schema_builder.py
+++ b/linkml_runtime/utils/schema_builder.py
@@ -68,8 +68,8 @@ class SchemaBuilder:
         :param slots: slot of slot names or slot objects.
         :param slot_usage: slots keyed by slot name (ignored if `use_attributes=True`)
         :param replace_if_present: if True, replace existing class if present
-        :param use_attributes: Whether to specify the given slots as an inline definition of
-            slots, attributes, in the class definition
+        :param use_attributes: Whether to specify the given slots as an inline
+            definition of slots, attributes, in the class definition
         :param kwargs: additional ClassDefinition properties
         :return: builder
         :raises ValueError: if class already exists and replace_if_present=False

--- a/tests/test_utils/test_schema_builder.py
+++ b/tests/test_utils/test_schema_builder.py
@@ -1,0 +1,30 @@
+import pytest
+
+from linkml_runtime.utils.schema_builder import SchemaBuilder
+from linkml_runtime.linkml_model import ClassDefinition
+
+
+@pytest.mark.parametrize("replace_if_present", [True, False])
+def test_add_existing_class(replace_if_present):
+    """
+    Test the case of adding a class with a name that is the same as a class that already
+    exists in the schema
+    """
+    builder = SchemaBuilder()
+
+    cls_name = "Person"
+
+    # Add a class to the schema
+    cls = ClassDefinition(name=cls_name, slots=["name"])
+    builder.add_class(cls)
+
+    # Add another class with the same name to the schema
+    cls_repeat = ClassDefinition(name=cls_name, slots=["age"])
+
+    if replace_if_present:
+        builder.add_class(cls_repeat, replace_if_present=True)
+        assert builder.schema.classes[cls_name].slots == ["age"]
+    else:
+        with pytest.raises(ValueError, match=f"Class {cls_name} already exists"):
+            builder.add_class(cls_repeat)
+        assert builder.schema.classes[cls_name].slots == ["name"]

--- a/tests/test_utils/test_schema_builder.py
+++ b/tests/test_utils/test_schema_builder.py
@@ -1,7 +1,9 @@
+from typing import Optional, List, Union
+
 import pytest
 
 from linkml_runtime.utils.schema_builder import SchemaBuilder
-from linkml_runtime.linkml_model import ClassDefinition
+from linkml_runtime.linkml_model import ClassDefinition, SlotDefinition
 
 
 @pytest.mark.parametrize("replace_if_present", [True, False])
@@ -28,3 +30,51 @@ def test_add_existing_class(replace_if_present):
         with pytest.raises(ValueError, match=f"Class {cls_name} already exists"):
             builder.add_class(cls_repeat)
         assert builder.schema.classes[cls_name].slots == ["name"]
+
+
+@pytest.mark.parametrize(
+    "slots",
+    [
+        None,
+        ["name", "age"],
+        ["name", SlotDefinition(name="age")],
+        [SlotDefinition(name="name"), SlotDefinition(name="age")],
+    ],
+)
+@pytest.mark.parametrize("use_attributes", [True, False])
+def test_add_class_with_slot_additions(
+    slots: Optional[List[Union[str, SlotDefinition]]], use_attributes: bool
+):
+    """
+    Test adding a class with separate additional slots specification
+    """
+    # If `slots` is None, it should be treated as if it were an empty list
+    if slots is None:
+        slots = []
+
+    slot_names = {s if isinstance(s, str) else s.name for s in slots}
+
+    builder = SchemaBuilder()
+
+    cls_name = "Person"
+
+    # Add a class to the schema
+    cls = ClassDefinition(name=cls_name)
+
+    if use_attributes:
+        # === The case where the slots specified should be added to the `attributes`
+        # meta slot of the class ===
+        if any(not isinstance(s, SlotDefinition) for s in slots):
+            with pytest.raises(
+                ValueError,
+                match="If use_attributes=True then slots must be SlotDefinitions",
+            ):
+                builder.add_class(cls, slots=slots, use_attributes=use_attributes)
+        else:
+            builder.add_class(cls, slots=slots, use_attributes=use_attributes)
+            assert builder.schema.classes[cls_name].attributes.keys() == slot_names
+    else:
+        # === The case where the slots specified should be added to the `slots`
+        # meta slot of the schema ===
+        builder.add_class(cls, slots=slots, use_attributes=use_attributes)
+        assert builder.schema.slots.keys() == slot_names

--- a/tests/test_utils/test_schema_builder.py
+++ b/tests/test_utils/test_schema_builder.py
@@ -7,6 +7,7 @@ from linkml_runtime.utils.schema_builder import SchemaBuilder
 from linkml_runtime.linkml_model import ClassDefinition, SlotDefinition
 
 
+# === Tests for `SchemaBuilder.add_class` ===
 @pytest.mark.parametrize("replace_if_present", [True, False])
 def test_add_existing_class(replace_if_present):
     """
@@ -144,3 +145,5 @@ def test_add_class_with_extra_kwargs(
         added_class = builder.schema.classes[class_name]
 
         assert added_class == expected_added_class
+
+# === Tests for `SchemaBuilder.add_class` end ===

--- a/tests/test_utils/test_schema_builder.py
+++ b/tests/test_utils/test_schema_builder.py
@@ -262,3 +262,5 @@ def test_add_enum_with_extra_kwargs(
         added_enum = builder.schema.enums[enum_name]
 
         assert added_enum == expected_added_enum
+
+# === Tests for `SchemaBuilder.add_enum` end ===


### PR DESCRIPTION
This PR does the following to `SchemaBuilder.add_enum()`.

Bug fixes (tests added):
1. Correct adding of permissible values that are `PermissibleValue` objects
2. Correct handling of `enum_def` values of different types

Other improvements (no test needed):
1. Provide missing documentation of params in the docstring
2. Convert `None` value in `permissible_values` to an empty list

Note: This PR is based on https://github.com/linkml/linkml-runtime/pull/338. To get the relevant commits of this PR, wait for https://github.com/linkml/linkml-runtime/pull/338 is merged to the main branch, and merge the main branch to this branch.