### PR TITLE
Fail actions on error correctly on Windows

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -49,6 +49,8 @@ jobs:
       #              coverage report   
       #----------------------------------------------
       - name: Generate coverage results
+        # Set bash shell to fail correctly on Windows https://github.com/actions/runner-images/issues/6668 
+        shell: bash
         run: |
           poetry run coverage run -m pytest
           poetry run coverage xml


### PR DESCRIPTION
I also made this change in #357 but wanted to see the Windows test results without any other change.

On Windows failing tests were not correctly detected. The run was still "green" even if errors occured. See https://github.com/actions/runner-images/issues/6668 for more.