### PR TITLE
Fix hidden windows failures

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -49,6 +49,8 @@ jobs:
       #              coverage report   
       #----------------------------------------------
       - name: Generate coverage results
+        # Set bash shell to fail correctly on Windows https://github.com/actions/runner-images/issues/6668 
+        shell: bash
         run: |
           poetry run coverage run -m pytest
           poetry run coverage xml

--- a/linkml_runtime/linkml_model/linkml_files.py
+++ b/linkml_runtime/linkml_model/linkml_files.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 from enum import Enum, auto
-from typing import Dict, Optional, Union, Tuple, NamedTuple
+from typing import Dict, Optional, Union, NamedTuple
 from urllib.parse import urljoin
 from dataclasses import dataclass
 
@@ -84,7 +84,7 @@ class _Path:
     SHEXJ = FormatPath("shex","shexj" )
     SQLDDL = FormatPath("sqlddl","sql" )
     SQLSCHEMA = FormatPath("sqlschema","sql" )
-    YAML = FormatPath(str(Path("model") / "schema"),"yaml" )
+    YAML = FormatPath((Path("model") / "schema").as_posix(),"yaml" )
 
     @classmethod
     def items(cls) -> Dict[str, FormatPath]:

--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -1,11 +1,12 @@
 import os
+import sys
 import uuid
 import logging
 import collections
 from functools import lru_cache
 from copy import copy, deepcopy
 from collections import defaultdict, deque
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import Mapping, Optional, Tuple, TypeVar
 import warnings
 
@@ -28,6 +29,7 @@ CLASSES = 'classes'
 ENUMS = 'enums'
 SUBSETS = 'subsets'
 TYPES = 'types'
+WINDOWS = sys.platform == 'win32'
 
 CLASS_NAME = Union[ClassDefinitionName, str]
 SLOT_NAME = Union[SlotDefinitionName, str]
@@ -304,7 +306,11 @@ class SchemaView(object):
                     # we should treat the two `types.yaml` as separate schemas from the POV of the
                     # origin schema.
                     if sn.startswith('.') and ':' not in i:
-                        i = os.path.normpath(str(Path(sn).parent / i))
+                        if WINDOWS:
+                            # This cannot be simplified. os.path.normpath() must be called before .as_posix()
+                            i = PurePath(os.path.normpath(PurePath(sn).parent / i)).as_posix()
+                        else:
+                            i = os.path.normpath(str(Path(sn).parent / i))
                     todo.append(i)
 
             # add item to closure


### PR DESCRIPTION
This fixes two Windows path-related issues that were undetected because of the gh-action.

See runs in #358 for the hidden failures that are fixed by this PR.

Closes linkml/linkml#2490