### PR TITLE
Fix detection of CURIES vs. absolute paths on Windows

### DIFF
--- a/.github/workflows/test-upstream.yaml
+++ b/.github/workflows/test-upstream.yaml
@@ -42,7 +42,7 @@ jobs:
         run: |
           set +e
           set +o pipefail
-          
+
           UPSTREAM_BRANCH=$( \
             echo "$PR_BODY" | \
             head -2 | \
@@ -52,12 +52,12 @@ jobs:
           )
           echo "Got upstream branch:"
           echo $UPSTREAM_BRANCH
-          
+
           if [[ -z "$UPSTREAM_BRANCH" ]]; then
             echo "Using main as default"
             UPSTREAM_BRANCH="main"
           fi
-          
+
           UPSTREAM_REPO=$( \
             echo "$PR_BODY" | \
             head -2 | \
@@ -67,7 +67,7 @@ jobs:
           )
           echo "Got upstream repo:"
           echo $UPSTREAM_REPO
-          
+
           if [[ -z "$UPSTREAM_REPO" ]]; then
             echo "Using linkml/linkml as default"
             UPSTREAM_REPO="linkml/linkml"
@@ -128,11 +128,6 @@ jobs:
           path: linkml/.venv
           key: venv-${{ matrix.python-version }}-${{ runner.os }}-${{ hashFiles('**/poetry.lock') }}
 
-      # make extra sure we're removing any old version of linkml-runtime that exists
-      - name: uninstall potentially cached linkml-runtime
-        working-directory: linkml
-        run: poetry run pip uninstall -y linkml-runtime
-
       # we are not using linkml-runtime's lockfile, but simulating what will happen
       # when we merge this and update linkml's lockfile
       - name: add linkml-runtime to lockfile
@@ -145,7 +140,7 @@ jobs:
       # the cache will still speedup the rest of the installation
       - name: install linkml
         working-directory: linkml
-        run: poetry install --no-interaction -E tests
+        run: poetry sync --no-interaction --all-extras
 
       - name: print linkml-runtime version
         working-directory: linkml

