### PR TITLE
Adding option to eval to prevent distribution over arrays and dicts.

### DIFF
--- a/tests/test_utils/test_eval_utils.py
+++ b/tests/test_utils/test_eval_utils.py
@@ -70,6 +70,8 @@ def test_eval_expressions():
     assert eval_expr('c.person_index.name', c=c) == ['x', 'x2']
     assert eval_expr('c.person_index.address.street', c=c) == ['1 x street', '2 x street']
     assert eval_expr('strlen(c.person_index.name)', c=c) == [1, 2]
+    pd = dict(name='x', aliases=['a', 'b', 'c'], address=Address(street='1 x street'))
+    assert eval_expr('p.name', p=pd, _distribute=False) == 'x'
 
 
 def test_no_eval_prohibited():


### PR DESCRIPTION
Previously the eval function in eval_utils auto-distributes over
many-valued options. This allows for this to be controlled.

For example, in this case when looking up an object, we want to avoid
distribution:

+    pd = dict(name='x', aliases=['a', 'b', 'c'], address=Address(street='1 x street'))
+    assert eval_expr('p.name', p=pd, _distribute=False) == 'x'
