### PR TITLE
Support isodate ending with Z

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -18,7 +18,7 @@ jobs:
           python-version: "3.8"
 
     runs-on: ${{ matrix.os }}
-
+    
     steps:
 
       #----------------------------------------------
@@ -49,6 +49,7 @@ jobs:
       #              coverage report   
       #----------------------------------------------
       - name: Generate coverage results
+        shell: bash
         run: |
           poetry run coverage run -m pytest
           poetry run coverage xml

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -49,7 +49,6 @@ jobs:
       #              coverage report   
       #----------------------------------------------
       - name: Generate coverage results
-        shell: bash
         run: |
           poetry run coverage run -m pytest
           poetry run coverage xml

--- a/tests/test_utils/test_metamodelcore.py
+++ b/tests/test_utils/test_metamodelcore.py
@@ -153,6 +153,7 @@ class MetamodelCoreTest(unittest.TestCase):
         XSDDate(datetime.datetime.now())
         self.assertFalse(XSDTime.is_valid('Jan 12, 2019'))
         self.assertFalse(XSDTime.is_valid(datetime.datetime.now()))
+        self.assertFalse(XSDTime.is_valid("2019-07-06T17:22:39Z"))
         self.assertTrue(XSDTime.is_valid(v))
 
     def test_date(self):
@@ -168,6 +169,9 @@ class MetamodelCoreTest(unittest.TestCase):
             XSDDate('Jan 12, 2019')
         with self.assertRaises(ValueError):
             XSDDate(datetime.datetime.now())
+        with self.assertRaises(ValueError):
+            XSDDate("2019-07-06T17:22:39Z")
+
         lax()
         bv = XSDDate('Jan 12, 2019')
         self.assertEqual('Jan 12, 2019', bv)
@@ -188,6 +192,7 @@ class MetamodelCoreTest(unittest.TestCase):
         vstr = str(Literal(v).value)
         self.assertEqual('2019-07-06 17:22:39.007300', vstr)       # Note that this has no 'T'
         self.assertEqual('2019-07-06T17:22:39.007300', XSDDateTime(vstr))
+        self.assertEqual('2019-07-06T17:22:39+00:00', XSDDateTime("2019-07-06T17:22:39Z"))
         with self.assertRaises(ValueError):
             XSDDateTime('Jan 12, 2019')
         lax()

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,10 @@
 [tox]
-envlist = py37, py38, py39, py310
-isolated_build = true
-skipsdist = true
-
+envlist = py39, py310, py311, py312
 
 [testenv]
-whitelist_externals = poetry
-commands=
-    poetry install -v
-    poetry run python -m unittest
-    poetry run comparefiles --help
+skip_install = true
+allowlist_externals = poetry
+commands_pre =
+    poetry install
+commands =
+    poetry run pytest 


### PR DESCRIPTION
The PR switches (for Python <3.11) to [isodate](https://pypi.python.org/pypi/isodate/) package for isodate parsing. It is already installed with LinkML since it is a rdflib dependency.

Todo (maybe -> done!):

- [x] restrict the use of the `isodate` package to Python < 3.11. Starting with Python 3.11 the standard library´s `datetime.datetime.fromisoformat` is able parse isodates ending with "Z" correctly.

Closes linkml/linkml#2096
Closes linkml/linkml#629