### PR TITLE
Consistent datetime parsing across all py-versions

### DIFF
--- a/linkml_runtime/utils/metamodelcore.py
+++ b/linkml_runtime/utils/metamodelcore.py
@@ -301,8 +301,11 @@ class XSDDateTime(str, TypedNode):
                 else:
                     if "T" in str(value):
                         value = isodate.parse_datetime(value)
-                    else:
+                    elif " " in value.strip():
                         value = isodate.parse_datetime("T".join(value.strip().split(' ', 1)))
+                    else: 
+                        # As datetime.fromisoformat allows dates to be parsed as datetime we do the same.
+                        value = isodate.parse_datetime(f"{value.strip()}T00:00:00")
             return value.isoformat()
         except (TypeError, ValueError) as e:
             if is_strict():

--- a/tests/test_utils/test_metamodelcore.py
+++ b/tests/test_utils/test_metamodelcore.py
@@ -193,8 +193,10 @@ class MetamodelCoreTest(unittest.TestCase):
         self.assertEqual('2019-07-06 17:22:39.007300', vstr)       # Note that this has no 'T'
         self.assertEqual('2019-07-06T17:22:39.007300', XSDDateTime(vstr))
         self.assertEqual('2019-07-06T17:22:39+00:00', XSDDateTime("2019-07-06T17:22:39Z"))
+        self.assertEqual('2019-07-06T00:00:00', XSDDateTime("2019-07-06")) # Date as datetime
         with self.assertRaises(ValueError):
             XSDDateTime('Jan 12, 2019')
+
         lax()
         self.assertEqual('penguins', XSDDateTime('penguins'))
         XSDDateTime(datetime.datetime.now())


### PR DESCRIPTION
Old Python versions before 3.11 have to use the isodate-package for parsing ISO 8601 date-times. Newer versions use `datetime.fromisoformat`. Both differ in handling of dates like "2025-02-24": Error in isodate-package, parsed to "2025-02-24T00:00:00" with `datetime.fromisoformat`. This PR makes the behavior the same across the supported Python versions.

The issue was observed in the PR #350.
