### PR TITLE
added new variable: element_type in yamlutils.as_json_object() and JSONDumper.dumps()

### DIFF
--- a/linkml_runtime/dumpers/json_dumper.py
+++ b/linkml_runtime/dumpers/json_dumper.py
@@ -16,7 +16,11 @@ from linkml_runtime.utils.yamlutils import YAMLRoot, as_json_object
 
 class JSONDumper(Dumper):
     def dump(
-        self, element: Union[BaseModel, YAMLRoot], to_file: str, contexts: CONTEXTS_PARAM_TYPE = None, **kwargs
+        self,
+        element: Union[BaseModel, YAMLRoot],
+        to_file: str,
+        contexts: CONTEXTS_PARAM_TYPE = None,
+        **kwargs,
     ) -> None:
         """
         Write element as json to to_file
@@ -34,7 +38,12 @@ class JSONDumper(Dumper):
             element = element.model_dump()
         super().dump(element, to_file, contexts=contexts, **kwargs)
 
-    def dumps(self, element: Union[BaseModel, YAMLRoot], contexts: CONTEXTS_PARAM_TYPE = None, inject_type=True) -> str:
+    def dumps(
+        self,
+        element: Union[BaseModel, YAMLRoot],
+        contexts: CONTEXTS_PARAM_TYPE = None,
+        inject_type=True,
+    ) -> str:
         """
         Return element as a JSON or a JSON-LD string
         :param element: LinkML object to be emitted
@@ -66,12 +75,12 @@ class JSONDumper(Dumper):
         if isinstance(element, BaseModel):
             element = element.model_dump()
         return json.dumps(
-        return json.dumps(
-            as_json_object(element, contexts, inject_type=inject_type, element_type=element_type),
+            as_json_object(
+                element, contexts, inject_type=inject_type, element_type=element_type
+            ),
             default=default,
             ensure_ascii=False,
             indent="  ",
-        )
         )
 
     @staticmethod
@@ -85,7 +94,10 @@ class JSONDumper(Dumper):
         return formatutils.remove_empty_items(obj, hide_protected_keys=True)
 
     def to_json_object(
-        self, element: Union[BaseModel, YAMLRoot], contexts: CONTEXTS_PARAM_TYPE = None, inject_type=True
+        self,
+        element: Union[BaseModel, YAMLRoot],
+        contexts: CONTEXTS_PARAM_TYPE = None,
+        inject_type=True,
     ) -> JsonObj:
         """
         As dumps(), except returns a JsonObj, not a string

--- a/linkml_runtime/dumpers/json_dumper.py
+++ b/linkml_runtime/dumpers/json_dumper.py
@@ -66,7 +66,12 @@ class JSONDumper(Dumper):
         if isinstance(element, BaseModel):
             element = element.model_dump()
         return json.dumps(
-            as_json_object(element, contexts, inject_type=inject_type, element_type=element_type), default=default, ensure_ascii=False, indent="  "
+        return json.dumps(
+            as_json_object(element, contexts, inject_type=inject_type, element_type=element_type),
+            default=default,
+            ensure_ascii=False,
+            indent="  ",
+        )
         )
 
     @staticmethod

--- a/linkml_runtime/dumpers/json_dumper.py
+++ b/linkml_runtime/dumpers/json_dumper.py
@@ -62,10 +62,11 @@ class JSONDumper(Dumper):
             else:
                 return json.JSONDecoder().decode(o)
 
+        element_type = element.__class__.__name__
         if isinstance(element, BaseModel):
             element = element.model_dump()
         return json.dumps(
-            as_json_object(element, contexts, inject_type=inject_type), default=default, ensure_ascii=False, indent="  "
+            as_json_object(element, contexts, inject_type=inject_type, element_type=element_type), default=default, ensure_ascii=False, indent="  "
         )
 
     @staticmethod

--- a/linkml_runtime/dumpers/json_dumper.py
+++ b/linkml_runtime/dumpers/json_dumper.py
@@ -16,11 +16,7 @@ from linkml_runtime.utils.yamlutils import YAMLRoot, as_json_object
 
 class JSONDumper(Dumper):
     def dump(
-        self,
-        element: Union[BaseModel, YAMLRoot],
-        to_file: str,
-        contexts: CONTEXTS_PARAM_TYPE = None,
-        **kwargs,
+        self, element: Union[BaseModel, YAMLRoot], to_file: str, contexts: CONTEXTS_PARAM_TYPE = None, **kwargs
     ) -> None:
         """
         Write element as json to to_file
@@ -38,12 +34,7 @@ class JSONDumper(Dumper):
             element = element.model_dump()
         super().dump(element, to_file, contexts=contexts, **kwargs)
 
