### PR TITLE
Fix object instantiation in `_normalize_inlined()`

### DIFF
--- a/linkml_runtime/utils/yamlutils.py
+++ b/linkml_runtime/utils/yamlutils.py
@@ -169,7 +169,7 @@ class YAMLRoot(JsonObj):
                         for lek, lev in items(list_entry):
                             if lek == key_name and not isinstance(lev, (list, dict, JsonObj)):
                                 # key_name:value
-                                order_up(list_entry[lek], slot_type(list_entry))
+                                order_up(list_entry[lek], slot_type(**list_entry))
                                 break   # Not strictly necessary, but
                             elif not isinstance(lev, (list, dict, JsonObj)):
                                 # key: value --> slot_type(key, value)


### PR DESCRIPTION
This commit fixes a problem that was discovered when using `linkml-convert` to convert  JSON to TTL using the schema: <https://concepts.inm7.de/s/simpleinput/unreleased.yaml>

The original code used a dictionary as the argument to the constructor of a Pydantic class, but should have used the `**`-operator to convert the dictionary into keyword arguments.