### PR TITLE
Fix SchemaView metadata injection and get URI

### DIFF
--- a/tests/test_utils/test_schemaview.py
+++ b/tests/test_utils/test_schemaview.py
@@ -6,8 +6,9 @@ import pytest
 from jsonasobj2 import JsonObj
 
 from linkml_runtime.dumpers import yaml_dumper
-from linkml_runtime.linkml_model.meta import Example, SchemaDefinition, ClassDefinition, SlotDefinitionName, SlotDefinition, \
-    ClassDefinitionName, Prefix
+from linkml_runtime.linkml_model.meta import Example, SchemaDefinition, ClassDefinition, SlotDefinitionName, \
+    SlotDefinition, \
+    ClassDefinitionName, Prefix, TypeDefinition
 from linkml_runtime.loaders.yaml_loader import YAMLLoader
 from linkml_runtime.utils.introspection import package_schemaview
 from linkml_runtime.utils.schemaview import SchemaView, SchemaUsage, OrderedBy
@@ -897,3 +898,17 @@ def test_materialize_nonscalar_slot_usage():
     assert cls.attributes["tempo"].annotations.preferred_unit.value == "BPM"
     assert cls.attributes["tempo"].domain_of == ["DJController"]
     assert cls.slot_usage["tempo"].domain_of == []
+
+
+def test_type_and_slot_with_same_name():
+    """
+    Test that checks the case where a URI needs to be resolved and a name is ambiguously used for a slot and a
+    type
+    """
+    schema_definition = SchemaDefinition(id="https://example.org/test#", name="test_schema", default_prefix="ex")
+
+    view = SchemaView(schema_definition)
+    view.add_slot(SlotDefinition(name="test", from_schema="https://example.org/another#"))
+    view.add_type(TypeDefinition(name="test", from_schema="https://example.org/imported#"))
+
+    assert view.get_uri("test", imports=True) == "ex:test"


### PR DESCRIPTION
I noticed an issue while working on our Gaia-X ontology as there is a slot named `uri` and also a type (from LinkML types) named `uri`. This caused the metadata injection (overwriting `from_schema` with the current schema ID) to fail as `dict`s are used and merged, meaning either the LinkML `uri` could get the correct schema ID or the Gaia-X `uri` slot not both.

To fix this I just proposed to merge the values in a list avoiding any collision.

Please note I also fixed the `get_uri(..)` method as in the case above I would get a `StopIteration` exception coming from the `next(..)` method arriving at the end of the schema map without finding element. To do so, I just added a default value to the iteration method: `next(<generator function>, <fallback/default value>)`.