### PR TITLE
Fix hidden windows failures

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -49,6 +49,8 @@ jobs:
       #              coverage report   
       #----------------------------------------------
       - name: Generate coverage results
+        # Set bash shell to fail correctly on Windows https://github.com/actions/runner-images/issues/6668 
+        shell: bash
         run: |
           poetry run coverage run -m pytest
           poetry run coverage xml

--- a/linkml_runtime/linkml_model/linkml_files.py
+++ b/linkml_runtime/linkml_model/linkml_files.py
@@ -1,4 +1,4 @@
-from pathlib import Path
+from pathlib import Path, PurePath
 from enum import Enum, auto
 from typing import Dict, Optional, Union, Tuple, NamedTuple
 from urllib.parse import urljoin
@@ -152,7 +152,7 @@ def LOCAL_PATH_FOR(source: Source, fmt: Format) -> str:
 
 
 def GITHUB_IO_PATH_FOR(source: Source, fmt: Format, version="latest") -> str:
-    path = '/'.join([version, 'linkml_model', *_build_path(source, fmt)])
+    path = PurePath(version, 'linkml_model', *_build_path(source, fmt)).as_posix()
     return urljoin(GITHUB_IO_BASE, path)
 
 
@@ -178,7 +178,7 @@ def GITHUB_PATH_FOR(source: Source,
 
     # Return the absolute latest entry for branch
     if release is ReleaseTag.LATEST or (release is ReleaseTag.CURRENT and branch != "main"):
-        path = '/'.join([branch, 'linkml_model', *_build_path(source, fmt)])
+        path = PurePath(branch, 'linkml_model', *_build_path(source, fmt)).as_posix()
         return urljoin(GITHUB_BASE, path)
 
     # Return the latest published version

--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -5,7 +5,7 @@ import collections
 from functools import lru_cache
 from copy import copy, deepcopy
 from collections import defaultdict, deque
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import Mapping, Optional, Tuple, TypeVar
 import warnings
 
@@ -304,7 +304,8 @@ class SchemaView(object):
                     # we should treat the two `types.yaml` as separate schemas from the POV of the
                     # origin schema.
                     if sn.startswith('.') and ':' not in i:
-                        i = os.path.normpath(str(Path(sn).parent / i))
+                        # This cannot be simplified. os.path.normpath() must be called before .as_posix()
+                        i = PurePath(os.path.normpath(PurePath(sn).parent / i)).as_posix()
                     todo.append(i)
 
             # add item to closure


### PR DESCRIPTION
This fixes two Windows path-related issues that were undetected because of the gh-action.

See runs in #358 for the hidden failures that are fixed by this PR.

Closes linkml/linkml#2490