### PR TITLE
fix(permissiblevalue): serialization

### DIFF
--- a/linkml_runtime/linkml_model/meta.py
+++ b/linkml_runtime/linkml_model/meta.py
@@ -4014,6 +4014,9 @@ class PermissibleValue(YAMLRoot):
 
         super().__post_init__(**kwargs)
 
+    def __repr__(self):
+        return repr(getattr(self, 'text')).replace("'", "")
+
 
 @dataclass(repr=False)
 class UniqueKey(YAMLRoot):

--- a/tests/test_loaders_dumpers/test_enum.py
+++ b/tests/test_loaders_dumpers/test_enum.py
@@ -26,6 +26,8 @@ class EnumTestCase(unittest.TestCase):
         print(StateEnum.LIVING)
         assert str(i.state) == 'LIVING'
         assert i.state.code == StateEnum.LIVING
+        pv = StateEnum.LIVING
+        assert str(pv) == 'LIVING'
         obj = json.loads(json_dumper.dumps(i))
         assert obj['state'] == 'LIVING'
         obj = yaml.safe_load(yaml_dumper.dumps(i))


### PR DESCRIPTION
Serialization of `PermissibleValue(text='value')` should be `'value'`, instead it is `PermissibleValue({"text": 'value'})`. This patch fixes it.

Fixes https://github.com/linkml/linkml/issues/2382