-    def dumps(
-        self,
-        element: Union[BaseModel, YAMLRoot],
-        contexts: CONTEXTS_PARAM_TYPE = None,
-        inject_type=True,
-    ) -> str:
+    def dumps(self, element: Union[BaseModel, YAMLRoot], contexts: CONTEXTS_PARAM_TYPE = None, inject_type=True) -> str:
         """
         Return element as a JSON or a JSON-LD string
         :param element: LinkML object to be emitted
@@ -75,9 +66,7 @@ class JSONDumper(Dumper):
         if isinstance(element, BaseModel):
             element = element.model_dump()
         return json.dumps(
-            as_json_object(
-                element, contexts, inject_type=inject_type, element_type=element_type
-            ),
+            as_json_object(element, contexts, inject_type=inject_type, element_type=element_type),
             default=default,
             ensure_ascii=False,
             indent="  ",
@@ -94,10 +83,7 @@ class JSONDumper(Dumper):
         return formatutils.remove_empty_items(obj, hide_protected_keys=True)
 
     def to_json_object(
-        self,
-        element: Union[BaseModel, YAMLRoot],
-        contexts: CONTEXTS_PARAM_TYPE = None,
-        inject_type=True,
+        self, element: Union[BaseModel, YAMLRoot], contexts: CONTEXTS_PARAM_TYPE = None, inject_type=True
     ) -> JsonObj:
         """
         As dumps(), except returns a JsonObj, not a string

--- a/linkml_runtime/utils/yamlutils.py
+++ b/linkml_runtime/utils/yamlutils.py
@@ -366,6 +366,7 @@ def as_json_object(element: YAMLRoot, contexts: CONTEXTS_PARAM_TYPE = None, inje
     :param element: element to return
     :param contexts: context(s) to include in the output
     :param inject_type: if True (default), add a @type at the top level
+    :param element_type: if provided, use this as the @type value instead of the element's class name
     :return: JsonObj representation of element
     """
     rval = copy(element)

--- a/linkml_runtime/utils/yamlutils.py
+++ b/linkml_runtime/utils/yamlutils.py
@@ -360,7 +360,7 @@ def as_yaml(element: YAMLRoot) -> str:
     return yaml.dump(element, Dumper=yaml.SafeDumper, sort_keys=False)
 
 
-def as_json_object(element: YAMLRoot, contexts: CONTEXTS_PARAM_TYPE = None, inject_type=True) -> JsonObj:
+def as_json_object(element: YAMLRoot, contexts: CONTEXTS_PARAM_TYPE = None, inject_type=True, element_type=None) -> JsonObj:
     """
     Return the representation of element as a JsonObj object
     :param element: element to return
@@ -370,7 +370,9 @@ def as_json_object(element: YAMLRoot, contexts: CONTEXTS_PARAM_TYPE = None, inje
     """
     rval = copy(element)
     if inject_type:
-        rval["@type"] = element.__class__.__name__
+        if element_type is None:
+            element_type = element.__class__.__name__
+        rval["@type"] = element_type
     context_element = merge_contexts(contexts)
     if context_element:
         rval["@context"] = context_element["@context"]

--- a/linkml_runtime/utils/yamlutils.py
+++ b/linkml_runtime/utils/yamlutils.py
@@ -360,7 +360,9 @@ def as_yaml(element: YAMLRoot) -> str:
     return yaml.dump(element, Dumper=yaml.SafeDumper, sort_keys=False)
 
 
-def as_json_object(element: YAMLRoot, contexts: CONTEXTS_PARAM_TYPE = None, inject_type=True, element_type=None) -> JsonObj:
+def as_json_object(
+    element: YAMLRoot, contexts: CONTEXTS_PARAM_TYPE = None, inject_type=True, element_type=None
+) -> JsonObj:
     """
     Return the representation of element as a JsonObj object
     :param element: element to return

--- a/tests/test_loaders_dumpers/test_dumpers_pydantic.py
+++ b/tests/test_loaders_dumpers/test_dumpers_pydantic.py
@@ -54,6 +54,16 @@ class PydanticDumpersTestCase(LoaderDumperTestCase):
                 "creator" not in data["books"][i].keys()
             self.assertEqual(data, remove_empty_items(self.bookseries.model_dump()))
 
+        # test @type is added to the top level and is assigned correct type when inject_type is True
+        bookseries_with_type = json.loads(json_dumper.dumps(self.bookseries, inject_type=True))
+        self.assertIn("@type", bookseries_with_type)
+        self.assertEqual("BookSeries", bookseries_with_type.get("@type"))
+
+        # test @type is not added to the top level when inject_type is False
+        bookseries_without_type = json.loads(json_dumper.dumps(self.bookseries, inject_type=False))
+        self.assertNotIn("@type", bookseries_without_type)
+        self.assertEqual(None, bookseries_without_type.get("@type"))
+
 
 class PydanticDumpersDateTestCase(LoaderDumperTestCase):
     @classmethod


### PR DESCRIPTION
In attempt to solve [issue#2849](https://github.com/linkml/linkml/issues/2849)

## Proposed Solution:
added new variable: `element_type` that stores the type of `element` prior to it being serialized to a dictionary by `model_dump()` in `JSONDumper.dumps(`). This will allow `@type` in `yamlutils.as_json_object()` to be assigned to the **true** type of `element`, rather than the being assigned to `dict` which is the type returned from `element.model_dump()`. This change only effects cases when `element` is of type `pydantic.BaseModel`.

## Bug Summary:
## Describe the bug
In `linkml_runtime/dumpers/json_dumper.py`, the `dumps()` method calls` element.model_dump()` early in the process, which converts the Pydantic model to a dictionary. This causes the loss of the original object type information needed for proper @type injection.

**Expected Behavior**

When `inject_type=True`, the `@type` field should contain the actual class name of the original object (e.g., `"OrganismTaxon"`, `"Gene"`, etc.).

**Current Behavior**

The `@type` field is set to `"dict"` because the type information is extracted after `model_dump()` converts the object to a dictionary.
