### PR TITLE
Cherry-pciked fixes from #378 for rc2

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,7 +4,12 @@
 
 name: Build and test linkml-runtime
 
-on: [pull_request]
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   test:

--- a/tests/test_utils/test_schema_builder.py
+++ b/tests/test_utils/test_schema_builder.py
@@ -185,7 +185,7 @@ def test_add_class_with_extra_kwargs(
 )
 def test_add_enum_with_extra_permissible_values(
     enum_def: EnumDefinition,
-    permissible_values: List[Union[str, PermissibleValue]],
+    permissible_values: list[Union[str, PermissibleValue]],
     expected_added_enum: Optional[EnumDefinition],
 ):
     """
@@ -231,7 +231,7 @@ def test_add_enum_with_extra_permissible_values(
 )
 def test_add_enum_with_extra_kwargs(
     enum_def: Union[EnumDefinition, dict, str],
-    extra_kwargs: Dict[str, Any],
+    extra_kwargs: dict[str, Any],
     expected_added_enum: Optional[EnumDefinition],
 ):
     """

--- a/tests/test_utils/test_schema_builder.py
+++ b/tests/test_utils/test_schema_builder.py
@@ -247,7 +247,7 @@ def test_add_enum_with_extra_kwargs(
     elif extra_kwargs.keys() - enum_meta_slots:
         # Handle the case of extra kwargs include a key that is not a meta slot of
         # `EnumDefinition`
-        with pytest.raises(ValueError):
+        with pytest.raises(TypeError):
             builder.add_enum(enum_def, **extra_kwargs)
     else:
         builder.add_enum(enum_def, **extra_kwargs)


### PR DESCRIPTION
upstream_repo: sneakers-the-rat/linkml
upstream_branch: python-3.13

This cherry-picks the two last commits from #378 to fix the typing issue (Dict/dict, List/list) and the type of expected exception in `tests/test_utils/test_schema_builder.py`.

As discussed in dev call the main action is not triggered on merging to main. I added a fix for the trigger.