### PR TITLE
test(schemaview): schema without default_prefix

### DIFF
--- a/tests/test_utils/input/kitchen_sink_nodefaultprefix.yaml
+++ b/tests/test_utils/input/kitchen_sink_nodefaultprefix.yaml
@@ -1,0 +1,270 @@
+id: https://w3id.org/linkml/tests/kitchen_sink
+name: kitchen_sink
+description: |-
+  Kitchen Sink Schema
+
+  This schema does not do anything useful. It exists to test all features of linkml.
+
+  This particular text field exists to demonstrate markdown within a text field:
+
+  Lists:
+
+     * a
+     * b
+     * c
+
+  And links, e.g to [Person](Person.md)
+
+default_curi_maps:
+  - semweb_context
+imports:
+  - linkml:types
+  - core
+prefixes:
+  pav: http://purl.org/pav/
+  dce: http://purl.org/dc/elements/1.1/
+  lego: http://geneontology.org/lego/
+  linkml: https://w3id.org/linkml/
+  biolink: https://w3id.org/biolink/
+  ks: https://w3id.org/linkml/tests/kitchen_sink/
+  RO: http://purl.obolibrary.org/obo/RO_
+  BFO: http://purl.obolibrary.org/obo/BFO_
+  tax: http://example.org/tax/
+default_range: string
+see_also:
+  - https://example.org/
+
+subsets:
+
+  subset A:
+    description: >-
+      test subset A
+    comments:
+      - this subset is meaningless, it is just here for testing
+    aliases:
+      - A
+  subset B:
+    description: >-
+      test subset B
+    aliases:
+      - B
+
+classes:
+
+  HasAliases:
+    mixin: true
+    attributes:
+      aliases:
+        multivalued: true
+
+  Thing:
+    slots:
+      - id
+      - name
+
+  Person:
+    is_a: Thing
+    in_subset:
+      - subset A
+    mixins:
+      - HasAliases
+    slots:
+      - has employment history
+      - has familial relationships
+      - has medical history
+      - age in years
+      - addresses
+      - has birth event
+    slot_usage:
+      name:
+        pattern: "^\\S+ \\S+"  ## do not do this in a real schema, people have all kinds of names
+
+  Adult:
+    is_a: Person
+    slot_usage:
+      age in years:
+        minimum_value: 16
+
+  Organization:
+    is_a: Thing
+    mixins:
+      - HasAliases
+
+  Place:
+    mixins:
+      - HasAliases
+    slots:
+      - id
+      - name
+  Address:
+    slots:
+      - street
+      - city
+
+  Event:
+    slots:
+      - started at time
+      - ended at time
+      - is current
+
+  Relationship:
+    slots:
+      - started at time
+      - ended at time
+      - related to
+      - type
+
+  FamilialRelationship:
+    is_a: Relationship
+    slot_usage:
+      type:
+        range: FamilialRelationshipType
+        required: true
+      related to:
+        range: Person
+        required: true
+
+  BirthEvent:
+    is_a: Event
+    slots:
+      - in location
+
+  EmploymentEvent:
+    is_a: Event
+    slots:
+      - employed at
+
+  MedicalEvent:
+    is_a: Event
+
+  WithLocation:
+    mixin: true
+    slots:
+      - in location
+
+  MarriageEvent:
+    is_a: Event
+    mixins:
+      - WithLocation
+    slots:
+      - married to
+
+  Company:
+    is_a: Organization
+    attributes:
+      ceo:
+        range: Person
+
+  Dataset:
+    attributes:
+      persons:
+        range: Person
+        inlined: true
+        inlined_as_list: true
+        multivalued: true
+      companies:
+        range: Company
+        inlined_as_list: true
+        inlined: true
+        multivalued: true
+      activities:
+        range: activity
+        inlined_as_list: true
+        inlined: true
+        multivalued: true
+
+slots:
+  employed at:
+    range: Company
+    in_subset:
+      - subset A
+  is current:
+    range: boolean
+    annotations:
+      tag: ks:foo
+      value: bar
+
+  has employment history:
+    range: EmploymentEvent
+    multivalued: true
+    inlined_as_list: true
+    in_subset:
+      - subset B
+  has marriage history:
+    range: MarriageEvent
+    multivalued: true
+    inlined_as_list: true
+    in_subset:
+      - subset B
+  has medical history:
+    range: MedicalEvent
+    multivalued: true
+    inlined_as_list: true
+    in_subset:
+      - subset B
+  has familial relationships:
+    range: FamilialRelationship
+    multivalued: true
+    inlined_as_list: true
+    in_subset:
+      - subset B
+  married to:
+    range: Person
+  in location:
+    range: Place
+  addresses:
+    range: Address
+    multivalued: True
+  age in years:
+    range: integer
+    minimum_value: 0
+    maximum_value: 999
+    in_subset:
+      - subset A
+      - subset B
+  related to:
+    range: Thing
+  type:
+    range: string
+  street:
+  city:
+  has birth event:
+    range: BirthEvent
+  height_in_m:
+    range: float
+    unit:
+      ucum_code: m
+
+
+
+
+
+enums:
+  FamilialRelationshipType:
+    permissible_values:
+      SIBLING_OF:
+      PARENT_OF:
+      CHILD_OF:
+  DiagnosisType:
+  OrganismType:
+    permissible_values:
+      MAMMAL:
+        meaning: tax:02
+      HUMAN:
+        is_a: MAMMAL
+  HCAExample:
+    see_also:
+      - https://github.com/linkml/linkml/issues/274
+    include:
+      - reachable_from:
+          source_ontology: bioregistry:go
+          source_nodes:
+            - GO:0007049
+            - GO:0022403
+          include_self: false
+          relationship_types:
+            - rdfs:subClassOf
+    minus:
+      concepts:
+        - LOINC:5932-9
+

