### PR TITLE
schemaview.py: make `permissible_value_*` act consistently with other such methods

### DIFF
--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -820,41 +820,37 @@ class SchemaView:
     @lru_cache(None)
     def permissible_value_parent(
         self, permissible_value: str, enum_name: ENUM_NAME
-    ) -> list[str | PermissibleValueText] | None:
+    ) -> list[str | PermissibleValueText]:
         """:param enum_name: child enum name
         :param permissible_value: permissible value
         :return: all direct parent enum names (is_a)
         """
         enum = self.get_enum(enum_name, strict=True)
-        if enum:
-            if permissible_value in enum.permissible_values:
-                pv = enum.permissible_values[permissible_value]
-                if pv.is_a:
-                    return [pv.is_a]
-            return None
-        return []
+        pv = enum.permissible_values.get(permissible_value)
+        if not pv:
+            err_msg = f'"{permissible_value}" is not a permissible value of the enum "{enum_name}".'
+            raise ValueError(err_msg)
+        return [pv.is_a] if pv.is_a else []
 
     @lru_cache(None)
     def permissible_value_children(
         self, permissible_value: str, enum_name: ENUM_NAME
-    ) -> list[str | PermissibleValueText] | None:
+    ) -> list[str | PermissibleValueText]:
         """:param enum_name: parent enum name
         :param permissible_value: permissible value
         :return: all direct child permissible values (is_a)
         """
         enum = self.get_enum(enum_name, strict=True)
-        children = []
-        if enum:
-            if permissible_value in enum.permissible_values:
-                pv = enum.permissible_values[permissible_value]
-                for isapv in enum.permissible_values:
-                    isapv_entity = enum.permissible_values[isapv]
-                    if isapv_entity.is_a and pv.text == isapv_entity.is_a:
-                        children.append(isapv)
-                return children
-            return None
-        msg = f'No such enum as "{enum_name}"'
-        raise ValueError(msg)
+        pv = enum.permissible_values.get(permissible_value)
+        if not pv:
+            err_msg = f'"{permissible_value}" is not a permissible value of the enum "{enum_name}".'
+            raise ValueError(err_msg)
+
+        return [
+            isa_pv
+            for isa_pv, isa_pv_entity in enum.permissible_values.items()
+            if isa_pv_entity.is_a and pv.text == isa_pv_entity.is_a
+        ]
 
     @lru_cache(None)
     def slot_parents(

--- a/tests/test_utils/test_schemaview.py
+++ b/tests/test_utils/test_schemaview.py
@@ -1048,8 +1048,12 @@ def test_alias_slot(schema_view_no_imports: SchemaView) -> None:
     assert postal_code_slot.alias == "zip"  # Assert alias is 'zip'
 
 
-def test_enums_and_enum_relationships(schema_view_no_imports: SchemaView) -> None:
-    """Test various aspects of Enum representation.
+def test_permissible_value_relationships(schema_view_no_imports: SchemaView) -> None:
+    """Test relationships between permissible values.
+
+    These tests use valid permissible_value / enum combinations.
+
+    See test_permissible_value_relationships_fail for invalid enum-PV pairings.
 
     CAT:
     LION:
@@ -1064,10 +1068,6 @@ def test_enums_and_enum_relationships(schema_view_no_imports: SchemaView) -> Non
     """
     view = schema_view_no_imports
 
-    # Test for ValueError when passing incorrect parameters
-    with pytest.raises(ValueError, match='No such enum: "not_an_enum"'):
-        view.permissible_value_parent("not_a_pv", "not_an_enum")
-
     animals = "Animals"
     animal_enum = view.get_enum(animals)
     assert animal_enum.name == animals
@@ -1075,7 +1075,7 @@ def test_enums_and_enum_relationships(schema_view_no_imports: SchemaView) -> Non
     pv_cat = animal_enum.permissible_values["CAT"]
     assert pv_cat.text == "CAT"
     assert pv_cat.is_a is None
-    assert view.permissible_value_parent("CAT", animals) is None
+    assert view.permissible_value_parent("CAT", animals) == []
     assert view.permissible_value_ancestors("CAT", animals) == ["CAT"]
     assert set(view.permissible_value_children("CAT", animals)) == {"LION", "TABBY"}
     assert set(view.permissible_value_descendants("CAT", animals)) == {"CAT", "LION", "ANGRY_LION", "TABBY"}
@@ -1100,6 +1100,19 @@ def test_enums_and_enum_relationships(schema_view_no_imports: SchemaView) -> Non
     assert view.permissible_value_ancestors("ANGRY_LION", animals) == ["ANGRY_LION", "LION", "CAT"]
     assert view.permissible_value_children("ANGRY_LION", animals) == []
     assert view.permissible_value_descendants("ANGRY_LION", animals) == ["ANGRY_LION"]
+
+
+@pytest.mark.parametrize("fn", ["parent", "children", "ancestors", "descendants"])
+def test_permissible_value_relationships_fail(schema_view_no_imports: SchemaView, fn: str) -> None:
+    """Test permissible_value relationships with incorrect enum/PV pairs."""
+    method_name = f"permissible_value_{fn}"
+    # invalid enum
+    with pytest.raises(ValueError, match='No such enum: "invalid_enum"'):
+        getattr(schema_view_no_imports, method_name)("invalid_pv", "invalid_enum")
+
+    # invalid pv, valid enum
+    with pytest.raises(ValueError, match='"invalid_pv" is not a permissible value of the enum "Animals"'):
+        getattr(schema_view_no_imports, method_name)("invalid_pv", "Animals")
 
 
 # FIXME: improve testing of dynamic enums


### PR DESCRIPTION
Two changes:

- Throw an error if the permissible value supplied in the query is _not_ a PV of the enum.

- Change the functioning of the `permissible_value_parent` method to return an empty list if the PV has no parents, which is what other `*_parents` (`class_parents`, `type_parents`, `slot_parents`, etc.) do. It was previously returning `None`.

Note: the naming of this method is inconsistent with the other parent terms and should be fixed at some point.