### PR TITLE
Change to secure publishing for PyPI

### DIFF
--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -55,6 +55,6 @@ jobs:
 
       - name: Publish package 📦 to PyPI
         if: github.event_name == 'release'
-        uses: pypa/gh-action-pypi-publish@v1.12
+        uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
           verbose: true

--- a/.github/workflows/pypi-publish.yaml
+++ b/.github/workflows/pypi-publish.yaml
@@ -40,12 +40,12 @@ jobs:
     name: Build and publish Python 🐍 package 📦 to PyPI
     needs: build
     runs-on: ubuntu-latest
-    # Next 5 lines prepare for trusted publishing: https://docs.pypi.org/trusted-publishers/adding-a-publisher/
-    # environment:
-    #   name: pypi-release
-    #   url: https://pypi.org/p/linkml-runtime
-    # permissions:
-    #   id-token: write  # this permission is mandatory for trusted publishing
+    # Uses trusted publishing. https://docs.pypi.org/trusted-publishers/adding-a-publisher/
+    environment:
+      name: pypi-release
+      url: https://pypi.org/p/linkml-runtime
+    permissions:
+      id-token: write  # This permission is mandatory for trusted publishing.
     steps:
       - name: Download built distribution
         uses: actions/download-artifact@v4.3.0
@@ -57,5 +57,4 @@ jobs:
         if: github.event_name == 'release'
         uses: pypa/gh-action-pypi-publish@v1.12
         with:
-          password: ${{ secrets.pypi_password }}
-          # verbose: true
+          verbose: true


### PR DESCRIPTION
upstream_repo: dalito/linkml
upstream_branch: issue2578-fix-uri-in-snapshot

Requires changing the configuration on  PyPI. It is important to use the same environment name "pypi-release" (this name is different from some screenshots in the docs).

The [upload-failure for 1.9.2-rc1](https://github.com/linkml/linkml-runtime/actions/runs/14781131922) was most probably only caused by specifying the used action as `pypa/gh-action-pypi-publish@v1.12`. The problem is that "1.12" is not a valid tag and so the action could not be downloaded/installed. In the [gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish/releases) repository they only tag full versions "1.12.4" but not the minor versions without patch level "1.12". I changed this PR to use the full version.