### PR TITLE
Fix multilayer relative imports

### DIFF
--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -113,7 +113,12 @@ def resolve_import(sn: str, i: str) -> str:
     if urlparse(i).scheme:
         return i
     else:
-        return os.path.normpath(str(Path(sn).parent / i))
+        path = os.path.normpath(str(Path(sn).parent / i))
+        if i.startswith(".") and not path.startswith("."):
+            # Above condition handles cases where both sn and i are relative paths, and path is not already relative
+            return f"./{path}"
+        else:
+            return path
 
 
 @dataclass
@@ -301,7 +306,9 @@ class SchemaView(object):
                     if i == sn:
                         continue
                     else:
+                        temp = i
                         i = resolve_import(sn, i)
+                    _ = sn, temp, i
                     todo.append(i)
 
             # add item to closure

--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -107,6 +107,14 @@ def is_absolute_path(path: str) -> bool:
     drive, tail = os.path.splitdrive(norm_path)
     return bool(drive and tail)
 
+#  WINDOWS:
+#     # This cannot be simplified. os.path.normpath() must be called before .as_posix()
+#     i = PurePath(os.path.normpath(PurePath(sn).parent / i)).as_posix()
+#     # i = resolve_import(sn, i)
+# else:
+#     # i = resolve_import(sn, i)
+#     i = os.path.normpath(str(Path(sn).parent / i))
+
 def _resolve_import(source_sch: str, imported_sch: str) -> str:
     if os.path.isabs(imported_sch):
         # Absolute import paths are not modified

--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -107,14 +107,6 @@ def is_absolute_path(path: str) -> bool:
     drive, tail = os.path.splitdrive(norm_path)
     return bool(drive and tail)
 
-#  WINDOWS:
-#     # This cannot be simplified. os.path.normpath() must be called before .as_posix()
-#     i = PurePath(os.path.normpath(PurePath(sn).parent / i)).as_posix()
-#     # i = resolve_import(sn, i)
-# else:
-#     # i = resolve_import(sn, i)
-#     i = os.path.normpath(str(Path(sn).parent / i))
-
 def _resolve_import(source_sch: str, imported_sch: str) -> str:
     if os.path.isabs(imported_sch):
         # Absolute import paths are not modified

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "linkml-runtime"
-version = "0.0.0"
+version = "1.8.3.dev0"
 description = "Runtime environment for LinkML, the Linked open data modeling language"
 authors = [
     "Chris Mungall <cjmungall@lbl.gov>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "linkml-runtime"
-version = "1.8.3.dev0"
+version = "0.0.0"
 description = "Runtime environment for LinkML, the Linked open data modeling language"
 authors = [
     "Chris Mungall <cjmungall@lbl.gov>",

--- a/tests/test_utils/input/imports_relative/L0_2/L2_2_0/L3_2_0_0/L4_2_0_0_0/greatgrandchild.yaml
+++ b/tests/test_utils/input/imports_relative/L0_2/L2_2_0/L3_2_0_0/L4_2_0_0_0/greatgrandchild.yaml
@@ -1,0 +1,5 @@
+id: greatgrandchild
+name: greatgrandchild
+title: greatgrandchild
+imports:
+  - linkml:types

--- a/tests/test_utils/input/imports_relative/L0_2/L2_2_0/L3_2_0_0/grandchild.yaml
+++ b/tests/test_utils/input/imports_relative/L0_2/L2_2_0/L3_2_0_0/grandchild.yaml
@@ -1,0 +1,6 @@
+id: grandchild
+name: grandchild
+title: grandchild
+imports:
+  - linkml:types
+  - ./L4_2_0_0_0/greatgrandchild

--- a/tests/test_utils/input/imports_relative/L0_2/L2_2_0/child.yaml
+++ b/tests/test_utils/input/imports_relative/L0_2/L2_2_0/child.yaml
@@ -1,0 +1,6 @@
+id: child
+name: child
+title: child
+imports:
+  - linkml:types
+  - ./L3_2_0_0/grandchild

--- a/tests/test_utils/input/imports_relative/L0_2/main.yaml
+++ b/tests/test_utils/input/imports_relative/L0_2/main.yaml
@@ -1,0 +1,6 @@
+id: main
+name: main
+title: main
+imports:
+  - linkml:types
+  - ./L2_2_0/child

--- a/tests/test_utils/test_schemaview.py
+++ b/tests/test_utils/test_schemaview.py
@@ -22,6 +22,8 @@ SCHEMA_WITH_IMPORTS = Path(INPUT_DIR) / 'kitchen_sink.yaml'
 SCHEMA_WITH_STRUCTURED_PATTERNS = Path(INPUT_DIR) / "pattern-example.yaml"
 SCHEMA_IMPORT_TREE = Path(INPUT_DIR) / 'imports' / 'main.yaml'
 SCHEMA_RELATIVE_IMPORT_TREE = Path(INPUT_DIR) / 'imports_relative' / 'L0_0' / 'L1_0_0' / 'main.yaml'
+SCHEMA_RELATIVE_IMPORT_TREE2 = Path(INPUT_DIR) / 'imports_relative' / 'L0_2' / 'main.yaml'
+
 
 yaml_loader = YAMLLoader()
 IS_CURRENT = 'is current'
@@ -548,6 +550,11 @@ def test_imports_relative():
     assert 'L110Index' in classes
     assert 'L2100Index' in classes
     assert 'L2101Index' in classes
+
+def test_imports_relative_load():
+    """Relative imports from relative imports should load without FileNotFoundError."""
+    sv = SchemaView(SCHEMA_RELATIVE_IMPORT_TREE2)
+    sv.imports_closure(imports=True)
 
 
 def test_direct_remote_imports():


### PR DESCRIPTION
Originally mentioned in [this issue](https://github.com/linkml/linkml/issues/2525) on the [linkml](https://github.com/linkml/linkml) repo.

When you attempt to use relative imports from a file that, itself, has been imported with a relative import, path resolution fails. This bug occurs both in `linkml` and `linkml-runtime`. In `linkml-runtime`, the problem occurs in `schemaview.py`:

```python
if sn.startswith('.') and ':' not in i:
       i = os.path.normpath(str(Path(sn).parent / i))
```

If both `sn` and `i` are relative file paths, the path added to `todo` is an absolute path (at least on Mac). When `i` later than becomes `sn`, it's not picked up by the above clause and anything it imports does not hit the above condition and therefore just defined relative to the base file.

Marking as draft. @sneakers-the-rat noticed you were the last to edit this section, specifically [here](https://github.com/will-0/linkml-runtime/commit/af5a1a6e40ac24f8bd0eabe6ab37d04f1021a326). Would appreciate input as to whether there's a reason for the above / it is expected behaviour and I'm missing something. 