### PR TITLE
Fix "workflow_dispatch" mode for test-upstream action

### DIFF
--- a/.github/workflows/test-upstream.yaml
+++ b/.github/workflows/test-upstream.yaml
@@ -80,7 +80,7 @@ jobs:
         shell: bash
         run: |
           echo "upstream_branch=${{ inputs.upstream_branch }}" >> "$GITHUB_ENV"
-          echo "upstream_repo=${{ inputs.upstream_repo }}" >> $GITHUB_ENV"
+          echo "upstream_repo=${{ inputs.upstream_repo }}" >> "$GITHUB_ENV"
 
       - name: checkout upstream
         uses: actions/checkout@v4


### PR DESCRIPTION
Adds a missing quote which led to failing runs when the job was triggered via "workflow_dispatch" option.