### PR TITLE
feat(schemaview): add is_simple_dict method

### DIFF
--- a/tests/test_utils/input/schemaview_is_inlined.yaml
+++ b/tests/test_utils/input/schemaview_is_inlined.yaml
@@ -45,6 +45,10 @@ slots:
 
   an_integer:
     range: integer
+
+  inlined_simple_dict:
+    range: ThingWithId
+    inlined_as_list: false
   
   # Pathological cases
   inlined_integer:

--- a/tests/test_utils/test_schemaview.py
+++ b/tests/test_utils/test_schemaview.py
@@ -865,12 +865,33 @@ def test_is_inlined():
         ("inlined_thing_without_id", True),
         ("inlined_as_list_thing_without_id", True),
         ("an_integer", False),
+        ("inlined_simple_dict", True),
         ("inlined_integer", False),
         ("inlined_as_list_integer", False)
     ]
     for slot_name, expected_result in cases:
         slot = sv.get_slot(slot_name)
         assert sv.is_inlined(slot) == expected_result
+
+
+def test_is_simple_dict():
+    schema_path = os.path.join(INPUT_DIR, "schemaview_is_inlined.yaml")
+    sv = SchemaView(schema_path)
+    cases = [
+        ("a_thing_with_id", False),
+        ("inlined_thing_with_id", False),
+        ("inlined_as_list_thing_with_id", False),
+        ("a_thing_without_id", False),
+        ("inlined_thing_without_id", False),
+        ("inlined_as_list_thing_without_id", False),
+        ("an_integer", False),
+        ("inlined_simple_dict", True),
+        ("inlined_integer", False),
+        ("inlined_as_list_integer", False)
+    ]
+    for slot_name, expected_result in cases:
+        slot = sv.get_slot(slot_name)
+        assert sv.is_simple_dict(slot) == expected_result
 
 
 def test_materialize_nonscalar_slot_usage():


### PR DESCRIPTION
Add method to SchemaView that helps checking if a slot is a simple dictionary or not.

After having [added the `linkml` helper function `is_simple_dict` months ago](https://github.com/linkml/linkml/commit/46e64f0be8c0de4e1e0c14026186f8f47be8fb5b), I realize that the schema viewer is the right place for that functionality.