### PR TITLE
Fix formatting in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,11 +47,13 @@ When opening a pull request, you can specify that your PR needs to be
 tested against a specific upstream branch and repository by specifying it
 in the first two lines of your pull request like this:
 
-> upstream_repo: my-cool-username/linkml
-> upstream_branch: some-complicated-feature
-> 
-> Hey everyone what up it's me your boy MC spongebob here with another banger
-> ... (PR continues)
+```
+upstream_repo: my-cool-username/linkml
+upstream_branch: some-complicated-feature
+ 
+Hey everyone what up it's me your boy MC spongebob here with another banger
+... (PR continues)
+```
 
 The order of the `upstream_repo` and `upstream_branch` tags doesn't matter,
 but they must be on the first two lines of the pull request comment and separated with a colon.


### PR DESCRIPTION
The instructions for `upstream` testing were not formatted correctly.