### PR TITLE
Always run upstream test action

### DIFF
--- a/.github/workflows/test-upstream.yaml
+++ b/.github/workflows/test-upstream.yaml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   test_upstream:
-    if: github.event_name == 'workflow_dispatch' || github.event.review.state == 'APPROVED'
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest ]

--- a/.github/workflows/test-upstream.yaml
+++ b/.github/workflows/test-upstream.yaml
@@ -1,7 +1,8 @@
 name: Test with upstream linkml
 on:
-  pull_request_review:
-    types: [ submitted ]
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
when i wrote the upstream test action, we limited it to being run after approval from maintainers because the upstream tests used to take an eternity. they don't anymore, and it turns out to be a bigger headache than expected to have to trigger the tests to run every time. so this PR just makes them run like a normal PR action