### PR TITLE
Create URIs (w3id.org PURLs) for Enums in same style as for classes & slots

### DIFF
--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -1213,6 +1213,9 @@ class SchemaView:
         elif isinstance(e, SlotDefinition):
             uri = e.slot_uri
             e_name = underscore(e.name)
+        elif isinstance(e, EnumDefinition):
+            uri = e.enum_uri
+            e_name = e.name
         elif isinstance(e, TypeDefinition):
             uri = e.uri
             e_name = underscore(e.name)

--- a/tests/test_utils/test_schemaview.py
+++ b/tests/test_utils/test_schemaview.py
@@ -12,6 +12,7 @@ from linkml_runtime.dumpers import yaml_dumper
 from linkml_runtime.linkml_model.meta import (
     ClassDefinition,
     ClassDefinitionName,
+    EnumDefinition,
     Example,
     Prefix,
     SchemaDefinition,
@@ -517,6 +518,9 @@ def test_imports(schema_view_with_imports: SchemaView) -> None:
     assert view.get_uri("TestClass", use_element_type=True) == "core:class/TestClass"
     assert view.get_uri("name", use_element_type=True) == "core:slot/name"
 
+    assert view.get_uri("OrganismType") == "ks:OrganismType"
+    assert view.get_uri("OrganismType", use_element_type=True) == "ks:enum/OrganismType"
+
     assert view.get_uri("string") == "xsd:string"
 
     # dynamic enums
@@ -988,6 +992,8 @@ def test_uris_without_default_prefix() -> None:
     view = SchemaView(schema_definition)
     view.add_class(ClassDefinition(name="TestClass", from_schema="https://example.org/another#"))
     view.add_slot(SlotDefinition(name="test_slot", from_schema="https://example.org/another#"))
+    view.add_enum(EnumDefinition(name="tEsT_enum", from_schema="https://example.org/another#"))
 
     assert view.get_uri("TestClass", imports=True) == "https://example.org/test#TestClass"
     assert view.get_uri("test_slot", imports=True) == "https://example.org/test#test_slot"
+    assert view.get_uri("tEsT_enum", imports=True) == "https://example.org/test#tEsT_enum"


### PR DESCRIPTION
This was marked as "todo" in schemaview since its creation but never done.

I tried to find out why this URI-generation was not implemented from the beginning but could not find anything. So I believe it is Ok to add. Happy to get some feedback on this.

Related to linkml/linkml#2710