### PR TITLE
schemaview.py: add `type_roots` method

### DIFF
--- a/linkml_runtime/utils/schemaview.py
+++ b/linkml_runtime/utils/schemaview.py
@@ -1152,6 +1152,17 @@ class SchemaView:
         ]
 
     @lru_cache(None)
+    def type_roots(self, imports: bool = True) -> list[TypeDefinitionName]:
+        """Return all types that have no parents.
+
+        :param imports: whether or not to include imports, defaults to True
+        :type imports: bool, optional
+        :return: list of all root types
+        :rtype: list[TypeDefinitionName]
+        """
+        return [t for t in self.all_types(imports=imports) if not self.type_parents(t, imports=imports)]
+
+    @lru_cache(None)
     def is_multivalued(self, slot_name: SlotDefinition) -> bool:
         """Return True if slot is multivalued, else returns False.
 

--- a/tests/test_utils/test_schemaview.py
+++ b/tests/test_utils/test_schemaview.py
@@ -957,6 +957,64 @@ def test_all_types_induced_types(schema_view_with_imports: SchemaView) -> None:
     assert len(view.type_ancestors("SymbolString")) == len(["SymbolString", "string"])
 
 
+@pytest.mark.parametrize(
+    ("schema", "type_roots"),
+    [
+        (
+            """
+  string:
+    uri: xsd:string
+    base: str
+  integer:
+    uri: xsd:integer
+    base: int
+  boolean:
+    uri: xsd:boolean
+    base: Bool
+""",
+            {"string", "integer", "boolean"},
+        ),
+        (
+            """
+  string:
+    uri: xsd:string
+    base: str
+  acronym:
+    typeof: string
+  TLA:
+    typeof: acronym
+  even_number:
+    typeof: integer
+  integer:
+    uri: xsd:integer
+    base: int
+""",
+            {"string", "integer"},
+        ),
+        (
+            """
+  circular_type:
+    uri: xsd:Circle
+    typeof: type_circle
+
+  type_circle:
+    typeof: circular_type
+
+  semi_circular_type:
+    typeof: circular_type
+""",
+            set(),
+        ),
+    ],
+)
+def test_type_roots(schema: str, type_roots: set[str]) -> None:
+    """Test the retrieval of types with no parent type."""
+    schema_head = "id: https://w3id.org/linkml/tests/types\nname: types\ntypes:\n"
+
+    sv = SchemaView(f"{schema_head}\n{schema}")
+    assert set(sv.type_roots()) == type_roots
+
+
 def test_all_enums(schema_view_with_imports: SchemaView) -> None:
     """Test all_enums"""
     view = schema_view_with_imports


### PR DESCRIPTION
Add a `type_roots` function, analogous to existing `class_roots` and `slot_roots` functions, to find all base types in a schema.

N.b. I haven't added a `type_leaves` function as I don't have any need of it, but it would be easy enough to do so.