--- a/tests/test_utils/test_schemaview.py
+++ b/tests/test_utils/test_schemaview.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 
 SCHEMA_NO_IMPORTS = Path(INPUT_DIR) / 'kitchen_sink_noimports.yaml'
 SCHEMA_WITH_IMPORTS = Path(INPUT_DIR) / 'kitchen_sink.yaml'
+SCHEMA_NO_DEFAULT_PREFIX = Path(INPUT_DIR) / 'kitchen_sink_nodefaultprefix.yaml'
 SCHEMA_WITH_STRUCTURED_PATTERNS = Path(INPUT_DIR) / "pattern-example.yaml"
 SCHEMA_IMPORT_TREE = Path(INPUT_DIR) / 'imports' / 'main.yaml'
 SCHEMA_RELATIVE_IMPORT_TREE = Path(INPUT_DIR) / 'imports_relative' / 'L0_0' / 'L1_0_0' / 'main.yaml'
@@ -41,6 +42,11 @@ def schema_view_no_imports():
 def view():
     """Fixture for SchemaView with imports."""
     return SchemaView(SCHEMA_WITH_IMPORTS)
+
+
+@pytest.fixture
+def schema_view_no_default_prefix():
+    return SchemaView(SCHEMA_NO_DEFAULT_PREFIX)
 
 
 def test_children_method(schema_view_no_imports):
@@ -916,3 +922,10 @@ def test_type_and_slot_with_same_name():
     view.add_type(TypeDefinition(name="test", from_schema="https://example.org/imported#"))
 
     assert view.get_uri("test", imports=True) == "ex:test"
+
+
+def test_no_default_prefix(schema_view_no_default_prefix):
+    view = schema_view_no_default_prefix
+    assert view.get_uri(COMPANY) == "https://w3id.org/linkml/tests/kitchen_sink/Company"
+    assert view.get_uri(EMPLOYED_AT) == 'https://w3id.org/linkml/tests/kitchen_sink/employed_at'
+    assert view.get_uri(AGENT) == 'prov:Agent'


### PR DESCRIPTION
Add regression test for issue #2578 [^1].

Issue was that SchemaView method `get_uri` was adding an errorneous ':' when no `default_prefix` was being declared in the schema.

[^1]: https://github.com/linkml/linkml/issues/2578