### PR TITLE
Constrain isodate import to Python < 3.11

### DIFF
--- a/linkml_runtime/utils/metamodelcore.py
+++ b/linkml_runtime/utils/metamodelcore.py
@@ -7,7 +7,6 @@ import sys
 from typing import Union, Optional
 from urllib.parse import urlparse
 
-import isodate
 from rdflib import Literal, BNode, URIRef
 from rdflib.namespace import is_ncname
 from rdflib.term import Identifier as rdflib_Identifier
@@ -18,6 +17,9 @@ from linkml_runtime.utils.strictness import is_strict
 from linkml_runtime.utils.uri_validator import validate_uri
 from linkml_runtime.utils.uri_validator import validate_uri_reference
 from linkml_runtime.utils.uri_validator import validate_curie
+
+if sys.version_info < (3, 11):
+    import isodate
 
 # Reference Decimal to make sure it stays in the imports
 _z = Decimal(1)

--- a/poetry.lock
+++ b/poetry.lock
@@ -386,6 +386,7 @@ description = "An ISO 8601 date/time/duration parser and formatter"
 optional = false
 python-versions = ">=3.7"
 groups = ["main"]
+markers = "python_version < \"3.11\""
 files = [
     {file = "isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15"},
     {file = "isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6"},
@@ -1229,4 +1230,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.9"
-content-hash = "33f9cfe6aea6e8743ca5021d096947ee070aaa2753230471c8667667e148a261"
+content-hash = "a86079065945ae5cb39460f22b2a0d331f8145aeec49d25f05cb23b20ce0c468"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "prefixmaps >=0.1.4",
     "curies >=0.5.4",
     "pydantic >=1.10.2, <3.0.0",
-    "isodate >=0.7.2, <1.0.0, python_version < '3.11'",
+    "isodate >=0.7.2, <1.0.0; python_version < '3.11'",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "prefixmaps >=0.1.4",
     "curies >=0.5.4",
     "pydantic >=1.10.2, <3.0.0",
-    "isodate >=0.7.2",
+    "isodate >=0.7.2, <1.0.0, python_version < '3.11'",
 ]
 
 [project.scripts]


### PR DESCRIPTION
upstream_repo: dalito/linkml
upstream_branch: issue2578-fix-uri-in-snapshot

Fixes that isodate is imported and declared as dependency for all Python versions although it is only needed for Python < 3.11.

This PR replaces #377.
