### PR TITLE
Specify repo and branch when testing against upstream

### DIFF
--- a/.github/workflows/test-upstream.yaml
+++ b/.github/workflows/test-upstream.yaml
@@ -36,8 +36,13 @@ jobs:
         if: github.event_name == 'pull_request'
         shell: bash
         run: |
+          PR_BODY=$(cat <<EOF
+            ${{ github.event.pull_request.body }}
+          EOF
+          )
+          
           UPSTREAM_BRANCH=$( \
-            echo ${{ github.event.pull_request.body }} | \
+            echo $PR_BODY | \
             head -2 | \
             grep upstream_branch | \
             cut -d ":" -f 2 | \
@@ -52,7 +57,7 @@ jobs:
           fi
           
           UPSTREAM_REPO=$( \
-            echo ${{ github.event.pull_request.body }} | \
+            echo $PR_BODY | \
             head -2 | \
             grep upstream_repo | \
             cut -d ":" -f 2 | \

--- a/.github/workflows/test-upstream.yaml
+++ b/.github/workflows/test-upstream.yaml
@@ -130,7 +130,7 @@ jobs:
       # make extra sure we're removing any old version of linkml-runtime that exists
       - name: uninstall potentially cached linkml-runtime
         working-directory: linkml
-        run: poetry run pip uninstall linkml-runtime
+        run: poetry run pip uninstall -y linkml-runtime
 
       # we are not using linkml-runtime's lockfile, but simulating what will happen
       # when we merge this and update linkml's lockfile

--- a/.github/workflows/test-upstream.yaml
+++ b/.github/workflows/test-upstream.yaml
@@ -42,7 +42,7 @@ jobs:
           )
           
           UPSTREAM_BRANCH=$( \
-            echo $PR_BODY | \
+            echo "$PR_BODY" | \
             head -2 | \
             grep upstream_branch | \
             cut -d ":" -f 2 | \
@@ -57,7 +57,7 @@ jobs:
           fi
           
           UPSTREAM_REPO=$( \
-            echo $PR_BODY | \
+            echo "$PR_BODY" | \
             head -2 | \
             grep upstream_repo | \
             cut -d ":" -f 2 | \

--- a/.github/workflows/test-upstream.yaml
+++ b/.github/workflows/test-upstream.yaml
@@ -17,6 +17,7 @@ on:
 jobs:
   test_upstream:
     strategy:
+      fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest ]
         python-version: [ "3.8", "3.9", "3.10", "3.11", "3.12" ]

--- a/.github/workflows/test-upstream.yaml
+++ b/.github/workflows/test-upstream.yaml
@@ -74,6 +74,7 @@ jobs:
         shell: bash
         run: |
           echo "upstream_branch=${{ inputs.upstream_branch }}" >> "$GITHUB_ENV"
+          echo "upstream_repo=${{ inputs.upstream_repo }}" >> $GITHUB_ENV"
 
       - name: checkout upstream
         uses: actions/checkout@v4
@@ -92,7 +93,7 @@ jobs:
           fetch-depth: 0
 
       - name: Ensure tags for linkml upstream if a different one than linkml/linkml is specified
-        if: "${{ env.upstream_repo }}" != "linkml/linkml"
+        if: "${{ env.upstream_repo != 'linkml/linkml' }}"
         working-directory: linkml
         run: |
           git remote add upstream https://github.com/linkml/linkml

--- a/.github/workflows/test-upstream.yaml
+++ b/.github/workflows/test-upstream.yaml
@@ -39,6 +39,9 @@ jobs:
         env:
           PR_BODY: ${{ github.event.pull_request.body }}
         run: |
+          set +e
+          set +o pipefail
+          
           UPSTREAM_BRANCH=$( \
             echo "$PR_BODY" | \
             head -2 | \

--- a/.github/workflows/test-upstream.yaml
+++ b/.github/workflows/test-upstream.yaml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   test_upstream:
-    if: github.event_name == 'workflow_dispatch' || github.event.review.state == 'APPROVED'
     strategy:
       matrix:
         os: [ ubuntu-latest, windows-latest ]

--- a/.github/workflows/test-upstream.yaml
+++ b/.github/workflows/test-upstream.yaml
@@ -4,6 +4,11 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      upstream_branch:
+        description: "Upstream linkml branch to test against"
+        required: true
+        default: 'main'
 
 jobs:
   test_upstream:
@@ -23,13 +28,39 @@ jobs:
       POETRY_VIRTUALENVS_IN_PROJECT: true
 
     steps:
+      - name: Get upstream branch from first line of PR Body
+        if: github.event_name == 'pull_request'
+        shell: bash
+        run: |
+          UPSTREAM_BRANCH=$( \
+            echo ${{ github.event.pull_request.body }} | \
+            head -1 | \
+            grep upstream_branch | \
+            cut -d ":" -f 2 | \
+            awk '{$1=$1};1' \
+          )
+          echo "Got upstream branch:"
+          echo $UPSTREAM_BRANCH
+          
+          if [[ -z "$UPSTREAM_BRANCH" ]]; then
+            echo "Using main as default"
+            UPSTREAM_BRANCH="main"
+          fi
+
+          echo "upstream_branch=$UPSTREAM_BRANCH" >> "$GITHUB_ENV"    
+
+      - name: Get upstream branch from workflow dispatch
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        run: |
+          echo "upstream_branch=${{ inputs.upstream_branch }}" >> "$GITHUB_ENV"
 
       - name: checkout upstream
         uses: actions/checkout@v4
         with:
           repository: linkml/linkml
           path: linkml
-          ref: main
+          ref: "${{ env.upstream_branch }}"
           fetch-depth: 0
 
       - name: checkout linkml-runtime

--- a/.github/workflows/test-upstream.yaml
+++ b/.github/workflows/test-upstream.yaml
@@ -1,7 +1,8 @@
 name: Test with upstream linkml
 on:
-  pull_request_review:
-    types: [ submitted ]
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test-upstream.yaml
+++ b/.github/workflows/test-upstream.yaml
@@ -5,10 +5,14 @@ on:
       - main
   workflow_dispatch:
     inputs:
+      upstream_repo:
+        description: "Upstream linkml repository to test against"
+        required: true
+        default: "linkml/linkml"
       upstream_branch:
         description: "Upstream linkml branch to test against"
         required: true
-        default: 'main'
+        default: "main"
 
 jobs:
   test_upstream:
@@ -28,13 +32,13 @@ jobs:
       POETRY_VIRTUALENVS_IN_PROJECT: true
 
     steps:
-      - name: Get upstream branch from first line of PR Body
+      - name: Get upstream branch and repo from first lines of PR Body
         if: github.event_name == 'pull_request'
         shell: bash
         run: |
           UPSTREAM_BRANCH=$( \
             echo ${{ github.event.pull_request.body }} | \
-            head -1 | \
+            head -2 | \
             grep upstream_branch | \
             cut -d ":" -f 2 | \
             awk '{$1=$1};1' \
@@ -46,8 +50,24 @@ jobs:
             echo "Using main as default"
             UPSTREAM_BRANCH="main"
           fi
+          
+          UPSTREAM_REPO=$( \
+            echo ${{ github.event.pull_request.body }} | \
+            head -2 | \
+            grep upstream_repo | \
+            cut -d ":" -f 2 | \
+            awk '{$1=$1};1' \
+          )
+          echo "Got upstream repo:"
+          echo $UPSTREAM_REPO
+          
+          if [[ -z "$UPSTREAM_REPO" ]]; then
+            echo "Using linkml/linkml as default"
+            UPSTREAM_REPO="linkml/linkml"
+          fi
 
-          echo "upstream_branch=$UPSTREAM_BRANCH" >> "$GITHUB_ENV"    
+          echo "upstream_branch=$UPSTREAM_BRANCH" >> "$GITHUB_ENV"
+          echo "upstream_repo=$UPSTREAM_REPO" >> "$GITHUB_ENV"
 
       - name: Get upstream branch from workflow dispatch
         if: github.event_name == 'workflow_dispatch'
@@ -58,7 +78,7 @@ jobs:
       - name: checkout upstream
         uses: actions/checkout@v4
         with:
-          repository: linkml/linkml
+          repository: "${{ env.upstream_repo }}"
           path: linkml
           ref: "${{ env.upstream_branch }}"
           fetch-depth: 0
@@ -71,7 +91,14 @@ jobs:
           path: linkml-runtime
           fetch-depth: 0
 
-      - name: Ensure tags if not run from main repo
+      - name: Ensure tags for linkml upstream if a different one than linkml/linkml is specified
+        if: "${{ env.upstream_repo }}" != "linkml/linkml"
+        working-directory: linkml
+        run: |
+          git remote add upstream https://github.com/linkml/linkml
+          git fetch upstream --tags
+
+      - name: Ensure tags for linkml-runtime if not run from main repo
         if: github.repository != 'linkml/linkml-runtime'
         working-directory: linkml-runtime
         run: |

--- a/.github/workflows/test-upstream.yaml
+++ b/.github/workflows/test-upstream.yaml
@@ -36,12 +36,9 @@ jobs:
       - name: Get upstream branch and repo from first lines of PR Body
         if: github.event_name == 'pull_request'
         shell: bash
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
-          PR_BODY=$(cat <<EOF
-            ${{ github.event.pull_request.body }}
-          EOF
-          )
-          
           UPSTREAM_BRANCH=$( \
             echo "$PR_BODY" | \
             head -2 | \

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,31 @@ ALSO NOTE: github.com lets you create a pull request from the main branch, autom
 
 > A code review (which happens with both the contributor and the reviewer present) is required for contributing.
 
+## Pull Requests
+
+### Upstream Testing
+
+`linkml-runtime` is tightly coupled to upstream `linkml`, 
+so all pull requests have their changes tested by running the upstream tests
+against the PR version of `linkml-runtime`.
+
+In some circumstances, paired changes need to be made against *both*
+`linkml` and `linkml-runtime`, where testing against the `main` branch
+of `linkml` is insufficient. 
+
+When opening a pull request, you can specify that your PR needs to be
+tested against a specific upstream branch and repository by specifying it
+in the first two lines of your pull request like this:
+
+> upstream_repo: my-cool-username/linkml
+> upstream_branch: some-complicated-feature
+> 
+> Hey everyone what up it's me your boy MC spongebob here with another banger
+> ... (PR continues)
+
+Maintainers can also specify upstream branches to test against when 
+dispatching the `test-upstream` workflow manually via the GUI prompt.
+
 ## Development environment setup
 
 1. Install [poetry](https://python-poetry.org/docs/#installation).
@@ -70,7 +95,21 @@ All code added to the linkml-runtime source must have tests. The repo uses the n
 You can run the test suite in the following way:
 
 ```
-poetry run python -m unittest discover
+poetry run python -m pytest
+```
+
+### Upstream Testing
+
+To run the upstream `linkml` tests against your branch,
+install `linkml` locally with poetry, and then manually install your
+local copy of `linkml-runtime`
+
+```shell
+git clone https://github.com/linkml/linkml
+cd linkml
+poetry install --all-extras --with tests
+poetry run pip install -e ~/location/of/linkml-runtime
+poetry run pytest
 ```
 
 ## Code style

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,11 @@ in the first two lines of your pull request like this:
 Maintainers can also specify upstream branches to test against when 
 dispatching the `test-upstream` workflow manually via the GUI prompt.
 
+Testing against an unverified upstream branch is not necessarily dangerous,
+since the [input is stored as a variable first and not executed as untrusted code](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable),
+but maintainers should take care to verify that the upstream branch and repo
+are correct and expected given the context of the PR.
+
 ## Development environment setup
 
 1. Install [poetry](https://python-poetry.org/docs/#installation).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,9 @@ in the first two lines of your pull request like this:
 > Hey everyone what up it's me your boy MC spongebob here with another banger
 > ... (PR continues)
 
+The order of the `upstream_repo` and `upstream_branch` tags doesn't matter,
+but they must be on the first two lines of the pull request comment and separated with a colon.
+
 Maintainers can also specify upstream branches to test against when 
 dispatching the `test-upstream` workflow manually via the GUI prompt.
 


### PR DESCRIPTION
Related to the discussion re: python 3.13:
- https://github.com/linkml/linkml-runtime/pull/345
- https://github.com/linkml/linkml/pull/2358

Builds off: https://github.com/linkml/linkml-runtime/pull/366
because it's just simpler to deal with the pull request metadata when the action is triggered by `pull_request`.

So `linkml-runtime` is tightly coupled to `linkml`, and there are enough tricky complexities in both that it's inevitable that we need to make coordinated changes to both packages at the same time - e.g. with the upgrade to python 3.13 support, neither `linkml-runtime` nor `linkml` could have the PR merged with passing tests because both sets of changes necessarily depended on the other.

This PR lets you specify a branch and/or repository to run the upstream tests in the body of the pull request by starting it with two lines like

> upstream_repo: sneakers-the-rat/linkml
> upstream_branch: python-3.13
> 
> blah blah blah the rest of the PR message

It also allows you to specify those when you run it via manual `workflow_dispatch`.

It can be observed as working here, noting that we get the [correct repo](https://github.com/sneakers-the-rat/linkml-runtime/actions/runs/13085918692/job/36517032161#step:4:23) and [correct branch](https://github.com/sneakers-the-rat/linkml-runtime/actions/runs/13085918692/job/36517032161#step:4:258):
https://github.com/sneakers-the-rat/linkml-runtime/pull/1
and this PR is an example of working with the default upstream when none is specified

This shouldn't be any more dangerous than running the action for external PRs already is, since the user input is [cast to an environment variable](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable) (rather than being [directly injected](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#example-of-a-script-injection-attack)), and while it is true they could be testing against an upstream branch that has been modified to pass all tests, or try to snatch environment variables, the same is already true with the existing action.

hopefully this makes things a lil easier and makes co-maintaining these repos less of a pain