### PR TITLE
Fix python 3.13 deprecation of typing.re

### DIFF
--- a/linkml_runtime/utils/slot.py
+++ b/linkml_runtime/utils/slot.py
@@ -1,12 +1,7 @@
 from dataclasses import dataclass
 from rdflib import URIRef
+from re import Pattern, Match
 from typing import Type, List, Optional, Any
-try:
-    # Python 3.8, 3.9, 3.10
-    from typing import re
-except:
-    # Python 3.11+
-    import re
 
 @dataclass
 class Slot:

--- a/linkml_runtime/utils/slot.py
+++ b/linkml_runtime/utils/slot.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
-from typing import Type, List, Optional, Any, re
+import re
+from typing import Type, List, Optional, Any
 
 from rdflib import URIRef
 

--- a/linkml_runtime/utils/slot.py
+++ b/linkml_runtime/utils/slot.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from rdflib import URIRef
 from re import Pattern, Match
-from typing import Type, List, Optional, Any
+from typing import Type, List, Optional, Any, Union
 
 @dataclass
 class Slot:
@@ -14,4 +14,4 @@ class Slot:
     domain: Optional[Type]
     range: Any
     mappings: Optional[List[URIRef]] = None
-    pattern: Optional[re] = None
+    pattern: Optional[Union[Pattern, Match]] = None

--- a/linkml_runtime/utils/slot.py
+++ b/linkml_runtime/utils/slot.py
@@ -1,9 +1,12 @@
 from dataclasses import dataclass
-import re
-from typing import Type, List, Optional, Any
-
 from rdflib import URIRef
-
+from typing import Type, List, Optional, Any
+try:
+    # Python 3.8, 3.9, 3.10
+    from typing import re
+except:
+    # Python 3.11+
+    import re
 
 @dataclass
 class Slot:


### PR DESCRIPTION
In python 3.13, `typing.re` was removed (deprecated since Python 3.8). See https://github.com/python/cpython/issues/92871

This pr refactors to support python 3.13 which currently throws

```python
ImportError: cannot import name 're' from 'typing' 
```