### PR TITLE
Fix test upstream: `-y` to pip uninstall

### DIFF
--- a/.github/workflows/test-upstream.yaml
+++ b/.github/workflows/test-upstream.yaml
@@ -68,7 +68,7 @@ jobs:
       # make extra sure we're removing any old version of linkml-runtime that exists
       - name: uninstall potentially cached linkml-runtime
         working-directory: linkml
-        run: poetry run pip uninstall linkml-runtime
+        run: poetry run pip uninstall -y linkml-runtime
 
       # we are not using linkml-runtime's lockfile, but simulating what will happen
       # when we merge this and update linkml's lockfile


### PR DESCRIPTION
We have a pileup of related PRs:
- https://github.com/linkml/linkml-runtime/pull/360 - currently failing because of this, needs to be merged ASAP
- https://github.com/linkml/linkml-runtime/pull/350 - fails on windows, masked by 360
- https://github.com/linkml/linkml-runtime/pull/367 - includes this, but does more
- https://github.com/linkml/linkml-runtime/pull/364 - also touches this action orthogonally (and removes the need for this) but needs changes in upstream

Trying to break the backlog with this tiny little commit that should let us do 360, which then will let us handle the rest