--- a/linkml_runtime/utils/context_utils.py
+++ b/linkml_runtime/utils/context_utils.py
@@ -50,7 +50,7 @@ def merge_contexts(contexts: CONTEXTS_PARAM_TYPE = None, base: Optional[Any] = N
         JsonObj(**{"@context": context_list[0] if len(context_list) == 1 else context_list})
 
 
-def map_import(importmap: dict[str, str], namespaces: Callable[[None], "Namespaces"], imp: Any) -> str:
+def map_import(importmap: dict[str, str], namespaces: Callable[[], "Namespaces"], imp: Any) -> str:
     """
     lookup an import in an importmap.
 
@@ -73,7 +73,8 @@ def map_import(importmap: dict[str, str], namespaces: Callable[[None], "Namespac
             else:
                 sname = os.path.join(expanded_prefix, lname)
     sname = importmap.get(sname, sname)  # Import map may use CURIE
-    sname = str(namespaces().uri_for(sname)) if ':' in sname else sname
+    if ':' in sname and not ":\\" in sname:  # Don't interpret Windows paths as CURIEs
+        sname = str(namespaces().uri_for(sname))
     return importmap.get(sname, sname)  # It may also use URI or other forms
 
 
@@ -103,7 +104,7 @@ def parse_import_map(map_: Optional[Union[str, dict[str, str], TextIOWrapper]],
     if base:
         outmap = dict()
         for k, v in rval.items():
-            if ':' not in v:
+            if ':' not in v or ":\\" in v:  # Don't interpret Windows paths as CURIEs
                 v = os.path.join(os.path.abspath(base), v)
             outmap[k] = v
         rval = outmap

--- a/linkml_runtime/utils/context_utils.py
+++ b/linkml_runtime/utils/context_utils.py
@@ -6,6 +6,12 @@ from typing import Optional, Union, Any, Callable
 import yaml
 from jsonasobj2 import JsonObj, loads
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from linkml_runtime.utils.namespaces import Namespaces
+
+
 CONTEXT_TYPE = Union[str, dict, JsonObj]
 CONTEXTS_PARAM_TYPE = Optional[Union[CONTEXT_TYPE, list[CONTEXT_TYPE]]]
 

--- a/tests/test_utils/test_context_utils.py
+++ b/tests/test_utils/test_context_utils.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 
 from jsonasobj2 import JsonObj, loads
@@ -93,17 +94,18 @@ def test_merge_contexts_base():
 @pytest.mark.parametrize(
     ("imp", "result"),
     [
-        ("linkml:types", r"C:\temp\linkml_model\model\schema\types"),
-        ("ex_file", "C:\\temp\\example\\schema"),
+        ("linkml:types", f"C:\\temp\\linkml_model\\model\\schema{os.sep}types"),
+        ("ex_file", "/tmp/example/schema"),
         ("_types", "https://w3id.org/linkml/types"),
     ],
 )
 def test_map_import(imp, result):
     importmap = {
         "linkml:": "C:\\temp\\linkml_model\\model\\schema",
-        "ex_file": "C:\\temp\\example\\schema",
+        "ex_file": "/tmp/example/schema",
         "_types": "linkml:types",
     }
+
     def namespaces():
         ns = Namespaces()
         ns["linkml"] = URIRef("https://w3id.org/linkml/")

--- a/tests/test_utils/test_context_utils.py
+++ b/tests/test_utils/test_context_utils.py
@@ -1,8 +1,12 @@
-import unittest
+import pytest
 
 from jsonasobj2 import JsonObj, loads
+from rdflib import URIRef
 
-from linkml_runtime.utils.context_utils import merge_contexts
+from linkml_runtime.linkml_model.meta import ClassDefinition, Prefix, SchemaDefinition
+from linkml_runtime.utils.context_utils import map_import, merge_contexts
+from linkml_runtime.utils.namespaces import Namespaces
+
 from tests.test_utils import METAMODEL_CONTEXT_URI, META_BASE_URI
 
 json_1 = '{ "ex": "http://example.org/test/", "ex2": "http://example.org/test2/" }'
@@ -26,43 +30,47 @@ context_output = """{
 }"""
 
 
-class ContextUtilsTestCase(unittest.TestCase):
-    def test_merge_contexts(self):
-        self.assertIsNone(merge_contexts())
-        self.assertEqual('file://local.jsonld', merge_contexts("local.jsonld")['@context'])
-        self.assertEqual('file://local.jsonld', merge_contexts(["local.jsonld"])['@context'])
-        self.assertEqual(METAMODEL_CONTEXT_URI, merge_contexts(METAMODEL_CONTEXT_URI)['@context'])
-        self.assertEqual(METAMODEL_CONTEXT_URI, merge_contexts([METAMODEL_CONTEXT_URI])['@context'])
-        self.assertEqual(JsonObj(ex='http://example.org/test/', ex2='http://example.org/test2/'),
-                         merge_contexts(json_1)['@context'])
-        self.assertEqual(JsonObj(ex='http://example.org/test/', ex2='http://example.org/test2/'),
-                         merge_contexts([json_1])['@context'])
-        self.assertEqual(JsonObj(ex='http://example.org/test3/', ex2=JsonObj(**{'@id': 'http://example.org/test4/'})),
-                         merge_contexts(json_2)['@context'])
-        self.assertEqual(JsonObj(ex='http://example.org/test3/', ex2=JsonObj(**{'@id': 'http://example.org/test4/'})),
-                         merge_contexts([json_2])['@context'])
-        self.assertEqual([f'file://local.jsonld',
-                          'https://w3id.org/linkml/meta.context.jsonld',
-                          JsonObj(ex='http://example.org/test/', ex2='http://example.org/test2/'),
-                          JsonObj(ex='http://example.org/test3/', ex2=JsonObj(**{'@id': 'http://example.org/test4/'}))],
-                         merge_contexts(["local.jsonld", METAMODEL_CONTEXT_URI, json_1, json_2])['@context'])
-        self.assertEqual(loads(context_output),
-                         merge_contexts(["local.jsonld", METAMODEL_CONTEXT_URI, json_1, json_2]))
+def test_merge_contexts():
+    assert merge_contexts() is None
+    assert "file://local.jsonld" == merge_contexts("local.jsonld")["@context"]
+    assert "file://local.jsonld" == merge_contexts(["local.jsonld"])["@context"]
+    assert METAMODEL_CONTEXT_URI == merge_contexts(METAMODEL_CONTEXT_URI)["@context"]
+    assert METAMODEL_CONTEXT_URI == merge_contexts([METAMODEL_CONTEXT_URI])["@context"]
+    assert JsonObj(ex="http://example.org/test/", ex2="http://example.org/test2/") == merge_contexts(json_1)["@context"]
+    assert (
+        JsonObj(ex="http://example.org/test/", ex2="http://example.org/test2/") == merge_contexts([json_1])["@context"]
+    )
+    assert (
+        JsonObj(ex="http://example.org/test3/", ex2=JsonObj(**{"@id": "http://example.org/test4/"}))
+        == merge_contexts(json_2)["@context"]
+    )
+    assert (
+        JsonObj(ex="http://example.org/test3/", ex2=JsonObj(**{"@id": "http://example.org/test4/"}))
+        == merge_contexts([json_2])["@context"]
+    )
+    assert [
+        f"file://local.jsonld",
+        "https://w3id.org/linkml/meta.context.jsonld",
+        JsonObj(ex="http://example.org/test/", ex2="http://example.org/test2/"),
+        JsonObj(ex="http://example.org/test3/", ex2=JsonObj(**{"@id": "http://example.org/test4/"})),
+    ] == merge_contexts(["local.jsonld", METAMODEL_CONTEXT_URI, json_1, json_2])["@context"]
+    assert loads(context_output) == merge_contexts(["local.jsonld", METAMODEL_CONTEXT_URI, json_1, json_2])
+    # Dups are not removed
+    assert JsonObj(
+        **{
+            "@context": [
+                JsonObj(ex="http://example.org/test/", ex2="http://example.org/test2/"),
+                JsonObj(ex="http://example.org/test/", ex2="http://example.org/test2/"),
+            ]
+        }
+    ) == merge_contexts([json_1, json_1])
+    assert "file://local.jsonld", merge_contexts("local.jsonld")["@context"]
 
-        # Dups are not removed
-        self.assertEqual(
-            JsonObj(**{'@context': [JsonObj(ex='http://example.org/test/', ex2='http://example.org/test2/'),
-                                    JsonObj(ex='http://example.org/test/', ex2='http://example.org/test2/')]}),
-            merge_contexts([json_1, json_1]))
-        self.assertEqual('file://local.jsonld', merge_contexts("local.jsonld")['@context'])
 
-    def test_merge_contexts_base(self):
-        self.assertEqual(
-            JsonObj(**{'@context':
-                           JsonObj(**{'@base': 'file://relloc'})}),
-            merge_contexts(base='file://relloc'))
-        self.assertEqual(loads(f'{{"@context": {{"@base": "{META_BASE_URI}"}}}}'), merge_contexts(base=META_BASE_URI))
-        self.assertEqual(loads("""
+def test_merge_contexts_base():
+    assert JsonObj(**{"@context": JsonObj(**{"@base": "file://relloc"})}) == merge_contexts(base="file://relloc")
+    assert loads(f'{{"@context": {{"@base": "{META_BASE_URI}"}}}}') == merge_contexts(base=META_BASE_URI)
+    assert loads("""
 {"@context": [
       "https://w3id.org/linkml/meta.context.jsonld",
       {
@@ -79,8 +87,28 @@ class ContextUtilsTestCase(unittest.TestCase):
          "@base": "https://w3id.org/linkml/"
       }
    ]
-}"""), merge_contexts([METAMODEL_CONTEXT_URI, json_1, json_2], base=META_BASE_URI))
+}""") == merge_contexts([METAMODEL_CONTEXT_URI, json_1, json_2], base=META_BASE_URI)
 
 
-if __name__ == '__main__':
-    unittest.main()
+@pytest.mark.parametrize(
+    ("imp", "result"),
+    [
+        ("linkml:types", r"C:\temp\linkml_model\model\schema\types"),
+        ("ex_file", "C:\\temp\\example\\schema"),
+        ("_types", "https://w3id.org/linkml/types"),
+    ],
+)
+def test_map_import(imp, result):
+    importmap = {
+        "linkml:": "C:\\temp\\linkml_model\\model\\schema",
+        "ex_file": "C:\\temp\\example\\schema",
+        "_types": "linkml:types",
+    }
+    def namespaces():
+        ns = Namespaces()
+        ns["linkml"] = URIRef("https://w3id.org/linkml/")
+        ns["ex_file"] = URIRef("https://example.org/file/")
+        ns["_types"] = URIRef("https://w3id.org/linkml/types/")
+        return ns
+
+    assert map_import(importmap, namespaces, imp) == result


### PR DESCRIPTION
upstream_repo: dalito/linkml
upstream_branch: issue2696-remove-windows-special-casing

Fixes issues in `utils/context_utils.py`:

- Avoids that absolute filepaths are treated as CURIES on Windows
- Fixes wrongly typed callable in `map_import` function
- Fixes test-upstream action to install linkml with `--all-extras` (else the pandera tests fail)

@ialarmedalien , @sierra-moxon - This was the problem you hit in linkml/linkml#2675

Related to linkml/linkml#2696