### PR TITLE
Fix: rdflib dumper ignores explicitly defined prefixes

### DIFF
--- a/linkml_runtime/dumpers/rdflib_dumper.py
+++ b/linkml_runtime/dumpers/rdflib_dumper.py
@@ -47,26 +47,26 @@ class RDFLibDumper(Dumper):
             # TODO replace with `prefix_map = prefix_map.bimap` after making minimum requirement on python 3.8
             prefix_map = {record.prefix: record.uri_prefix for record in prefix_map.records}
         logger.debug(f'PREFIXMAP={prefix_map}')
+        namespaces = schemaview.namespaces()
         if prefix_map:
             for k, v in prefix_map.items():
                 if k == "@base":
-                    schemaview.namespaces()._base = v
+                    namespaces._base = v
                 else:
-                    schemaview.namespaces()[k] = v
+                    namespaces[k] = v
                     g.namespace_manager.bind(k, URIRef(v))
-            for prefix in schemaview.namespaces():
-                g.bind(prefix, URIRef(schemaview.namespaces()[prefix]))
-        else:
-            for prefix in schemaview.namespaces():
-                g.bind(prefix, URIRef(schemaview.namespaces()[prefix]))
+
+        for prefix in namespaces:
+            g.bind(prefix, URIRef(namespaces[prefix]))
         # user can pass in base in prefixmap using '_base'. This gets set
         # in namespaces as a plain dict assignment - explicitly call the setter
         # to set the underlying "@base"
-        if "_base" in schemaview.namespaces():
-            schemaview.namespaces()._base = schemaview.namespaces()["_base"]
-            g.base = schemaview.namespaces()._base
-        if schemaview.namespaces()._base:
-            g.base = schemaview.namespaces()._base
+        if "_base" in namespaces:
+            namespaces._base = namespaces["_base"]
+
+        if namespaces._base:
+            g.base = namespaces._base
+
         self.inject_triples(element, schemaview, g)
         return g
 

--- a/linkml_runtime/utils/namespaces.py
+++ b/linkml_runtime/utils/namespaces.py
@@ -78,12 +78,11 @@ class Namespaces(CaseInsensitiveDict):
                 super().__setitem__(value, target_bnode)
         elif is_ncname(key):
             v = Namespace(str(value))
-            if key in self:
-                if self[key] != v:
-                    logging.getLogger('Namespaces').\
-                        warning(f"{key} namespace is already mapped to {self[key]} - Mapping to {v} ignored")
-            else:
-                super().__setitem__(key, v)
+            if key in self and self[key] != v:
+                logger = logging.getLogger('linkml_runtime.Namespaces')
+                logger.warning(f"{key} namespace is already mapped to {self[key]} - Overriding with mapping to {v}")
+
+            super().__setitem__(key, v)
         else:
             raise ValueError(f"Invalid NCName: {key}")
 

--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -179,10 +179,10 @@ class SchemaView(object):
     def namespaces(self) -> Namespaces:
         namespaces = Namespaces()
         for s in self.schema_map.values():
-            for prefix in s.prefixes.values():
-                namespaces[prefix.prefix_prefix] = prefix.prefix_reference
             for cmap in self.schema.default_curi_maps:
                 namespaces.add_prefixmap(cmap, include_defaults=False)
+            for prefix in s.prefixes.values():
+                namespaces[prefix.prefix_prefix] = prefix.prefix_reference
         return namespaces
 
     def load_import(self, imp: str, from_schema: SchemaDefinition = None):


### PR DESCRIPTION
Related to: https://github.com/mapping-commons/sssom-py/pull/558

copy and pasting discussion from slack:

- first is that schemaview assigns from the default_curi_maps after explicitly defined prefixes - so those prefixes in the default curi map (which is the source of the allcaps HSAPDV) override explicit prefixes. explicit assignment should always override defaults
- second is in the Namespaces object. currently it rejects repeated assignment to the same key. since it is a case insensitive dict, HsapDv is the same key as HASPDV . That shouldn’t be the case - explicit assignment should always override existing values
- and then finally, as noted above, the rdflib dumper makes repeated calls to schemaview.namespaces() and tries to assign to it, which does nothing (or should do nothing, and if it does something then it’s a bug and a side effect of mutating values in the cache which 100% should not be relied on). So i instead made a single call to schemaview.namespaces(), assigning that to a variable, and then mutated that variable instead in the as_rdf_graph method.

opening this as a draft because i don't know this code, it fixes the linked issue, but i don't have a good sense of why things are the way they are currently.